### PR TITLE
refactor: remove tracking key from processed mails

### DIFF
--- a/crates/mail-processor/src/resolvers/participant_enemy.rs
+++ b/crates/mail-processor/src/resolvers/participant_enemy.rs
@@ -656,20 +656,6 @@ impl Resolver for ParticipantEnemyResolver {
             enemy_obj.insert("is_rally".into(), Value::from(1));
         }
 
-        // tracking key
-        if let Some(ctk) = enemy_snap
-            .and_then(|s| s.get("CTK").and_then(Value::as_str))
-            .filter(|s| !s.is_empty())
-        {
-            enemy_obj.insert("tracking_key".into(), Value::String(ctk.to_owned()));
-        } else if let Some(ctk2) = atk_block
-            .get("CTK")
-            .and_then(Value::as_str)
-            .filter(|s| !s.is_empty())
-        {
-            enemy_obj.insert("tracking_key".into(), Value::String(ctk2.to_owned()));
-        }
-
         // npc
         map_put_i32(
             enemy_obj,

--- a/crates/mail-processor/src/resolvers/participant_self.rs
+++ b/crates/mail-processor/src/resolvers/participant_self.rs
@@ -256,18 +256,6 @@ impl ParticipantSelfResolver {
         )
     }
 
-    fn best_tracking_key_for_pid(sections: &[Value], pid: i64) -> Option<String> {
-        for sec in sections {
-            if let Some(ctk) = Self::section_tracking_key(sec)
-                && !ctk.is_empty()
-                && Self::tracking_key_belongs_to_pid(ctk, pid)
-            {
-                return Some(ctk.to_owned());
-            }
-        }
-        None
-    }
-
     fn find_secondary_commander_level(
         sections: &[Value],
         self_snap: &Value,
@@ -601,15 +589,6 @@ impl Resolver for ParticipantSelfResolver {
                 .and_then(Value::as_i64)
                 .map(|x| x as i32),
         );
-        if let Some(pid) = obj.get("player_id").and_then(Value::as_i64)
-            && let Some(ctk) = Self::section_tracking_key(self_snap)
-                .filter(|s| !s.is_empty())
-                .filter(|s| Self::tracking_key_belongs_to_pid(s, pid))
-                .map(|s| s.to_owned())
-                .or_else(|| Self::best_tracking_key_for_pid(sections, pid))
-        {
-            obj.insert("tracking_key".into(), Value::String(ctk));
-        }
 
         // equipment and formation
         map_put_str(

--- a/crates/mail-processor/src/structures.rs
+++ b/crates/mail-processor/src/structures.rs
@@ -92,8 +92,6 @@ pub struct Participant {
 
     // COSId
     pub kingdom_id: Option<i32>,
-    // CTK (format: pid_timestamp_hid_hid2[_rallyType])
-    pub tracking_key: Option<String>,
 
     // HEq
     pub equipment: Option<String>,


### PR DESCRIPTION
This is more of an internal value that we use during the processing, we don't need to include it in the final result. 