### PR TITLE
fix: filter ark reports in kvk only

### DIFF
--- a/crates/rokbattles-api/src/v1/reports.rs
+++ b/crates/rokbattles-api/src/v1/reports.rs
@@ -85,6 +85,7 @@ pub async fn list_reports(
     }
     if params.kvk_only.unwrap_or(false) {
         filters.push(doc! { "report.metadata.is_kvk": 1 });
+        filters.push(doc! { "report.metadata.email_role": { "$ne": "dungeon" } });
     }
     if params.ark_only.unwrap_or(false) {
         filters.push(doc! { "report.metadata.email_role": "dungeon" });


### PR DESCRIPTION
Some ark reports appear in kvk only because the they're currently in kvk and server ID doesn't match kingdom ID. Filtering out dungeon emails will resolve this 