### PR TITLE
refactor: do not import all headlessui in ui components

### DIFF
--- a/apps/rokbattles-platform/src/components/ui/alert.tsx
+++ b/apps/rokbattles-platform/src/components/ui/alert.tsx
@@ -1,4 +1,13 @@
-import * as Headless from "@headlessui/react";
+import {
+  type DescriptionProps,
+  type DialogProps,
+  type DialogTitleProps,
+  Description as HeadlessDescription,
+  Dialog as HeadlessDialog,
+  DialogBackdrop as HeadlessDialogBackdrop,
+  DialogPanel as HeadlessDialogPanel,
+  DialogTitle as HeadlessDialogTitle,
+} from "@headlessui/react";
 import type React from "react";
 import { cn } from "@/lib/cn";
 import { Text } from "./text";
@@ -21,19 +30,19 @@ export function Alert({
   children,
   ...props
 }: { size?: keyof typeof sizes; className?: string; children: React.ReactNode } & Omit<
-  Headless.DialogProps,
+  DialogProps,
   "as" | "className"
 >) {
   return (
-    <Headless.Dialog {...props}>
-      <Headless.DialogBackdrop
+    <HeadlessDialog {...props}>
+      <HeadlessDialogBackdrop
         transition
         className="fixed inset-0 flex w-screen justify-center overflow-y-auto bg-zinc-950/15 px-2 py-2 transition duration-100 focus:outline-0 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:px-6 sm:py-8 lg:px-8 lg:py-16 dark:bg-zinc-950/50"
       />
 
       <div className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0">
         <div className="grid min-h-full grid-rows-[1fr_auto_1fr] justify-items-center p-8 sm:grid-rows-[1fr_auto_3fr] sm:p-4">
-          <Headless.DialogPanel
+          <HeadlessDialogPanel
             transition
             className={cn(
               className,
@@ -43,19 +52,19 @@ export function Alert({
             )}
           >
             {children}
-          </Headless.DialogPanel>
+          </HeadlessDialogPanel>
         </div>
       </div>
-    </Headless.Dialog>
+    </HeadlessDialog>
   );
 }
 
 export function AlertTitle({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DialogTitleProps, "as" | "className">) {
+}: { className?: string } & Omit<DialogTitleProps, "as" | "className">) {
   return (
-    <Headless.DialogTitle
+    <HeadlessDialogTitle
       {...props}
       className={cn(
         className,
@@ -68,9 +77,9 @@ export function AlertTitle({
 export function AlertDescription({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DescriptionProps<typeof Text>, "as" | "className">) {
+}: { className?: string } & Omit<DescriptionProps<typeof Text>, "as" | "className">) {
   return (
-    <Headless.Description
+    <HeadlessDescription
       as={Text}
       {...props}
       className={cn(className, "mt-2 text-center text-pretty sm:text-left")}

--- a/apps/rokbattles-platform/src/components/ui/avatar.tsx
+++ b/apps/rokbattles-platform/src/components/ui/avatar.tsx
@@ -1,4 +1,4 @@
-import * as Headless from "@headlessui/react";
+import { type ButtonProps, Button as HeadlessButton } from "@headlessui/react";
 import Image from "next/image";
 import type React from "react";
 import { forwardRef } from "react";
@@ -100,7 +100,7 @@ export const AvatarButton = forwardRef(function AvatarButton(
     ...props
   }: AvatarProps &
     (
-      | ({ href?: never } & Omit<Headless.ButtonProps, "as" | "className">)
+      | ({ href?: never } & Omit<ButtonProps, "as" | "className">)
       | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, "className">)
     ),
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -120,10 +120,10 @@ export const AvatarButton = forwardRef(function AvatarButton(
     </Link>
   ) : (
     // @ts-expect-error
-    <Headless.Button {...props} className={classes} ref={ref}>
+    <HeadlessButton {...props} className={classes} ref={ref}>
       <TouchTarget>
         <Avatar src={src} frameSrc={frameSrc} square={square} initials={initials} alt={alt} />
       </TouchTarget>
-    </Headless.Button>
+    </HeadlessButton>
   );
 });

--- a/apps/rokbattles-platform/src/components/ui/badge.tsx
+++ b/apps/rokbattles-platform/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import * as Headless from "@headlessui/react";
+import { type ButtonProps, Button as HeadlessButton } from "@headlessui/react";
 import type React from "react";
 import { forwardRef } from "react";
 import { cn } from "@/lib/cn";
@@ -61,7 +61,7 @@ export const BadgeButton = forwardRef(function BadgeButton(
     children,
     ...props
   }: BadgeProps & { className?: string; children: React.ReactNode } & (
-      | ({ href?: never } & Omit<Headless.ButtonProps, "as" | "className">)
+      | ({ href?: never } & Omit<ButtonProps, "as" | "className">)
       | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, "className">)
     ),
   ref: React.ForwardedRef<HTMLElement>
@@ -80,10 +80,10 @@ export const BadgeButton = forwardRef(function BadgeButton(
     </Link>
   ) : (
     // @ts-expect-error
-    <Headless.Button {...props} className={classes} ref={ref}>
+    <HeadlessButton {...props} className={classes} ref={ref}>
       <TouchTarget>
         <Badge color={color}>{children}</Badge>
       </TouchTarget>
-    </Headless.Button>
+    </HeadlessButton>
   );
 });

--- a/apps/rokbattles-platform/src/components/ui/button.tsx
+++ b/apps/rokbattles-platform/src/components/ui/button.tsx
@@ -1,4 +1,7 @@
-import * as Headless from "@headlessui/react";
+import {
+  Button as HeadlessButton,
+  type ButtonProps as HeadlessButtonProps,
+} from "@headlessui/react";
 import type React from "react";
 import { forwardRef } from "react";
 import { cn } from "@/lib/cn";
@@ -164,7 +167,7 @@ type ButtonProps = (
   | { color?: never; outline: true; plain?: never }
   | { color?: never; outline?: never; plain: true }
 ) & { className?: string; children: React.ReactNode } & (
-    | ({ href?: never } & Omit<Headless.ButtonProps, "as" | "className">)
+    | ({ href?: never } & Omit<HeadlessButtonProps, "as" | "className">)
     | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, "className">)
   );
 
@@ -189,9 +192,9 @@ export const Button = forwardRef(function Button(
     </Link>
   ) : (
     // @ts-expect-error
-    <Headless.Button {...props} className={cn(classes, "cursor-default")} ref={ref}>
+    <HeadlessButton {...props} className={cn(classes, "cursor-default")} ref={ref}>
       <TouchTarget>{children}</TouchTarget>
-    </Headless.Button>
+    </HeadlessButton>
   );
 });
 

--- a/apps/rokbattles-platform/src/components/ui/checkbox.tsx
+++ b/apps/rokbattles-platform/src/components/ui/checkbox.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  type CheckboxProps,
+  type FieldProps,
+  Checkbox as HeadlessCheckbox,
+  Field as HeadlessField,
+} from "@headlessui/react";
 import { useTranslations } from "next-intl";
 import type React from "react";
 import { cn } from "@/lib/cn";
@@ -24,9 +29,9 @@ export function CheckboxGroup({ className, ...props }: React.ComponentPropsWitho
 export function CheckboxField({
   className,
   ...props
-}: { className?: string } & Omit<Headless.FieldProps, "as" | "className">) {
+}: { className?: string } & Omit<FieldProps, "as" | "className">) {
   return (
-    <Headless.Field
+    <HeadlessField
       data-slot="field"
       {...props}
       className={cn(
@@ -124,10 +129,10 @@ export function Checkbox({
 }: {
   color?: Color;
   className?: string;
-} & Omit<Headless.CheckboxProps, "as" | "className">) {
+} & Omit<CheckboxProps, "as" | "className">) {
   const t = useTranslations("common");
   return (
-    <Headless.Checkbox
+    <HeadlessCheckbox
       data-slot="control"
       {...props}
       className={cn(className, "group inline-flex focus:outline-hidden")}
@@ -157,6 +162,6 @@ export function Checkbox({
           />
         </svg>
       </span>
-    </Headless.Checkbox>
+    </HeadlessCheckbox>
   );
 }

--- a/apps/rokbattles-platform/src/components/ui/combobox.tsx
+++ b/apps/rokbattles-platform/src/components/ui/combobox.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  type ComboboxOptionProps,
+  type ComboboxProps,
+  Combobox as HeadlessCombobox,
+  ComboboxButton as HeadlessComboboxButton,
+  ComboboxInput as HeadlessComboboxInput,
+  ComboboxOption as HeadlessComboboxOption,
+  ComboboxOptions as HeadlessComboboxOptions,
+} from "@headlessui/react";
 import { useState } from "react";
 import { cn } from "@/lib/cn";
 
@@ -24,7 +32,7 @@ export function Combobox<T>({
   autoFocus?: boolean;
   "aria-label"?: string;
   children: (value: NonNullable<T>) => React.ReactElement;
-} & Omit<Headless.ComboboxProps<T, false>, "as" | "multiple" | "children"> & {
+} & Omit<ComboboxProps<T, false>, "as" | "multiple" | "children"> & {
     anchor?: "top" | "bottom";
   }) {
   const [query, setQuery] = useState("");
@@ -39,7 +47,7 @@ export function Combobox<T>({
         );
 
   return (
-    <Headless.Combobox
+    <HeadlessCombobox
       {...props}
       multiple={false}
       virtual={{ options: filteredOptions }}
@@ -63,7 +71,7 @@ export function Combobox<T>({
           "has-data-invalid:before:shadow-red-500/10",
         ])}
       >
-        <Headless.ComboboxInput
+        <HeadlessComboboxInput
           autoFocus={autoFocus}
           data-slot="control"
           aria-label={ariaLabel}
@@ -92,7 +100,7 @@ export function Combobox<T>({
             "dark:scheme-dark",
           ])}
         />
-        <Headless.ComboboxButton className="group absolute inset-y-0 right-0 flex items-center px-2">
+        <HeadlessComboboxButton className="group absolute inset-y-0 right-0 flex items-center px-2">
           <svg
             className="size-5 stroke-zinc-500 group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 sm:size-4 dark:stroke-zinc-400 dark:group-data-hover:stroke-zinc-300 forced-colors:stroke-[CanvasText]"
             viewBox="0 0 16 16"
@@ -112,9 +120,9 @@ export function Combobox<T>({
               strokeLinejoin="round"
             />
           </svg>
-        </Headless.ComboboxButton>
+        </HeadlessComboboxButton>
       </span>
-      <Headless.ComboboxOptions
+      <HeadlessComboboxOptions
         transition
         anchor={anchor}
         className={cn(
@@ -135,8 +143,8 @@ export function Combobox<T>({
         )}
       >
         {({ option }) => children(option)}
-      </Headless.ComboboxOptions>
-    </Headless.Combobox>
+      </HeadlessComboboxOptions>
+    </HeadlessCombobox>
   );
 }
 
@@ -145,7 +153,7 @@ export function ComboboxOption<T>({
   className,
   ...props
 }: { className?: string; children?: React.ReactNode } & Omit<
-  Headless.ComboboxOptionProps<"div", T>,
+  ComboboxOptionProps<"div", T>,
   "as" | "className"
 >) {
   const sharedClasses = cn(
@@ -160,7 +168,7 @@ export function ComboboxOption<T>({
   );
 
   return (
-    <Headless.ComboboxOption
+    <HeadlessComboboxOption
       {...props}
       className={cn(
         // Basic layout
@@ -184,7 +192,7 @@ export function ComboboxOption<T>({
       >
         <path d="M4 8.5l3 3L12 4" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-    </Headless.ComboboxOption>
+    </HeadlessComboboxOption>
   );
 }
 

--- a/apps/rokbattles-platform/src/components/ui/dialog.tsx
+++ b/apps/rokbattles-platform/src/components/ui/dialog.tsx
@@ -1,4 +1,13 @@
-import * as Headless from "@headlessui/react";
+import {
+  type DescriptionProps,
+  type DialogProps,
+  type DialogTitleProps,
+  Description as HeadlessDescription,
+  Dialog as HeadlessDialog,
+  DialogBackdrop as HeadlessDialogBackdrop,
+  DialogPanel as HeadlessDialogPanel,
+  DialogTitle as HeadlessDialogTitle,
+} from "@headlessui/react";
 import type React from "react";
 import { cn } from "@/lib/cn";
 import { Text } from "./text";
@@ -21,19 +30,19 @@ export function Dialog({
   children,
   ...props
 }: { size?: keyof typeof sizes; className?: string; children: React.ReactNode } & Omit<
-  Headless.DialogProps,
+  DialogProps,
   "as" | "className"
 >) {
   return (
-    <Headless.Dialog {...props}>
-      <Headless.DialogBackdrop
+    <HeadlessDialog {...props}>
+      <HeadlessDialogBackdrop
         transition
         className="fixed inset-0 flex w-screen justify-center overflow-y-auto bg-zinc-950/25 px-2 py-2 transition duration-100 focus:outline-0 data-closed:opacity-0 data-enter:ease-out data-leave:ease-in sm:px-6 sm:py-8 lg:px-8 lg:py-16 dark:bg-zinc-950/50"
       />
 
       <div className="fixed inset-0 w-screen overflow-y-auto pt-6 sm:pt-0">
         <div className="grid min-h-full grid-rows-[1fr_auto] justify-items-center sm:grid-rows-[1fr_auto_3fr] sm:p-4">
-          <Headless.DialogPanel
+          <HeadlessDialogPanel
             transition
             className={cn(
               className,
@@ -43,19 +52,19 @@ export function Dialog({
             )}
           >
             {children}
-          </Headless.DialogPanel>
+          </HeadlessDialogPanel>
         </div>
       </div>
-    </Headless.Dialog>
+    </HeadlessDialog>
   );
 }
 
 export function DialogTitle({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DialogTitleProps, "as" | "className">) {
+}: { className?: string } & Omit<DialogTitleProps, "as" | "className">) {
   return (
-    <Headless.DialogTitle
+    <HeadlessDialogTitle
       {...props}
       className={cn(
         className,
@@ -68,10 +77,8 @@ export function DialogTitle({
 export function DialogDescription({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DescriptionProps<typeof Text>, "as" | "className">) {
-  return (
-    <Headless.Description as={Text} {...props} className={cn(className, "mt-2 text-pretty")} />
-  );
+}: { className?: string } & Omit<DescriptionProps<typeof Text>, "as" | "className">) {
+  return <HeadlessDescription as={Text} {...props} className={cn(className, "mt-2 text-pretty")} />;
 }
 
 export function DialogBody({ className, ...props }: React.ComponentPropsWithoutRef<"div">) {

--- a/apps/rokbattles-platform/src/components/ui/dropdown.tsx
+++ b/apps/rokbattles-platform/src/components/ui/dropdown.tsx
@@ -1,31 +1,48 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  type DescriptionProps,
+  Description as HeadlessDescription,
+  Menu as HeadlessMenu,
+  MenuButton as HeadlessMenuButton,
+  MenuHeading as HeadlessMenuHeading,
+  MenuItem as HeadlessMenuItem,
+  MenuItems as HeadlessMenuItems,
+  MenuSection as HeadlessMenuSection,
+  MenuSeparator as HeadlessMenuSeparator,
+  type MenuButtonProps,
+  type MenuHeadingProps,
+  type MenuItemProps,
+  type MenuItemsProps,
+  type MenuProps,
+  type MenuSectionProps,
+  type MenuSeparatorProps,
+} from "@headlessui/react";
 import type React from "react";
 import { cn } from "@/lib/cn";
 import { Button } from "./button";
 import { Link } from "./link";
 
-export function Dropdown(props: Headless.MenuProps) {
-  return <Headless.Menu {...props} />;
+export function Dropdown(props: MenuProps) {
+  return <HeadlessMenu {...props} />;
 }
 
 export function DropdownButton<T extends React.ElementType = typeof Button>({
   // @ts-expect-error
   as = Button,
   ...props
-}: { className?: string } & Omit<Headless.MenuButtonProps<T>, "className">) {
+}: { className?: string } & Omit<MenuButtonProps<T>, "className">) {
   // @ts-expect-error
-  return <Headless.MenuButton as={as} {...props} />;
+  return <HeadlessMenuButton as={as} {...props} />;
 }
 
 export function DropdownMenu({
   anchor = "bottom",
   className,
   ...props
-}: { className?: string } & Omit<Headless.MenuItemsProps, "as" | "className">) {
+}: { className?: string } & Omit<MenuItemsProps, "as" | "className">) {
   return (
-    <Headless.MenuItems
+    <HeadlessMenuItems
       {...props}
       transition
       anchor={anchor}
@@ -56,8 +73,8 @@ export function DropdownItem({
   className,
   ...props
 }: { className?: string } & (
-  | ({ href?: never } & Omit<Headless.MenuItemProps<"button">, "as" | "className">)
-  | ({ href: string } & Omit<Headless.MenuItemProps<typeof Link>, "as" | "className">)
+  | ({ href?: never } & Omit<MenuItemProps<"button">, "as" | "className">)
+  | ({ href: string } & Omit<MenuItemProps<typeof Link>, "as" | "className">)
 )) {
   const classes = cn(
     className,
@@ -82,10 +99,10 @@ export function DropdownItem({
 
   return typeof props.href === "string" ? (
     // @ts-expect-error
-    <Headless.MenuItem as={Link} {...props} className={classes} />
+    <HeadlessMenuItem as={Link} {...props} className={classes} />
   ) : (
     // @ts-expect-error
-    <Headless.MenuItem as="button" type="button" {...props} className={classes} />
+    <HeadlessMenuItem as="button" type="button" {...props} className={classes} />
   );
 }
 
@@ -96,9 +113,9 @@ export function DropdownHeader({ className, ...props }: React.ComponentPropsWith
 export function DropdownSection({
   className,
   ...props
-}: { className?: string } & Omit<Headless.MenuSectionProps, "as" | "className">) {
+}: { className?: string } & Omit<MenuSectionProps, "as" | "className">) {
   return (
-    <Headless.MenuSection
+    <HeadlessMenuSection
       {...props}
       className={cn(
         className,
@@ -112,9 +129,9 @@ export function DropdownSection({
 export function DropdownHeading({
   className,
   ...props
-}: { className?: string } & Omit<Headless.MenuHeadingProps, "as" | "className">) {
+}: { className?: string } & Omit<MenuHeadingProps, "as" | "className">) {
   return (
-    <Headless.MenuHeading
+    <HeadlessMenuHeading
       {...props}
       className={cn(
         className,
@@ -127,9 +144,9 @@ export function DropdownHeading({
 export function DropdownDivider({
   className,
   ...props
-}: { className?: string } & Omit<Headless.MenuSeparatorProps, "as" | "className">) {
+}: { className?: string } & Omit<MenuSeparatorProps, "as" | "className">) {
   return (
-    <Headless.MenuSeparator
+    <HeadlessMenuSeparator
       {...props}
       className={cn(
         className,
@@ -153,9 +170,9 @@ export function DropdownLabel({ className, ...props }: React.ComponentPropsWitho
 export function DropdownDescription({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DescriptionProps, "as" | "className">) {
+}: { className?: string } & Omit<DescriptionProps, "as" | "className">) {
   return (
-    <Headless.Description
+    <HeadlessDescription
       data-slot="description"
       {...props}
       className={cn(
@@ -171,11 +188,11 @@ export function DropdownShortcut({
   className,
   ...props
 }: { keys: string | string[]; className?: string } & Omit<
-  Headless.DescriptionProps<"kbd">,
+  DescriptionProps<"kbd">,
   "as" | "className"
 >) {
   return (
-    <Headless.Description
+    <HeadlessDescription
       as="kbd"
       {...props}
       className={cn(className, "col-start-5 row-start-1 flex justify-self-end")}
@@ -192,6 +209,6 @@ export function DropdownShortcut({
           {char}
         </kbd>
       ))}
-    </Headless.Description>
+    </HeadlessDescription>
   );
 }

--- a/apps/rokbattles-platform/src/components/ui/fieldset.tsx
+++ b/apps/rokbattles-platform/src/components/ui/fieldset.tsx
@@ -1,13 +1,24 @@
-import * as Headless from "@headlessui/react";
+import {
+  type DescriptionProps,
+  type FieldProps,
+  type FieldsetProps,
+  Description as HeadlessDescription,
+  Field as HeadlessField,
+  Fieldset as HeadlessFieldset,
+  Label as HeadlessLabel,
+  Legend as HeadlessLegend,
+  type LabelProps,
+  type LegendProps,
+} from "@headlessui/react";
 import type React from "react";
 import { cn } from "@/lib/cn";
 
 export function Fieldset({
   className,
   ...props
-}: { className?: string } & Omit<Headless.FieldsetProps, "as" | "className">) {
+}: { className?: string } & Omit<FieldsetProps, "as" | "className">) {
   return (
-    <Headless.Fieldset
+    <HeadlessFieldset
       {...props}
       className={cn(className, "*:data-[slot=text]:mt-1 [&>*+[data-slot=control]]:mt-6")}
     />
@@ -17,9 +28,9 @@ export function Fieldset({
 export function Legend({
   className,
   ...props
-}: { className?: string } & Omit<Headless.LegendProps, "as" | "className">) {
+}: { className?: string } & Omit<LegendProps, "as" | "className">) {
   return (
-    <Headless.Legend
+    <HeadlessLegend
       data-slot="legend"
       {...props}
       className={cn(
@@ -37,9 +48,9 @@ export function FieldGroup({ className, ...props }: React.ComponentPropsWithoutR
 export function Field({
   className,
   ...props
-}: { className?: string } & Omit<Headless.FieldProps, "as" | "className">) {
+}: { className?: string } & Omit<FieldProps, "as" | "className">) {
   return (
-    <Headless.Field
+    <HeadlessField
       {...props}
       className={cn(
         className,
@@ -57,9 +68,9 @@ export function Field({
 export function Label({
   className,
   ...props
-}: { className?: string } & Omit<Headless.LabelProps, "as" | "className">) {
+}: { className?: string } & Omit<LabelProps, "as" | "className">) {
   return (
-    <Headless.Label
+    <HeadlessLabel
       data-slot="label"
       {...props}
       className={cn(
@@ -73,9 +84,9 @@ export function Label({
 export function Description({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DescriptionProps, "as" | "className">) {
+}: { className?: string } & Omit<DescriptionProps, "as" | "className">) {
   return (
-    <Headless.Description
+    <HeadlessDescription
       data-slot="description"
       {...props}
       className={cn(
@@ -89,9 +100,9 @@ export function Description({
 export function ErrorMessage({
   className,
   ...props
-}: { className?: string } & Omit<Headless.DescriptionProps, "as" | "className">) {
+}: { className?: string } & Omit<DescriptionProps, "as" | "className">) {
   return (
-    <Headless.Description
+    <HeadlessDescription
       data-slot="error"
       {...props}
       className={cn(

--- a/apps/rokbattles-platform/src/components/ui/input.tsx
+++ b/apps/rokbattles-platform/src/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import * as Headless from "@headlessui/react";
+import { Input as HeadlessInput, type InputProps } from "@headlessui/react";
 import type React from "react";
 import { forwardRef } from "react";
 import { cn } from "@/lib/cn";
@@ -30,7 +30,7 @@ export const Input = forwardRef(function Input(
   }: {
     className?: string;
     type?: "email" | "number" | "password" | "search" | "tel" | "text" | "url" | DateType;
-  } & Omit<Headless.InputProps, "as" | "className">,
+  } & Omit<InputProps, "as" | "className">,
   ref: React.ForwardedRef<HTMLInputElement>
 ) {
   return (
@@ -50,7 +50,7 @@ export const Input = forwardRef(function Input(
         "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
       ])}
     >
-      <Headless.Input
+      <HeadlessInput
         ref={ref}
         {...props}
         className={cn([

--- a/apps/rokbattles-platform/src/components/ui/layout/auth-layout.tsx
+++ b/apps/rokbattles-platform/src/components/ui/layout/auth-layout.tsx
@@ -1,0 +1,9 @@
+export function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="flex min-h-dvh flex-col p-2">
+      <div className="flex grow items-center justify-center p-6 lg:rounded-lg lg:bg-white lg:p-10 lg:shadow-xs lg:ring-1 lg:ring-zinc-950/5 dark:lg:bg-zinc-900 dark:lg:ring-white/10">
+        {children}
+      </div>
+    </main>
+  );
+}

--- a/apps/rokbattles-platform/src/components/ui/layout/sidebar-layout.tsx
+++ b/apps/rokbattles-platform/src/components/ui/layout/sidebar-layout.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  CloseButton as HeadlessCloseButton,
+  Dialog as HeadlessDialog,
+  DialogBackdrop as HeadlessDialogBackdrop,
+  DialogPanel as HeadlessDialogPanel,
+} from "@headlessui/react";
 import { useTranslations } from "next-intl";
 import type React from "react";
 import { useState } from "react";
@@ -29,25 +34,25 @@ function MobileSidebar({
 }: React.PropsWithChildren<{ open: boolean; close: () => void }>) {
   const t = useTranslations("navigation");
   return (
-    <Headless.Dialog open={open} onClose={close} className="lg:hidden">
-      <Headless.DialogBackdrop
+    <HeadlessDialog open={open} onClose={close} className="lg:hidden">
+      <HeadlessDialogBackdrop
         transition
         className="fixed inset-0 bg-black/30 transition data-closed:opacity-0 data-enter:duration-300 data-enter:ease-out data-leave:duration-200 data-leave:ease-in"
       />
-      <Headless.DialogPanel
+      <HeadlessDialogPanel
         transition
         className="fixed inset-y-0 w-full max-w-80 p-2 transition duration-300 ease-in-out data-closed:-translate-x-full"
       >
         <div className="flex h-full flex-col rounded-lg bg-white shadow-xs ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10">
           <div className="-mb-3 px-4 pt-3">
-            <Headless.CloseButton as={NavbarItem} aria-label={t("closeNavigation")}>
+            <HeadlessCloseButton as={NavbarItem} aria-label={t("closeNavigation")}>
               <CloseMenuIcon />
-            </Headless.CloseButton>
+            </HeadlessCloseButton>
           </div>
           {children}
         </div>
-      </Headless.DialogPanel>
-    </Headless.Dialog>
+      </HeadlessDialogPanel>
+    </HeadlessDialog>
   );
 }
 

--- a/apps/rokbattles-platform/src/components/ui/link.tsx
+++ b/apps/rokbattles-platform/src/components/ui/link.tsx
@@ -1,4 +1,4 @@
-import * as Headless from "@headlessui/react";
+import { DataInteractive } from "@headlessui/react";
 import NextLink, { type LinkProps } from "next/link";
 import type React from "react";
 import { forwardRef } from "react";
@@ -8,8 +8,8 @@ export const Link = forwardRef(function Link(
   ref: React.ForwardedRef<HTMLAnchorElement>
 ) {
   return (
-    <Headless.DataInteractive>
+    <DataInteractive>
       <NextLink {...props} ref={ref} />
-    </Headless.DataInteractive>
+    </DataInteractive>
   );
 });

--- a/apps/rokbattles-platform/src/components/ui/listbox.tsx
+++ b/apps/rokbattles-platform/src/components/ui/listbox.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  Listbox as HeadlessListbox,
+  ListboxButton as HeadlessListboxButton,
+  ListboxOption as HeadlessListboxOption,
+  ListboxOptions as HeadlessListboxOptions,
+  ListboxSelectedOption as HeadlessListboxSelectedOption,
+  type ListboxOptionProps,
+  type ListboxProps,
+} from "@headlessui/react";
 import { Fragment } from "react";
 import { cn } from "@/lib/cn";
 
@@ -17,10 +25,10 @@ export function Listbox<T>({
   autoFocus?: boolean;
   "aria-label"?: string;
   children?: React.ReactNode;
-} & Omit<Headless.ListboxProps<typeof Fragment, T>, "as" | "multiple">) {
+} & Omit<ListboxProps<typeof Fragment, T>, "as" | "multiple">) {
   return (
-    <Headless.Listbox {...props} multiple={false}>
-      <Headless.ListboxButton
+    <HeadlessListbox {...props} multiple={false}>
+      <HeadlessListboxButton
         autoFocus={autoFocus}
         data-slot="control"
         aria-label={ariaLabel}
@@ -40,7 +48,7 @@ export function Listbox<T>({
           "data-disabled:opacity-50 data-disabled:before:bg-zinc-950/5 data-disabled:before:shadow-none",
         ])}
       >
-        <Headless.ListboxSelectedOption
+        <HeadlessListboxSelectedOption
           as="span"
           options={options}
           placeholder={
@@ -86,8 +94,8 @@ export function Listbox<T>({
             />
           </svg>
         </span>
-      </Headless.ListboxButton>
-      <Headless.ListboxOptions
+      </HeadlessListboxButton>
+      <HeadlessListboxOptions
         transition
         anchor="selection start"
         className={cn(
@@ -108,8 +116,8 @@ export function Listbox<T>({
         )}
       >
         {options}
-      </Headless.ListboxOptions>
-    </Headless.Listbox>
+      </HeadlessListboxOptions>
+    </HeadlessListbox>
   );
 }
 
@@ -118,7 +126,7 @@ export function ListboxOption<T>({
   className,
   ...props
 }: { className?: string; children?: React.ReactNode } & Omit<
-  Headless.ListboxOptionProps<"div", T>,
+  ListboxOptionProps<"div", T>,
   "as" | "className"
 >) {
   const sharedClasses = cn(
@@ -133,7 +141,7 @@ export function ListboxOption<T>({
   );
 
   return (
-    <Headless.ListboxOption as={Fragment} {...props}>
+    <HeadlessListboxOption as={Fragment} {...props}>
       {({ selectedOption }) => {
         if (selectedOption) {
           return <div className={cn(className, sharedClasses)}>{children}</div>;
@@ -171,7 +179,7 @@ export function ListboxOption<T>({
           </div>
         );
       }}
-    </Headless.ListboxOption>
+    </HeadlessListboxOption>
   );
 }
 

--- a/apps/rokbattles-platform/src/components/ui/navbar.tsx
+++ b/apps/rokbattles-platform/src/components/ui/navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import { type ButtonProps, Button as HeadlessButton } from "@headlessui/react";
 import { LayoutGroup, motion } from "motion/react";
 import type React from "react";
 import { forwardRef, useId } from "react";
@@ -43,7 +43,7 @@ export const NavbarItem = forwardRef(function NavbarItem(
     children,
     ...props
   }: { current?: boolean; className?: string; children: React.ReactNode } & (
-    | ({ href?: never } & Omit<Headless.ButtonProps, "as" | "className">)
+    | ({ href?: never } & Omit<ButtonProps, "as" | "className">)
     | ({ href: string } & Omit<React.ComponentPropsWithoutRef<typeof Link>, "className">)
   ),
   ref: React.ForwardedRef<HTMLAnchorElement | HTMLButtonElement>
@@ -87,14 +87,14 @@ export const NavbarItem = forwardRef(function NavbarItem(
         </Link>
       ) : (
         // @ts-expect-error
-        <Headless.Button
+        <HeadlessButton
           {...props}
           className={cn("cursor-default", classes)}
           data-current={current ? "true" : undefined}
           ref={ref}
         >
           <TouchTarget>{children}</TouchTarget>
-        </Headless.Button>
+        </HeadlessButton>
       )}
     </span>
   );

--- a/apps/rokbattles-platform/src/components/ui/radio.tsx
+++ b/apps/rokbattles-platform/src/components/ui/radio.tsx
@@ -1,12 +1,19 @@
-import * as Headless from "@headlessui/react";
+import {
+  type FieldProps,
+  Field as HeadlessField,
+  Radio as HeadlessRadio,
+  RadioGroup as HeadlessRadioGroup,
+  type RadioGroupProps,
+  type RadioProps,
+} from "@headlessui/react";
 import { cn } from "@/lib/cn";
 
 export function RadioGroup({
   className,
   ...props
-}: { className?: string } & Omit<Headless.RadioGroupProps, "as" | "className">) {
+}: { className?: string } & Omit<RadioGroupProps, "as" | "className">) {
   return (
-    <Headless.RadioGroup
+    <HeadlessRadioGroup
       data-slot="control"
       {...props}
       className={cn(
@@ -23,9 +30,9 @@ export function RadioGroup({
 export function RadioField({
   className,
   ...props
-}: { className?: string } & Omit<Headless.FieldProps, "as" | "className">) {
+}: { className?: string } & Omit<FieldProps, "as" | "className">) {
   return (
-    <Headless.Field
+    <HeadlessField
       data-slot="field"
       {...props}
       className={cn(
@@ -121,12 +128,9 @@ export function Radio({
   color = "dark/zinc",
   className,
   ...props
-}: { color?: Color; className?: string } & Omit<
-  Headless.RadioProps,
-  "as" | "className" | "children"
->) {
+}: { color?: Color; className?: string } & Omit<RadioProps, "as" | "className" | "children">) {
   return (
-    <Headless.Radio
+    <HeadlessRadio
       data-slot="control"
       {...props}
       className={cn(className, "group inline-flex focus:outline-hidden")}
@@ -140,6 +144,6 @@ export function Radio({
           )}
         />
       </span>
-    </Headless.Radio>
+    </HeadlessRadio>
   );
 }

--- a/apps/rokbattles-platform/src/components/ui/select.tsx
+++ b/apps/rokbattles-platform/src/components/ui/select.tsx
@@ -1,14 +1,10 @@
-import * as Headless from "@headlessui/react";
+import { Select as HeadlessSelect, type SelectProps } from "@headlessui/react";
 import type React from "react";
 import { forwardRef } from "react";
 import { cn } from "@/lib/cn";
 
 export const Select = forwardRef(function Select(
-  {
-    className,
-    multiple,
-    ...props
-  }: { className?: string } & Omit<Headless.SelectProps, "as" | "className">,
+  { className, multiple, ...props }: { className?: string } & Omit<SelectProps, "as" | "className">,
   ref: React.ForwardedRef<HTMLSelectElement>
 ) {
   return (
@@ -28,7 +24,7 @@ export const Select = forwardRef(function Select(
         "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
       ])}
     >
-      <Headless.Select
+      <HeadlessSelect
         ref={ref}
         multiple={multiple}
         {...props}

--- a/apps/rokbattles-platform/src/components/ui/sidebar.tsx
+++ b/apps/rokbattles-platform/src/components/ui/sidebar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import * as Headless from "@headlessui/react";
+import {
+  type ButtonProps,
+  Button as HeadlessButton,
+  CloseButton as HeadlessCloseButton,
+} from "@headlessui/react";
 import { LayoutGroup, motion } from "motion/react";
 import type React from "react";
 import { forwardRef, useId } from "react";
@@ -87,8 +91,8 @@ export const SidebarItem = forwardRef(function SidebarItem(
     children,
     ...props
   }: { current?: boolean; className?: string; children: React.ReactNode } & (
-    | ({ href?: never } & Omit<Headless.ButtonProps, "as" | "className">)
-    | ({ href: string } & Omit<Headless.ButtonProps<typeof Link>, "as" | "className">)
+    | ({ href?: never } & Omit<ButtonProps, "as" | "className">)
+    | ({ href: string } & Omit<ButtonProps<typeof Link>, "as" | "className">)
   ),
   ref: React.ForwardedRef<HTMLAnchorElement | HTMLButtonElement>
 ) {
@@ -124,7 +128,7 @@ export const SidebarItem = forwardRef(function SidebarItem(
       )}
       {typeof props.href === "string" ? (
         // @ts-expect-error
-        <Headless.CloseButton
+        <HeadlessCloseButton
           as={Link}
           {...props}
           className={classes}
@@ -132,17 +136,17 @@ export const SidebarItem = forwardRef(function SidebarItem(
           ref={ref}
         >
           <TouchTarget>{children}</TouchTarget>
-        </Headless.CloseButton>
+        </HeadlessCloseButton>
       ) : (
         // @ts-expect-error
-        <Headless.Button
+        <HeadlessButton
           {...props}
           className={cn("cursor-default", classes)}
           data-current={current ? "true" : undefined}
           ref={ref}
         >
           <TouchTarget>{children}</TouchTarget>
-        </Headless.Button>
+        </HeadlessButton>
       )}
     </span>
   );

--- a/apps/rokbattles-platform/src/components/ui/switch.tsx
+++ b/apps/rokbattles-platform/src/components/ui/switch.tsx
@@ -1,4 +1,9 @@
-import * as Headless from "@headlessui/react";
+import {
+  type FieldProps,
+  Field as HeadlessField,
+  Switch as HeadlessSwitch,
+  type SwitchProps,
+} from "@headlessui/react";
 import type React from "react";
 import { cn } from "@/lib/cn";
 
@@ -21,9 +26,9 @@ export function SwitchGroup({ className, ...props }: React.ComponentPropsWithout
 export function SwitchField({
   className,
   ...props
-}: { className?: string } & Omit<Headless.FieldProps, "as" | "className">) {
+}: { className?: string } & Omit<FieldProps, "as" | "className">) {
   return (
-    <Headless.Field
+    <HeadlessField
       data-slot="field"
       {...props}
       className={cn(
@@ -143,9 +148,9 @@ export function Switch({
 }: {
   color?: Color;
   className?: string;
-} & Omit<Headless.SwitchProps, "as" | "className" | "children">) {
+} & Omit<SwitchProps, "as" | "className" | "children">) {
   return (
-    <Headless.Switch
+    <HeadlessSwitch
       data-slot="control"
       {...props}
       className={cn(
@@ -190,6 +195,6 @@ export function Switch({
           "group-data-checked:group-data-disabled:bg-white group-data-checked:group-data-disabled:shadow-sm group-data-checked:group-data-disabled:ring-black/5"
         )}
       />
-    </Headless.Switch>
+    </HeadlessSwitch>
   );
 }

--- a/apps/rokbattles-platform/src/components/ui/textarea.tsx
+++ b/apps/rokbattles-platform/src/components/ui/textarea.tsx
@@ -1,4 +1,4 @@
-import * as Headless from "@headlessui/react";
+import { Textarea as HeadlessTextarea, type TextareaProps } from "@headlessui/react";
 import type React from "react";
 import { forwardRef } from "react";
 import { cn } from "@/lib/cn";
@@ -8,7 +8,7 @@ export const Textarea = forwardRef(function Textarea(
     className,
     resizable = true,
     ...props
-  }: { className?: string; resizable?: boolean } & Omit<Headless.TextareaProps, "as" | "className">,
+  }: { className?: string; resizable?: boolean } & Omit<TextareaProps, "as" | "className">,
   ref: React.ForwardedRef<HTMLTextAreaElement>
 ) {
   return (
@@ -28,7 +28,7 @@ export const Textarea = forwardRef(function Textarea(
         "has-data-disabled:opacity-50 has-data-disabled:before:bg-zinc-950/5 has-data-disabled:before:shadow-none",
       ])}
     >
-      <Headless.Textarea
+      <HeadlessTextarea
         ref={ref}
         {...props}
         className={cn([


### PR DESCRIPTION
With the upcoming change to move to ultracite, we need to remove these types of imports. 