### PR TITLE
refactor: skip re-parsing json in mail processor

### DIFF
--- a/crates/mail-cli/src/processing.rs
+++ b/crates/mail-cli/src/processing.rs
@@ -82,7 +82,8 @@ pub(crate) fn process_decoded_mail(
             serde_json::to_value(processed_mail)?
         }
         _ => {
-            let processed_mail = mail_processor_battle::process(&decoded.raw_json_text)?;
+            let processed_mail =
+                mail_processor_battle::process_sections(&decoded.decoded_mail.sections)?;
             serde_json::to_value(processed_mail)?
         }
     };

--- a/crates/mail-processor-battle/src/lib.rs
+++ b/crates/mail-processor-battle/src/lib.rs
@@ -5,24 +5,16 @@ pub mod resolvers;
 pub mod structures;
 
 use crate::{
-    context::MailContext,
-    error::ProcessError,
-    helpers::is_ascii_digits,
-    resolvers::battle::BattleResolver,
-    resolvers::metadata::MetadataResolver,
-    resolvers::overview::OverviewResolver,
-    resolvers::participant_enemy::ParticipantEnemyResolver,
-    resolvers::participant_self::ParticipantSelfResolver,
-    structures::{DecodedMail, ParsedMail},
+    context::MailContext, error::ProcessError, helpers::is_ascii_digits,
+    resolvers::battle::BattleResolver, resolvers::metadata::MetadataResolver,
+    resolvers::overview::OverviewResolver, resolvers::participant_enemy::ParticipantEnemyResolver,
+    resolvers::participant_self::ParticipantSelfResolver, structures::ParsedMail,
 };
 use mail_processor_sdk::ResolverChain;
-use serde_json::json;
+use serde_json::{Value, json};
 use std::cmp::Ordering;
 
-pub fn process(json_text: &str) -> Result<Vec<ParsedMail>, ProcessError> {
-    let root: DecodedMail = serde_json::from_str(json_text)?;
-    let sections = &root.sections;
-
+pub fn process_sections(sections: &[Value]) -> Result<Vec<ParsedMail>, ProcessError> {
     if sections.is_empty() {
         return Ok(Vec::new());
     }

--- a/crates/rokbattles-processor/src/main.rs
+++ b/crates/rokbattles-processor/src/main.rs
@@ -231,7 +231,7 @@ async fn process_mail(
 
     let docs = match mail_type {
         EmailType::Battle => {
-            let mail_obj = mail_processor_battle::process(mail_str)?;
+            let mail_obj = mail_processor_battle::process_sections(&decoded_mail.sections)?;
             let mut docs = Vec::with_capacity(mail_obj.len());
 
             // Need to review bulk write API later, something might be wrong with it in current version of the driver


### PR DESCRIPTION
Use the decoded sections instead of re-parsing json