### PR TITLE
refactor: disable reports & pairings command in discord bot

### DIFF
--- a/apps/rokbattles-bot/src/commands/index.ts
+++ b/apps/rokbattles-bot/src/commands/index.ts
@@ -1,5 +1,3 @@
-import { PairingsCommand } from "@/commands/self/PairingsCommand";
-import { ReportsCommand } from "@/commands/self/ReportsCommand";
 import { HelpCommand } from "@/commands/system/HelpCommand";
 import { MailcacheCommand } from "@/commands/system/MailcacheCommand";
 import { CommandCollection } from "@/lib/CommandHandler";
@@ -9,8 +7,8 @@ export function commands(): CommandCollection {
 
   coll.add(HelpCommand);
   coll.add(MailcacheCommand);
-  coll.add(ReportsCommand);
-  coll.add(PairingsCommand);
+  // coll.add(ReportsCommand);
+  // coll.add(PairingsCommand);
 
   return coll;
 }


### PR DESCRIPTION
This is temporarily until we've had time to refactor it after 1.0.0. Likely will be enabled again in 1.1.0