### PR TITLE
refactor: break desktop app watcher file into smaller files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -4362,7 +4363,7 @@ name = "rokbattles-tauri"
 version = "0.3.12"
 dependencies = [
  "anyhow",
- "mail-decoder-legacy",
+ "mail-decoder",
  "notify",
  "reqwest",
  "serde",

--- a/crates/rokbattles-tauri/src-tauri/Cargo.toml
+++ b/crates/rokbattles-tauri/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tauri-plugin-dialog = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
-reqwest = { workspace = true }
-mail-decoder-legacy = { path = "../../mail-decoder-legacy" }
+reqwest = { workspace = true, features = ["multipart"] }
+mail-decoder = { path = "../../mail-decoder" }
 tauri-plugin-updater = { workspace = true }
 notify = { workspace = true }

--- a/crates/rokbattles-tauri/src-tauri/src/lib.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/lib.rs
@@ -133,6 +133,24 @@ async fn reprocess_all(
     Ok(())
 }
 
+#[tauri::command]
+async fn pause_watcher(
+    app: AppHandle,
+    watcher: tauri::State<'_, WatcherManager>,
+) -> Result<(), String> {
+    watcher.stop(&app).await;
+    Ok(())
+}
+
+#[tauri::command]
+async fn resume_watcher(
+    app: AppHandle,
+    watcher: tauri::State<'_, WatcherManager>,
+) -> Result<(), String> {
+    watcher.start(&app).await;
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let app = tauri::Builder::default()
@@ -158,7 +176,9 @@ pub fn run() {
             list_dirs,
             add_dir,
             remove_dir,
-            reprocess_all
+            reprocess_all,
+            pause_watcher,
+            resume_watcher
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/crates/rokbattles-tauri/src-tauri/src/watcher.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher.rs
@@ -1,76 +1,28 @@
-use crate::read_dirs;
-use anyhow::Context;
-use notify::{RecommendedWatcher, RecursiveMode, Watcher as _};
-use serde::{Deserialize, Serialize};
+mod config;
+mod mail;
+mod scan;
+mod state;
+mod store;
+mod upload;
+
+use self::config::WatcherConfig;
+use self::mail::{detect_mail_type, file_name_for_upload, is_supported_mail_type};
+use self::scan::{apply_fs_event, next_file, refresh_scans_if_needed, sync_fs_watches};
+use self::state::WatcherState;
+use self::store::{file_sig, read_processed, read_upload_queue};
+use self::upload::{is_retryable_status, post_file_to_api, upload_backoff};
+use serde::Serialize;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    fs, io,
-    io::Read,
-    io::Write,
-    path::Path,
+    collections::HashSet,
+    fs,
     path::PathBuf,
     sync::OnceLock,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, SystemTime},
 };
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, watch};
 
-// TODO Replace JSON store with SQLite (or sled)
-//  Migration: import existing processed.json on first run, then remove it.
-const PROCESSED_FILE: &str = "processed-v2.json";
-const LEGACY_PROCESSED_FILE: &str = "processed.json";
-const UPLOAD_QUEUE_FILE: &str = "upload-queue.json";
-const STORE_FLUSH_EVERY_UPDATES: usize = 20_000;
-const STORE_FLUSH_INTERVAL: Duration = Duration::from_secs(300);
-const DIR_REFRESH_INTERVAL_IDLE: Duration = Duration::from_secs(5);
-const DIR_REFRESH_INTERVAL_BUSY: Duration = Duration::from_secs(60);
-const FULL_DIR_REFRESH_INTERVAL: Duration = Duration::from_secs(180);
-const SCAN_BUDGET_PER_TICK: usize = 256;
-const IDLE_SLEEP: Duration = Duration::from_millis(750);
-const QUEUE_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
-const QUEUE_FLUSH_EVERY_UPDATES: usize = 64;
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
-const UPLOAD_PREFETCH_TARGET: usize = 4;
-const METRICS_INTERVAL: Duration = Duration::from_secs(30);
-const HOT_TRACKED_LIMIT: usize = 4096;
-const HOT_RESCAN_INTERVAL: Duration = Duration::from_millis(750);
-const HOT_RESCAN_BUDGET: usize = 64;
-const FILE_STABLE_AGE_MS: u128 = 1500;
-const FILE_RETRY_DELAY_MS: u128 = 750;
-const FILE_CHANGED_DELAY_MS: u128 = 1000;
-const FULL_REFRESH_VALIDATE_RECENT: usize = 5000;
-const FULL_REFRESH_VALIDATE_MAX_PATHS: usize = 512;
-const FS_EVENT_BUDGET: usize = 512;
-const FS_EVENT_QUEUE_CAPACITY: usize = 4096;
-const CONFIG_REFRESH_INTERVAL: Duration = Duration::from_secs(2);
-const API_INGRESS_URL: &str = "https://ingress.rokbattles.com/v1/ingress";
-
 static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct ProcessedStore {
-    entries: HashMap<String, FileSig>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-struct UploadQueueStore {
-    version: u32,
-    items: Vec<QueuedUpload>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct QueuedUpload {
-    path: String,
-    sig: FileSig,
-    attempts: u32,
-    not_before_ms: Option<u128>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct FileSig {
-    size: u64,
-    modified: u128,
-}
 
 #[derive(Debug, Clone, Serialize)]
 struct LogPayload {
@@ -112,674 +64,6 @@ fn emit_log(app: &AppHandle, message: impl Into<String>) {
     );
 }
 
-fn filename_only(path: &Path) -> String {
-    path.file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default()
-        .to_string()
-}
-
-fn processed_file(app: &AppHandle) -> anyhow::Result<PathBuf> {
-    let dir = app
-        .path()
-        .app_config_dir()
-        .context("Could not resolve app config directory")?;
-    fs::create_dir_all(&dir).context("Failed to create app config directory")?;
-    Ok(dir.join(PROCESSED_FILE))
-}
-
-fn upload_queue_file(app: &AppHandle) -> anyhow::Result<PathBuf> {
-    let dir = app
-        .path()
-        .app_config_dir()
-        .context("Could not resolve app config directory")?;
-    fs::create_dir_all(&dir).context("Failed to create app config directory")?;
-    Ok(dir.join(UPLOAD_QUEUE_FILE))
-}
-
-pub fn delete_processed(app: &AppHandle) -> anyhow::Result<()> {
-    let path = processed_file(app)?;
-    if path.exists() {
-        fs::remove_file(&path).with_context(|| format!("Failed removing {:?}", path))?;
-    }
-
-    let dir = path.parent().map(Path::to_path_buf);
-    if let Some(dir) = dir {
-        let legacy = dir.join(LEGACY_PROCESSED_FILE);
-        if legacy.exists() {
-            fs::remove_file(&legacy).with_context(|| format!("Failed removing {:?}", legacy))?;
-        }
-    }
-    Ok(())
-}
-
-pub fn delete_upload_queue(app: &AppHandle) -> anyhow::Result<()> {
-    let path = upload_queue_file(app)?;
-    if path.exists() {
-        fs::remove_file(&path).with_context(|| format!("Failed removing {:?}", path))?;
-    }
-    Ok(())
-}
-
-fn file_sig(meta: &fs::Metadata) -> anyhow::Result<FileSig> {
-    let size = meta.len();
-    let modified_time = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-    let modified = modified_time
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or(Duration::ZERO)
-        .as_millis();
-    Ok(FileSig { size, modified })
-}
-
-fn read_processed(app: &AppHandle) -> anyhow::Result<ProcessedStore> {
-    let path = processed_file(app)?;
-    if !path.exists() {
-        return Ok(ProcessedStore::default());
-    }
-    let data = fs::read(&path).with_context(|| format!("Failed reading {:?}", path))?;
-    if data.is_empty() {
-        return Ok(ProcessedStore::default());
-    }
-    let store: ProcessedStore =
-        serde_json::from_slice(&data).with_context(|| format!("Invalid JSON in {:?}", path))?;
-    Ok(store)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    let tmp_path = path.with_extension("tmp");
-    let mut file = fs::File::create(&tmp_path)
-        .with_context(|| format!("Failed creating temp file {:?}", tmp_path))?;
-    file.write_all(bytes)
-        .with_context(|| format!("Failed writing temp file {:?}", tmp_path))?;
-
-    if let Err(e) = fs::rename(&tmp_path, path) {
-        // Best-effort fallback for Windows rename semantics.
-        if e.kind() == io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(path);
-            fs::rename(&tmp_path, path).with_context(|| format!("Failed replacing {:?}", path))?;
-        } else {
-            return Err(e).with_context(|| format!("Failed renaming {:?} -> {:?}", tmp_path, path));
-        }
-    }
-    Ok(())
-}
-
-fn write_processed(app: &AppHandle, store: &ProcessedStore) -> anyhow::Result<()> {
-    let path = processed_file(app)?;
-    let json = serde_json::to_vec(store).context("Failed to serialize processed store to JSON")?;
-    atomic_write(&path, &json).with_context(|| format!("Failed writing {:?}", path))?;
-    Ok(())
-}
-
-fn read_upload_queue(app: &AppHandle) -> anyhow::Result<UploadQueueStore> {
-    let path = upload_queue_file(app)?;
-    if !path.exists() {
-        return Ok(UploadQueueStore::default());
-    }
-    let data = fs::read(&path).with_context(|| format!("Failed reading {:?}", path))?;
-    if data.is_empty() {
-        return Ok(UploadQueueStore::default());
-    }
-    let store: UploadQueueStore =
-        serde_json::from_slice(&data).with_context(|| format!("Invalid JSON in {:?}", path))?;
-    Ok(store)
-}
-
-fn write_upload_queue(app: &AppHandle, store: &UploadQueueStore) -> anyhow::Result<()> {
-    let path = upload_queue_file(app)?;
-    let json = serde_json::to_vec(store).context("Failed to serialize upload queue to JSON")?;
-    atomic_write(&path, &json).with_context(|| format!("Failed writing {:?}", path))?;
-    Ok(())
-}
-
-fn parse_rok_mail_id(filename: &str) -> Option<u128> {
-    let rest = filename.strip_prefix("Persistent.Mail.")?;
-    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
-        return None;
-    }
-    rest.parse::<u128>().ok()
-}
-
-fn detect_mail_type<'a>(mail: &'a mail_decoder_legacy::MailBorrowed<'a>) -> Option<&'a str> {
-    for section in &mail.sections {
-        let mail_decoder_legacy::ValueBorrowed::Object(entries) = section else {
-            continue;
-        };
-        for (key, value) in entries {
-            if *key != "type" {
-                continue;
-            }
-            let mail_decoder_legacy::ValueBorrowed::String(value) = value else {
-                return None;
-            };
-            return Some(value);
-        }
-    }
-    None
-}
-
-fn has_rok_fileheader_from_file(path: &PathBuf) -> anyhow::Result<bool> {
-    let mut f = fs::File::open(path)
-        .with_context(|| format!("Failed to open file for header check: {:?}", path))?;
-    let mut buf = [0u8; 32];
-    let _ = f.read(&mut buf)?;
-    Ok(mail_decoder_legacy::has_rok_mail_header(&buf))
-}
-
-#[derive(Debug, Clone)]
-struct DirScan {
-    dir: PathBuf,
-    ids: Vec<u128>,
-    known_ids: HashSet<u128>,
-    cursor: usize,
-    last_refresh: Instant,
-    max_id: Option<u128>,
-    last_full_refresh: Instant,
-}
-
-impl DirScan {
-    fn new(dir: PathBuf) -> Self {
-        Self {
-            dir,
-            ids: Vec::new(),
-            known_ids: HashSet::new(),
-            cursor: 0,
-            last_refresh: Instant::now()
-                .checked_sub(DIR_REFRESH_INTERVAL_BUSY)
-                .unwrap_or_else(Instant::now),
-            max_id: None,
-            last_full_refresh: Instant::now()
-                .checked_sub(FULL_DIR_REFRESH_INTERVAL)
-                .unwrap_or_else(Instant::now),
-        }
-    }
-
-    fn is_stale(&self) -> bool {
-        let interval = if self.cursor == 0 {
-            DIR_REFRESH_INTERVAL_IDLE
-        } else {
-            DIR_REFRESH_INTERVAL_BUSY
-        };
-        self.ids.is_empty() || self.last_refresh.elapsed() >= interval
-    }
-
-    fn peek_next_id(&self) -> Option<u128> {
-        if self.cursor == 0 {
-            None
-        } else {
-            Some(self.ids[self.cursor - 1])
-        }
-    }
-
-    fn pop_next_id(&mut self) -> Option<u128> {
-        if self.cursor == 0 {
-            return None;
-        }
-        self.cursor -= 1;
-        Some(self.ids[self.cursor])
-    }
-
-    fn path_for_id(&self, id: u128) -> PathBuf {
-        self.dir.join(format!("Persistent.Mail.{id}"))
-    }
-}
-
-struct WatcherState {
-    scans: Vec<DirScan>,
-    dirs: Vec<PathBuf>,
-    dirs_last_read: Instant,
-    store: ProcessedStore,
-    store_dirty_updates: usize,
-    store_last_flush: Instant,
-    upload_queue: VecDeque<QueuedUpload>,
-    upload_queued_paths: HashSet<String>,
-    upload_queue_dirty_updates: usize,
-    upload_queue_last_flush: Instant,
-    scan_refreshes: u64,
-    store_flushes: u64,
-    upload_queue_flushes: u64,
-    hot_paths: VecDeque<String>,
-    hot_set: HashSet<String>,
-    hot_last_scan: Instant,
-}
-
-impl WatcherState {
-    fn new(store: ProcessedStore, upload_queue_store: UploadQueueStore) -> Self {
-        let mut upload_queue = VecDeque::new();
-        let mut upload_queued_paths = HashSet::new();
-        for item in upload_queue_store.items {
-            if upload_queued_paths.insert(item.path.clone()) {
-                upload_queue.push_back(item);
-            }
-        }
-
-        Self {
-            scans: Vec::new(),
-            dirs: Vec::new(),
-            dirs_last_read: Instant::now()
-                .checked_sub(CONFIG_REFRESH_INTERVAL)
-                .unwrap_or_else(Instant::now),
-            store,
-            store_dirty_updates: 0,
-            store_last_flush: Instant::now(),
-            upload_queue,
-            upload_queued_paths,
-            upload_queue_dirty_updates: 0,
-            upload_queue_last_flush: Instant::now(),
-            scan_refreshes: 0,
-            store_flushes: 0,
-            upload_queue_flushes: 0,
-            hot_paths: VecDeque::new(),
-            hot_set: HashSet::new(),
-            hot_last_scan: Instant::now(),
-        }
-    }
-
-    fn maybe_flush_store(&mut self, app: &AppHandle) {
-        if self.store_dirty_updates == 0 {
-            return;
-        }
-        if self.store_dirty_updates < STORE_FLUSH_EVERY_UPDATES
-            && self.store_last_flush.elapsed() < STORE_FLUSH_INTERVAL
-        {
-            return;
-        }
-        if let Err(e) = write_processed(app, &self.store) {
-            eprintln!("[rokbattles] failed to flush processed store: {}", e);
-            return;
-        }
-        self.store_dirty_updates = 0;
-        self.store_last_flush = Instant::now();
-        self.store_flushes += 1;
-    }
-
-    fn maybe_flush_upload_queue(&mut self, app: &AppHandle) {
-        if self.upload_queue_dirty_updates == 0 {
-            return;
-        }
-        if self.upload_queue_dirty_updates < QUEUE_FLUSH_EVERY_UPDATES
-            && self.upload_queue_last_flush.elapsed() < QUEUE_FLUSH_INTERVAL
-        {
-            return;
-        }
-        let store = UploadQueueStore {
-            version: 1,
-            items: self.upload_queue.iter().cloned().collect(),
-        };
-        if let Err(e) = write_upload_queue(app, &store) {
-            eprintln!("[rokbattles] failed to flush upload queue: {}", e);
-            return;
-        }
-        self.upload_queue_dirty_updates = 0;
-        self.upload_queue_last_flush = Instant::now();
-        self.upload_queue_flushes += 1;
-    }
-
-    fn track_hot_path(&mut self, path: String) {
-        if self.hot_set.contains(&path) {
-            return;
-        }
-        if self.hot_paths.len() >= HOT_TRACKED_LIMIT
-            && let Some(old) = self.hot_paths.pop_front()
-        {
-            self.hot_set.remove(&old);
-        }
-        self.hot_set.insert(path.clone());
-        self.hot_paths.push_back(path);
-    }
-
-    fn enqueue_upload(&mut self, item: QueuedUpload) {
-        let path = item.path.clone();
-        if !self.upload_queued_paths.insert(item.path.clone()) {
-            return;
-        }
-        self.upload_queue.push_back(item);
-        self.upload_queue_dirty_updates += 1;
-        self.track_hot_path(path);
-    }
-
-    fn pop_ready_upload(&mut self, now_ms: u128) -> Option<QueuedUpload> {
-        let len = self.upload_queue.len();
-        for _ in 0..len {
-            let item = self.upload_queue.pop_front()?;
-            if item.not_before_ms.is_some_and(|t| t > now_ms) {
-                self.upload_queue.push_back(item);
-                continue;
-            }
-            self.upload_queued_paths.remove(&item.path);
-            self.upload_queue_dirty_updates += 1;
-            return Some(item);
-        }
-        None
-    }
-
-    fn requeue_upload(&mut self, item: QueuedUpload) {
-        if self.upload_queued_paths.insert(item.path.clone()) {
-            self.upload_queue.push_back(item);
-            self.upload_queue_dirty_updates += 1;
-        }
-    }
-
-    fn maybe_rescan_hot(&mut self, now_ms: u128) {
-        if self.hot_last_scan.elapsed() < HOT_RESCAN_INTERVAL {
-            return;
-        }
-        self.hot_last_scan = Instant::now();
-
-        for _ in 0..HOT_RESCAN_BUDGET {
-            let Some(path_str) = self.hot_paths.pop_front() else {
-                break;
-            };
-
-            let path = PathBuf::from(&path_str);
-            let Some(existing) = self.store.entries.get(&path_str).cloned() else {
-                self.hot_paths.push_back(path_str);
-                continue;
-            };
-
-            let meta = match fs::metadata(&path) {
-                Ok(m) => m,
-                Err(_) => {
-                    self.hot_paths.push_back(path_str);
-                    continue;
-                }
-            };
-            let sig = match file_sig(&meta) {
-                Ok(s) => s,
-                Err(_) => {
-                    self.hot_paths.push_back(path_str);
-                    continue;
-                }
-            };
-
-            if sig != existing {
-                self.store.entries.insert(path_str.clone(), sig.clone());
-                self.store_dirty_updates += 1;
-                self.enqueue_upload(QueuedUpload {
-                    path: path_str.clone(),
-                    sig,
-                    attempts: 0,
-                    not_before_ms: Some(now_ms.saturating_add(FILE_CHANGED_DELAY_MS)),
-                });
-            }
-
-            self.hot_paths.push_back(path_str);
-        }
-    }
-}
-
-async fn refresh_scans_if_needed(app: &AppHandle, state: &mut WatcherState) -> bool {
-    let next_dirs =
-        if !state.dirs.is_empty() && state.dirs_last_read.elapsed() < CONFIG_REFRESH_INTERVAL {
-            state.dirs.clone()
-        } else {
-            let dirs = match read_dirs(app) {
-                Ok(d) => d,
-                Err(e) => {
-                    emit_log(app, format!("Failed to read config: {}", e));
-                    eprintln!("[rokbattles] failed to read config: {}", e);
-                    return false;
-                }
-            };
-            let next_dirs: Vec<PathBuf> = dirs.into_iter().map(PathBuf::from).collect();
-            state.dirs = next_dirs.clone();
-            state.dirs_last_read = Instant::now();
-            next_dirs
-        };
-    let needs_rebuild = state.scans.len() != next_dirs.len()
-        || state
-            .scans
-            .iter()
-            .zip(next_dirs.iter())
-            .any(|(scan, dir)| &scan.dir != dir);
-
-    if needs_rebuild {
-        state.scans = next_dirs.into_iter().map(DirScan::new).collect();
-    }
-
-    let mut did_refresh = false;
-    let mut refresh_count = 0u64;
-    let mut full_refreshed_dirs: Vec<PathBuf> = Vec::new();
-    for scan in &mut state.scans {
-        if !scan.is_stale() {
-            continue;
-        }
-        #[derive(Debug)]
-        enum RefreshResult {
-            Full(Vec<u128>),
-            New(Vec<u128>),
-        }
-
-        let do_full = scan.last_full_refresh.elapsed() >= FULL_DIR_REFRESH_INTERVAL;
-        let dir = scan.dir.clone();
-        let max_id = scan.max_id;
-        let ids = tauri::async_runtime::spawn_blocking(move || -> anyhow::Result<RefreshResult> {
-            let read_dir = fs::read_dir(&dir)
-                .with_context(|| format!("Failed to read directory {:?}", dir))?;
-
-            let mut ids = Vec::new();
-            for entry in read_dir.flatten() {
-                let Ok(file_type) = entry.file_type() else {
-                    continue;
-                };
-                if !file_type.is_file() {
-                    continue;
-                }
-                let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
-                    continue;
-                };
-                let Some(id) = parse_rok_mail_id(&name) else {
-                    continue;
-                };
-
-                if !do_full
-                    && let Some(max) = max_id
-                    && id <= max
-                {
-                    continue;
-                }
-                ids.push(id);
-            }
-
-            ids.sort_unstable();
-            ids.dedup();
-
-            if do_full || max_id.is_none() {
-                Ok(RefreshResult::Full(ids))
-            } else {
-                Ok(RefreshResult::New(ids))
-            }
-        })
-        .await;
-
-        match ids {
-            Ok(Ok(RefreshResult::Full(ids))) => {
-                if scan.ids.is_empty() {
-                    scan.max_id = ids.last().copied();
-                    scan.known_ids = ids.iter().copied().collect();
-                    scan.ids = ids;
-                    scan.cursor = scan.ids.len();
-                } else {
-                    for id in ids {
-                        if scan.known_ids.insert(id) {
-                            scan.ids.insert(scan.cursor, id);
-                            scan.cursor = scan.cursor.saturating_add(1);
-                            scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
-                        }
-                    }
-                }
-
-                scan.last_refresh = Instant::now();
-                scan.last_full_refresh = Instant::now();
-                did_refresh = true;
-                refresh_count += 1;
-                full_refreshed_dirs.push(scan.dir.clone());
-            }
-            Ok(Ok(RefreshResult::New(ids))) => {
-                for id in ids {
-                    if scan.known_ids.insert(id) {
-                        scan.ids.insert(scan.cursor, id);
-                        scan.cursor = scan.cursor.saturating_add(1);
-                        scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
-                    }
-                }
-                scan.last_refresh = Instant::now();
-                did_refresh = true;
-                refresh_count += 1;
-            }
-            Ok(Err(e)) => {
-                eprintln!(
-                    "[rokbattles] directory scan failed for {:?}: {}",
-                    scan.dir, e
-                );
-            }
-            Err(e) => {
-                eprintln!(
-                    "[rokbattles] directory scan task failed for {:?}: {}",
-                    scan.dir, e
-                );
-            }
-        }
-    }
-
-    state.scan_refreshes = state.scan_refreshes.saturating_add(refresh_count);
-
-    if !full_refreshed_dirs.is_empty() {
-        let now_ms = now_epoch_ms();
-        for dir in full_refreshed_dirs {
-            let Some(scan) = state.scans.iter().find(|s| s.dir == dir) else {
-                continue;
-            };
-
-            let recent_ids = scan
-                .ids
-                .iter()
-                .rev()
-                .take(FULL_REFRESH_VALIDATE_RECENT)
-                .copied()
-                .collect::<Vec<u128>>();
-
-            let mut validate_paths: Vec<PathBuf> = Vec::new();
-            let mut validate_keys: Vec<String> = Vec::new();
-            for id in recent_ids {
-                let path = scan.path_for_id(id);
-                let key = path.to_string_lossy().to_string();
-                if state.store.entries.contains_key(&key) {
-                    validate_paths.push(path);
-                    validate_keys.push(key);
-                    if validate_paths.len() >= FULL_REFRESH_VALIDATE_MAX_PATHS {
-                        break;
-                    }
-                }
-            }
-
-            if validate_paths.is_empty() {
-                continue;
-            }
-
-            let results = tauri::async_runtime::spawn_blocking(move || {
-                validate_paths
-                    .into_iter()
-                    .zip(validate_keys)
-                    .filter_map(|(path, key)| {
-                        let meta = fs::metadata(&path).ok()?;
-                        let sig = file_sig(&meta).ok()?;
-                        Some((key, sig))
-                    })
-                    .collect::<Vec<(String, FileSig)>>()
-            })
-            .await;
-
-            let Ok(results) = results else {
-                continue;
-            };
-
-            for (key, sig_now) in results {
-                let Some(existing) = state.store.entries.get(&key).cloned() else {
-                    continue;
-                };
-                if existing == sig_now {
-                    continue;
-                }
-                state.store.entries.insert(key.clone(), sig_now.clone());
-                state.store_dirty_updates += 1;
-                state.enqueue_upload(QueuedUpload {
-                    path: key,
-                    sig: sig_now,
-                    attempts: 0,
-                    not_before_ms: Some(now_ms.saturating_add(FILE_CHANGED_DELAY_MS)),
-                });
-            }
-        }
-    }
-
-    did_refresh
-}
-
-async fn next_file(app: &AppHandle, state: &mut WatcherState) -> Option<QueuedUpload> {
-    for _ in 0..SCAN_BUDGET_PER_TICK {
-        let (scan_idx, _best_id) = state
-            .scans
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, scan)| scan.peek_next_id().map(|id| (idx, id)))
-            .max_by_key(|(_, id)| *id)?;
-
-        let scan = &mut state.scans[scan_idx];
-        let id = scan.pop_next_id()?;
-        let path = scan.path_for_id(id);
-        let key = path.to_string_lossy().to_string();
-
-        if state.store.entries.contains_key(&key) {
-            continue;
-        }
-
-        let meta = match fs::metadata(&path) {
-            Ok(m) => m,
-            Err(_) => continue,
-        };
-        let sig = match file_sig(&meta) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-
-        // check file header (blocking IO)
-        let header = tauri::async_runtime::spawn_blocking({
-            let path = path.clone();
-            move || has_rok_fileheader_from_file(&path)
-        })
-        .await;
-
-        match header {
-            Ok(Ok(true)) => {
-                state.store.entries.insert(key, sig.clone());
-                state.store_dirty_updates += 1;
-                state.maybe_flush_store(app);
-                return Some(QueuedUpload {
-                    path: path.to_string_lossy().to_string(),
-                    sig,
-                    attempts: 0,
-                    not_before_ms: None,
-                });
-            }
-            Ok(Ok(false)) => {
-                state.store.entries.insert(key, sig);
-                state.store_dirty_updates += 1;
-                state.maybe_flush_store(app);
-            }
-            Ok(Err(e)) => {
-                eprintln!("[rokbattles] header check failed on {:?}: {}", path, e)
-            }
-            Err(e) => {
-                eprintln!("[rokbattles] header check task failed on {:?}: {}", path, e)
-            }
-        }
-    }
-
-    state.maybe_flush_store(app);
-    None
-}
-
 fn now_epoch_ms() -> u128 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -787,96 +71,18 @@ fn now_epoch_ms() -> u128 {
         .as_millis()
 }
 
-fn upload_backoff(attempts: u32) -> Duration {
-    let seconds = 2u64.saturating_pow(attempts.min(10));
-    Duration::from_secs(seconds.clamp(2, 300))
+pub fn delete_processed(app: &AppHandle) -> anyhow::Result<()> {
+    store::delete_processed(app, &WatcherConfig::default())
 }
 
-fn sync_fs_watches(
-    watcher: Option<&mut RecommendedWatcher>,
-    watched_dirs: &mut HashSet<PathBuf>,
-    desired_dirs: &[PathBuf],
-) {
-    let Some(watcher) = watcher else {
-        return;
-    };
-
-    let desired: HashSet<PathBuf> = desired_dirs.iter().cloned().collect();
-
-    for dir in watched_dirs
-        .difference(&desired)
-        .cloned()
-        .collect::<Vec<_>>()
-    {
-        if let Err(e) = watcher.unwatch(&dir) {
-            eprintln!("[rokbattles] failed to unwatch {:?}: {}", dir, e);
-        }
-        watched_dirs.remove(&dir);
-    }
-
-    for dir in desired
-        .difference(watched_dirs)
-        .cloned()
-        .collect::<Vec<_>>()
-    {
-        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
-            eprintln!("[rokbattles] failed to watch {:?}: {}", dir, e);
-            continue;
-        }
-        watched_dirs.insert(dir);
-    }
-}
-
-fn apply_fs_event(state: &mut WatcherState, path: PathBuf, now_ms: u128) {
-    let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
-        return;
-    };
-    let Some(id) = parse_rok_mail_id(name) else {
-        return;
-    };
-
-    let meta = match fs::metadata(&path) {
-        Ok(m) => m,
-        Err(_) => return,
-    };
-    let sig = match file_sig(&meta) {
-        Ok(s) => s,
-        Err(_) => return,
-    };
-
-    let key = path.to_string_lossy().to_string();
-    if let Some(existing) = state.store.entries.get(&key)
-        && *existing == sig
-    {
-        return;
-    }
-    state.store.entries.insert(key.clone(), sig.clone());
-    state.store_dirty_updates += 1;
-    state.enqueue_upload(QueuedUpload {
-        path: key,
-        sig,
-        attempts: 0,
-        not_before_ms: Some(now_ms.saturating_add(FILE_RETRY_DELAY_MS)),
-    });
-
-    if let Some(parent) = path.parent()
-        && let Some(scan) = state.scans.iter_mut().find(|s| s.dir == parent)
-    {
-        let _ = scan.known_ids.insert(id);
-        scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
-    }
-}
-
-#[derive(Debug)]
-struct UploadApiError {
-    status: Option<reqwest::StatusCode>,
-    retry_after: Option<Duration>,
-    message: String,
+pub fn delete_upload_queue(app: &AppHandle) -> anyhow::Result<()> {
+    store::delete_upload_queue(app, &WatcherConfig::default())
 }
 
 pub struct WatcherTask {
     shutdown: watch::Sender<bool>,
     handle: tauri::async_runtime::JoinHandle<()>,
+    shutdown_timeout: Duration,
 }
 
 impl WatcherTask {
@@ -885,7 +91,7 @@ impl WatcherTask {
         let mut handle = self.handle;
         tokio::select! {
             _ = &mut handle => {}
-            _ = tokio::time::sleep(SHUTDOWN_TIMEOUT) => {
+            _ = tokio::time::sleep(self.shutdown_timeout) => {
                 emit_log(app, "Watcher shutdown timed out; aborting task");
                 handle.abort();
             }
@@ -893,67 +99,33 @@ impl WatcherTask {
     }
 }
 
-async fn post_file_to_api(
-    client: &reqwest::Client,
-    api_url: &str,
-    bytes: Vec<u8>,
-) -> Result<(), UploadApiError> {
-    let resp = client
-        .post(api_url)
-        .header(reqwest::header::CONTENT_TYPE, "application/octet-stream")
-        .body(bytes)
-        .send()
-        .await
-        .map_err(|e| UploadApiError {
-            status: None,
-            retry_after: None,
-            message: format!("failed to send mail to API: {e}"),
-        })?;
-
-    let status = resp.status();
-    if !status.is_success() {
-        let retry_after = resp
-            .headers()
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|h| h.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok())
-            .map(Duration::from_secs);
-        let text = resp.text().await.unwrap_or_default();
-        return Err(UploadApiError {
-            status: Some(status),
-            retry_after,
-            message: format!("API rejected upload: {} {}", status, text),
-        });
-    }
-    Ok(())
-}
-
 pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
     let app = app.clone();
 
-    let api_url = API_INGRESS_URL.to_string();
+    let config = WatcherConfig::default();
+    let api_url = config.api_ingress_url.to_string();
+    let shutdown_timeout = config.shutdown_timeout;
     let client = http_client();
 
     let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
-    let (fs_tx, mut fs_rx) = mpsc::channel::<PathBuf>(FS_EVENT_QUEUE_CAPACITY);
+    let (fs_tx, mut fs_rx) = mpsc::channel::<PathBuf>(config.fs_event_queue_capacity);
+    let config_for_task = config.clone();
     let handle = tauri::async_runtime::spawn(async move {
-        let processed = match read_processed(&app) {
+        let processed = match read_processed(&app, &config_for_task) {
             Ok(store) => store,
             Err(e) => {
                 emit_log(&app, format!("Failed to read processed store: {}", e));
-                eprintln!("[rokbattles] failed to read processed store: {}", e);
-                ProcessedStore::default()
+                store::ProcessedStore::default()
             }
         };
-        let upload_queue = match read_upload_queue(&app) {
+        let upload_queue = match read_upload_queue(&app, &config_for_task) {
             Ok(store) => store,
             Err(e) => {
                 emit_log(&app, format!("Failed to read upload queue: {}", e));
-                eprintln!("[rokbattles] failed to read upload queue: {}", e);
-                UploadQueueStore::default()
+                store::UploadQueueStore::default()
             }
         };
-        let mut state = WatcherState::new(processed, upload_queue);
+        let mut state = WatcherState::new(config_for_task, processed, upload_queue);
         let mut fs_watcher = match notify::recommended_watcher({
             let fs_tx = fs_tx.clone();
             move |res: Result<notify::Event, notify::Error>| {
@@ -966,22 +138,14 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
         }) {
             Ok(w) => Some(w),
             Err(e) => {
-                eprintln!(
-                    "[rokbattles] failed to initialize filesystem watcher: {}",
-                    e
+                emit_log(
+                    &app,
+                    format!("Failed to initialize filesystem watcher: {}", e),
                 );
                 None
             }
         };
         let mut fs_watched_dirs: HashSet<PathBuf> = HashSet::new();
-
-        let mut last_metrics = Instant::now();
-        let mut metrics_processed: u64 = 0;
-        let mut metrics_uploaded: u64 = 0;
-        let mut metrics_skipped: u64 = 0;
-        let mut metrics_decode_failed: u64 = 0;
-        let mut metrics_upload_failed: u64 = 0;
-        let mut metrics_fs_events: u64 = 0;
 
         loop {
             if *shutdown_rx.borrow() {
@@ -997,17 +161,16 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
             state.maybe_rescan_hot(now_ms);
 
             let _ = refresh_scans_if_needed(&app, &mut state).await;
-            sync_fs_watches(fs_watcher.as_mut(), &mut fs_watched_dirs, &state.dirs);
+            sync_fs_watches(&app, fs_watcher.as_mut(), &mut fs_watched_dirs, &state.dirs);
 
-            for _ in 0..FS_EVENT_BUDGET {
+            for _ in 0..state.config.fs_event_budget {
                 let Ok(path) = fs_rx.try_recv() else {
                     break;
                 };
-                metrics_fs_events += 1;
                 apply_fs_event(&mut state, path, now_ms);
             }
 
-            while state.upload_queue.len() < UPLOAD_PREFETCH_TARGET {
+            while state.upload_queue.len() < state.config.upload_prefetch_target {
                 if let Some(item) = next_file(&app, &mut state).await {
                     state.enqueue_upload(item);
                 } else {
@@ -1015,54 +178,35 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
                 }
             }
 
-            if last_metrics.elapsed() >= METRICS_INTERVAL {
-                eprintln!(
-                    "[rokbattles] metrics: processed={} uploaded={} skipped={} decode_failed={} upload_failed={} fs_events={} queue={} hot={} processed_entries={} dir_refreshes={} store_flushes={} queue_flushes={}",
-                    metrics_processed,
-                    metrics_uploaded,
-                    metrics_skipped,
-                    metrics_decode_failed,
-                    metrics_upload_failed,
-                    metrics_fs_events,
-                    state.upload_queue.len(),
-                    state.hot_paths.len(),
-                    state.store.entries.len(),
-                    state.scan_refreshes,
-                    state.store_flushes,
-                    state.upload_queue_flushes,
-                );
-                last_metrics = Instant::now();
-            }
-
             if let Some(item) = state.pop_ready_upload(now_ms) {
                 let path = PathBuf::from(&item.path);
-                let fname = filename_only(&path);
-                metrics_processed += 1;
-                emit_log(&app, format!("Processing {}", fname));
-                eprintln!("[rokbattles] processing {:?}", path);
+                let Some(file_name) = file_name_for_upload(&path) else {
+                    emit_log(&app, "Skipping file with invalid name");
+                    continue;
+                };
+                emit_log(&app, format!("Processing {}", file_name));
 
                 let meta = match fs::metadata(&path) {
                     Ok(m) => m,
                     Err(e) => {
-                        emit_log(&app, format!("Failed to stat file {}: {}", fname, e));
-                        eprintln!("[rokbattles] failed to stat file {:?}: {}", path, e);
+                        emit_log(&app, format!("Failed to stat file {}: {}", file_name, e));
                         continue;
                     }
                 };
                 let sig_now = match file_sig(&meta) {
                     Ok(s) => s,
                     Err(e) => {
-                        emit_log(&app, format!("Failed to stat file {}: {}", fname, e));
-                        eprintln!("[rokbattles] failed to stat file {:?}: {}", path, e);
+                        emit_log(&app, format!("Failed to stat file {}: {}", file_name, e));
                         continue;
                     }
                 };
                 let age_ms = now_ms.saturating_sub(sig_now.modified);
-                if sig_now != item.sig || age_ms < FILE_STABLE_AGE_MS {
+                if sig_now != item.sig || age_ms < state.config.file_stable_age_ms {
                     let path_key = item.path.clone();
                     let mut next = item;
                     next.sig = sig_now.clone();
-                    next.not_before_ms = Some(now_ms.saturating_add(FILE_RETRY_DELAY_MS));
+                    next.not_before_ms =
+                        Some(now_ms.saturating_add(state.config.file_retry_delay_ms));
                     state.requeue_upload(next);
 
                     state.store.entries.insert(path_key, sig_now);
@@ -1078,8 +222,7 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
                 {
                     Ok(Ok(b)) => b,
                     Ok(Err(e)) => {
-                        emit_log(&app, format!("Failed to read file {}: {}", fname, e));
-                        eprintln!("[rokbattles] failed to read file {:?}: {}", path, e);
+                        emit_log(&app, format!("Failed to read file {}: {}", file_name, e));
 
                         let mut next = item;
                         next.attempts = next.attempts.saturating_add(1);
@@ -1089,8 +232,7 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
                         continue;
                     }
                     Err(e) => {
-                        emit_log(&app, format!("Failed to read file {}: {}", fname, e));
-                        eprintln!("[rokbattles] read task failed for {:?}: {}", path, e);
+                        emit_log(&app, format!("Failed to read file {}: {}", file_name, e));
 
                         let mut next = item;
                         next.attempts = next.attempts.saturating_add(1);
@@ -1101,52 +243,39 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
                     }
                 };
 
-                let decoded = match mail_decoder_legacy::decode(&bytes) {
+                let decoded = match mail_decoder::decode(&bytes) {
                     Ok(m) => m,
                     Err(e) => {
-                        metrics_decode_failed += 1;
-                        emit_log(&app, format!("Decode failed for {}: {}", fname, e));
-                        eprintln!("[rokbattles] decode failed for {:?}: {}", path, e);
+                        emit_log(&app, format!("Decode failed for {}: {}", file_name, e));
                         continue;
                     }
                 };
 
                 let first_type = detect_mail_type(&decoded);
-                let supported_type = first_type.is_some_and(|t| {
-                    t.eq_ignore_ascii_case("Battle")
-                        || t.eq_ignore_ascii_case("DuelBattle2")
-                        || t.eq_ignore_ascii_case("BarCanyonKillBoss")
-                });
+                let supported_type = first_type.is_some_and(is_supported_mail_type);
                 if !supported_type {
-                    metrics_skipped += 1;
                     emit_log(
                         &app,
                         format!(
                             "Skipping unsupported mail {} (detected: {})",
-                            fname,
+                            file_name,
                             first_type.unwrap_or("Unknown")
                         ),
-                    );
-                    eprintln!(
-                        "[rokbattles] skipping unsupported mail {:?} (detected: {:?})",
-                        path,
-                        first_type.unwrap_or("Unknown")
                     );
                     continue;
                 }
 
-                match post_file_to_api(client, &api_url, bytes).await {
-                    Ok(()) => {
-                        metrics_uploaded += 1;
-                        emit_log(&app, format!("Uploaded {}", fname));
-                        eprintln!("[rokbattles] uploaded mail {:?}", path);
+                match post_file_to_api(client, &api_url, &file_name, bytes).await {
+                    Ok(status) => {
+                        emit_log(&app, status.log_message(&file_name));
                     }
                     Err(e) => {
-                        metrics_upload_failed += 1;
-                        emit_log(&app, format!("Failed to upload {}: {}", fname, e.message));
-                        eprintln!("[rokbattles] failed to upload {:?}: {}", path, e.message);
+                        emit_log(
+                            &app,
+                            format!("Failed to upload {}: {}", file_name, e.message),
+                        );
 
-                        let retryable = e.status.is_none_or(|s| s == 429 || s.is_server_error());
+                        let retryable = is_retryable_status(e.status);
                         if retryable {
                             let mut next = item;
                             next.attempts = next.attempts.saturating_add(1);
@@ -1163,7 +292,7 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
 
             let now_ms = now_epoch_ms();
             tokio::select! {
-                _ = tokio::time::sleep(IDLE_SLEEP) => {}
+                _ = tokio::time::sleep(state.config.idle_sleep) => {}
                 res = shutdown_rx.changed() => {
                     if res.is_ok() && *shutdown_rx.borrow() {
                         state.maybe_flush_store(&app);
@@ -1173,7 +302,6 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
                 }
                 maybe_path = fs_rx.recv() => {
                     if let Some(path) = maybe_path {
-                        metrics_fs_events += 1;
                         apply_fs_event(&mut state, path, now_ms);
                     }
                 }
@@ -1184,5 +312,6 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
     WatcherTask {
         shutdown: shutdown_tx,
         handle,
+        shutdown_timeout,
     }
 }

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/config.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/config.rs
@@ -58,7 +58,7 @@ pub(crate) struct WatcherConfig {
 impl Default for WatcherConfig {
     fn default() -> Self {
         Self {
-            processed_file_name: "processed-v2.json",
+            processed_file_name: "processed-v3.json",
             upload_queue_file_name: "upload-queue.json",
             store_flush_every_updates: 20_000,
             store_flush_interval: Duration::from_secs(300),

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/config.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/config.rs
@@ -1,0 +1,88 @@
+use std::time::Duration;
+
+/// Runtime tuning knobs for the watcher loop.
+#[derive(Debug, Clone)]
+pub(crate) struct WatcherConfig {
+    /// Current processed store filename.
+    pub(crate) processed_file_name: &'static str,
+    /// Pending upload queue filename.
+    pub(crate) upload_queue_file_name: &'static str,
+    /// Flush processed state after this many updates to cap memory growth.
+    pub(crate) store_flush_every_updates: usize,
+    /// Maximum time to keep processed state only in-memory.
+    pub(crate) store_flush_interval: Duration,
+    /// Directory rescan cadence while idle.
+    pub(crate) dir_refresh_interval_idle: Duration,
+    /// Directory rescan cadence while actively scanning.
+    pub(crate) dir_refresh_interval_busy: Duration,
+    /// Full directory rescan cadence to catch missed events.
+    pub(crate) full_dir_refresh_interval: Duration,
+    /// Max number of files to scan per loop tick.
+    pub(crate) scan_budget_per_tick: usize,
+    /// Idle sleep to avoid busy looping when no work is pending.
+    pub(crate) idle_sleep: Duration,
+    /// Max time to keep the upload queue only in-memory.
+    pub(crate) queue_flush_interval: Duration,
+    /// Flush upload queue after this many updates.
+    pub(crate) queue_flush_every_updates: usize,
+    /// Graceful shutdown timeout before aborting the task.
+    pub(crate) shutdown_timeout: Duration,
+    /// Prefetch this many uploads ahead of time.
+    pub(crate) upload_prefetch_target: usize,
+    /// Max number of recently changed paths to track for rescans.
+    pub(crate) hot_tracked_limit: usize,
+    /// Rescan interval for recently changed paths.
+    pub(crate) hot_rescan_interval: Duration,
+    /// Max hot paths to rescan per interval.
+    pub(crate) hot_rescan_budget: usize,
+    /// Minimum age before a file is considered stable enough to upload (ms).
+    pub(crate) file_stable_age_ms: u128,
+    /// Delay before retrying a file read failure (ms).
+    pub(crate) file_retry_delay_ms: u128,
+    /// Delay before retrying a changed file (ms).
+    pub(crate) file_changed_delay_ms: u128,
+    /// Max number of recent ids to validate after a full refresh.
+    pub(crate) full_refresh_validate_recent: usize,
+    /// Max paths to revalidate after a full refresh.
+    pub(crate) full_refresh_validate_max_paths: usize,
+    /// Limit filesystem events processed per tick.
+    pub(crate) fs_event_budget: usize,
+    /// Capacity for filesystem event channel.
+    pub(crate) fs_event_queue_capacity: usize,
+    /// Refresh interval for reading config dirs.
+    pub(crate) config_refresh_interval: Duration,
+    /// Ingress upload endpoint.
+    pub(crate) api_ingress_url: &'static str,
+}
+
+impl Default for WatcherConfig {
+    fn default() -> Self {
+        Self {
+            processed_file_name: "processed-v2.json",
+            upload_queue_file_name: "upload-queue.json",
+            store_flush_every_updates: 20_000,
+            store_flush_interval: Duration::from_secs(300),
+            dir_refresh_interval_idle: Duration::from_secs(5),
+            dir_refresh_interval_busy: Duration::from_secs(60),
+            full_dir_refresh_interval: Duration::from_secs(180),
+            scan_budget_per_tick: 256,
+            idle_sleep: Duration::from_millis(750),
+            queue_flush_interval: Duration::from_secs(2),
+            queue_flush_every_updates: 64,
+            shutdown_timeout: Duration::from_secs(3),
+            upload_prefetch_target: 4,
+            hot_tracked_limit: 4096,
+            hot_rescan_interval: Duration::from_millis(750),
+            hot_rescan_budget: 64,
+            file_stable_age_ms: 1500,
+            file_retry_delay_ms: 750,
+            file_changed_delay_ms: 1000,
+            full_refresh_validate_recent: 5000,
+            full_refresh_validate_max_paths: 512,
+            fs_event_budget: 512,
+            fs_event_queue_capacity: 4096,
+            config_refresh_interval: Duration::from_secs(2),
+            api_ingress_url: "https://ingress.rokbattles.com/v2/upload",
+        }
+    }
+}

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/mail.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/mail.rs
@@ -1,0 +1,146 @@
+use serde_json::{Map, Value};
+use std::path::Path;
+
+/// Parse the numeric mail id from a RoK mail filename.
+pub(crate) fn parse_rok_mail_id(filename: &str) -> Option<u128> {
+    let rest = filename.strip_prefix("Persistent.Mail.")?;
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    rest.parse::<u128>().ok()
+}
+
+/// Normalize a decoded mail payload to a single root object.
+///
+/// Some mail buffers decode to a singleton array, so we treat that one object
+/// as the root for convenience.
+fn normalize_mail_root(value: &Value) -> Option<&Map<String, Value>> {
+    match value {
+        Value::Object(map) => Some(map),
+        Value::Array(items) => match items.as_slice() {
+            [Value::Object(map)] => Some(map),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Extract the mail type string from a decoded mail payload.
+pub(crate) fn detect_mail_type(value: &Value) -> Option<&str> {
+    let root = normalize_mail_root(value)?;
+    root.get("type").and_then(Value::as_str)
+}
+
+/// Check whether a mail type is supported by the upload pipeline.
+pub(crate) fn is_supported_mail_type(mail_type: &str) -> bool {
+    mail_type.eq_ignore_ascii_case("Battle")
+        || mail_type.eq_ignore_ascii_case("DuelBattle2")
+        || mail_type.eq_ignore_ascii_case("BarCanyonKillBoss")
+}
+
+/// Heuristic header validation to quickly skip non-mail buffers.
+pub(crate) fn has_rok_mail_header(buf: &[u8]) -> bool {
+    if buf.len() < 32 {
+        return false;
+    }
+    if buf[0] != 0xFF {
+        return false;
+    }
+    if buf[9] != 0x05 || buf[10] != 0x04 {
+        return false;
+    }
+    let len = {
+        let start = 11;
+        let end = start + 4;
+        let Some(bytes) = buf.get(start..end) else {
+            return false;
+        };
+        u32::from_le_bytes(bytes.try_into().unwrap_or([0; 4]))
+    };
+    if len != 9 {
+        return false;
+    }
+    let start = 15;
+    let end = start + 9;
+    let Some(bytes) = buf.get(start..end) else {
+        return false;
+    };
+    bytes == b"mailScene"
+}
+
+/// Extract a non-empty file name for API uploads.
+pub(crate) fn file_name_for_upload(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|s| s.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn normalize_mail_root_accepts_object_and_singleton_array() {
+        let object = json!({ "type": "Battle" });
+        assert!(normalize_mail_root(&object).is_some());
+
+        let singleton = json!([{ "type": "Battle" }]);
+        assert!(normalize_mail_root(&singleton).is_some());
+
+        let multiple = json!([{ "type": "Battle" }, { "type": "Battle" }]);
+        assert!(normalize_mail_root(&multiple).is_none());
+    }
+
+    #[test]
+    fn detect_mail_type_pulls_string_type() {
+        let payload = json!({ "type": "DuelBattle2" });
+        assert_eq!(detect_mail_type(&payload), Some("DuelBattle2"));
+
+        let non_string = json!({ "type": 12 });
+        assert_eq!(detect_mail_type(&non_string), None);
+    }
+
+    #[test]
+    fn supported_mail_types_are_case_insensitive() {
+        assert!(is_supported_mail_type("Battle"));
+        assert!(is_supported_mail_type("duelbattle2"));
+        assert!(is_supported_mail_type("BARCANYONKILLBOSS"));
+        assert!(!is_supported_mail_type("Unknown"));
+    }
+
+    #[test]
+    fn parse_rok_mail_id_requires_numeric_suffix() {
+        assert_eq!(parse_rok_mail_id("Persistent.Mail.123"), Some(123));
+        assert_eq!(parse_rok_mail_id("Persistent.Mail.001"), Some(1));
+        assert_eq!(parse_rok_mail_id("Persistent.Mail."), None);
+        assert_eq!(parse_rok_mail_id("Persistent.Mail.123a"), None);
+        assert_eq!(parse_rok_mail_id("Other.Mail.123"), None);
+    }
+
+    #[test]
+    fn file_name_for_upload_rejects_missing_names() {
+        assert_eq!(
+            file_name_for_upload(Path::new("Persistent.Mail.123")),
+            Some("Persistent.Mail.123".to_string())
+        );
+        assert_eq!(file_name_for_upload(Path::new("")), None);
+    }
+
+    #[test]
+    fn has_rok_mail_header_matches_expected_bytes() {
+        let mut buf = vec![0u8; 32];
+        buf[0] = 0xFF;
+        buf[9] = 0x05;
+        buf[10] = 0x04;
+        buf[11..15].copy_from_slice(9u32.to_le_bytes().as_slice());
+        buf[15..24].copy_from_slice(b"mailScene");
+
+        assert!(has_rok_mail_header(&buf));
+
+        let mut wrong = buf.clone();
+        wrong[0] = 0x00;
+        assert!(!has_rok_mail_header(&wrong));
+    }
+}

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/scan.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/scan.rs
@@ -1,0 +1,430 @@
+use anyhow::Context;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher as _};
+use std::{
+    collections::HashSet,
+    fs,
+    io::Read,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+use tauri::AppHandle;
+
+use super::emit_log;
+use super::mail::parse_rok_mail_id;
+use super::state::WatcherState;
+use super::store::{QueuedUpload, file_sig};
+
+#[derive(Debug, Clone)]
+pub(crate) struct DirScan {
+    pub(crate) dir: PathBuf,
+    pub(crate) ids: Vec<u128>,
+    pub(crate) known_ids: HashSet<u128>,
+    pub(crate) cursor: usize,
+    pub(crate) last_refresh: Instant,
+    pub(crate) max_id: Option<u128>,
+    pub(crate) last_full_refresh: Instant,
+}
+
+impl DirScan {
+    pub(crate) fn new(
+        dir: PathBuf,
+        dir_refresh_interval_busy: Duration,
+        full_dir_refresh_interval: Duration,
+    ) -> Self {
+        Self {
+            dir,
+            ids: Vec::new(),
+            known_ids: HashSet::new(),
+            cursor: 0,
+            last_refresh: Instant::now()
+                .checked_sub(dir_refresh_interval_busy)
+                .unwrap_or_else(Instant::now),
+            max_id: None,
+            last_full_refresh: Instant::now()
+                .checked_sub(full_dir_refresh_interval)
+                .unwrap_or_else(Instant::now),
+        }
+    }
+
+    fn is_stale(
+        &self,
+        dir_refresh_interval_idle: Duration,
+        dir_refresh_interval_busy: Duration,
+    ) -> bool {
+        let interval = if self.cursor == 0 {
+            dir_refresh_interval_idle
+        } else {
+            dir_refresh_interval_busy
+        };
+        self.ids.is_empty() || self.last_refresh.elapsed() >= interval
+    }
+
+    fn peek_next_id(&self) -> Option<u128> {
+        if self.cursor == 0 {
+            None
+        } else {
+            Some(self.ids[self.cursor - 1])
+        }
+    }
+
+    fn pop_next_id(&mut self) -> Option<u128> {
+        if self.cursor == 0 {
+            return None;
+        }
+        self.cursor -= 1;
+        Some(self.ids[self.cursor])
+    }
+
+    fn path_for_id(&self, id: u128) -> PathBuf {
+        self.dir.join(format!("Persistent.Mail.{id}"))
+    }
+}
+
+pub(crate) async fn refresh_scans_if_needed(app: &AppHandle, state: &mut WatcherState) -> bool {
+    let config_refresh_interval = state.config.config_refresh_interval;
+    let dir_refresh_interval_idle = state.config.dir_refresh_interval_idle;
+    let dir_refresh_interval_busy = state.config.dir_refresh_interval_busy;
+    let full_dir_refresh_interval = state.config.full_dir_refresh_interval;
+    let full_refresh_validate_recent = state.config.full_refresh_validate_recent;
+    let full_refresh_validate_max_paths = state.config.full_refresh_validate_max_paths;
+    let file_changed_delay_ms = state.config.file_changed_delay_ms;
+    let next_dirs =
+        if !state.dirs.is_empty() && state.dirs_last_read.elapsed() < config_refresh_interval {
+            state.dirs.clone()
+        } else {
+            let dirs = match crate::read_dirs(app) {
+                Ok(d) => d,
+                Err(e) => {
+                    emit_log(app, format!("Failed to read config: {}", e));
+                    return false;
+                }
+            };
+            let next_dirs: Vec<PathBuf> = dirs.into_iter().map(PathBuf::from).collect();
+            state.dirs = next_dirs.clone();
+            state.dirs_last_read = Instant::now();
+            next_dirs
+        };
+    let needs_rebuild = state.scans.len() != next_dirs.len()
+        || state
+            .scans
+            .iter()
+            .zip(next_dirs.iter())
+            .any(|(scan, dir)| &scan.dir != dir);
+
+    if needs_rebuild {
+        state.scans = next_dirs
+            .into_iter()
+            .map(|dir| DirScan::new(dir, dir_refresh_interval_busy, full_dir_refresh_interval))
+            .collect();
+    }
+
+    let mut did_refresh = false;
+    let mut refresh_count = 0u64;
+    let mut full_refreshed_dirs: Vec<PathBuf> = Vec::new();
+    for scan in &mut state.scans {
+        if !scan.is_stale(dir_refresh_interval_idle, dir_refresh_interval_busy) {
+            continue;
+        }
+        #[derive(Debug)]
+        enum RefreshResult {
+            Full(Vec<u128>),
+            New(Vec<u128>),
+        }
+
+        let do_full = scan.last_full_refresh.elapsed() >= full_dir_refresh_interval;
+        let dir = scan.dir.clone();
+        let max_id = scan.max_id;
+        let ids = tauri::async_runtime::spawn_blocking(move || -> anyhow::Result<RefreshResult> {
+            let read_dir = fs::read_dir(&dir)
+                .with_context(|| format!("Failed to read directory {:?}", dir))?;
+
+            let mut ids = Vec::new();
+            for entry in read_dir.flatten() {
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if !file_type.is_file() {
+                    continue;
+                }
+                let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                    continue;
+                };
+                let Some(id) = parse_rok_mail_id(&name) else {
+                    continue;
+                };
+
+                if !do_full
+                    && let Some(max) = max_id
+                    && id <= max
+                {
+                    continue;
+                }
+                ids.push(id);
+            }
+
+            ids.sort_unstable();
+            ids.dedup();
+
+            if do_full || max_id.is_none() {
+                Ok(RefreshResult::Full(ids))
+            } else {
+                Ok(RefreshResult::New(ids))
+            }
+        })
+        .await;
+
+        match ids {
+            Ok(Ok(RefreshResult::Full(ids))) => {
+                if scan.ids.is_empty() {
+                    scan.max_id = ids.last().copied();
+                    scan.known_ids = ids.iter().copied().collect();
+                    scan.ids = ids;
+                    scan.cursor = scan.ids.len();
+                } else {
+                    for id in ids {
+                        if scan.known_ids.insert(id) {
+                            scan.ids.insert(scan.cursor, id);
+                            scan.cursor = scan.cursor.saturating_add(1);
+                            scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
+                        }
+                    }
+                }
+
+                scan.last_refresh = Instant::now();
+                scan.last_full_refresh = Instant::now();
+                did_refresh = true;
+                refresh_count += 1;
+                full_refreshed_dirs.push(scan.dir.clone());
+            }
+            Ok(Ok(RefreshResult::New(ids))) => {
+                for id in ids {
+                    if scan.known_ids.insert(id) {
+                        scan.ids.insert(scan.cursor, id);
+                        scan.cursor = scan.cursor.saturating_add(1);
+                        scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
+                    }
+                }
+                scan.last_refresh = Instant::now();
+                did_refresh = true;
+                refresh_count += 1;
+            }
+            Ok(Err(e)) => {
+                emit_log(
+                    app,
+                    format!("Directory scan failed for {:?}: {}", scan.dir, e),
+                );
+            }
+            Err(e) => {
+                emit_log(
+                    app,
+                    format!("Directory scan task failed for {:?}: {}", scan.dir, e),
+                );
+            }
+        }
+    }
+
+    state.scan_refreshes = state.scan_refreshes.saturating_add(refresh_count);
+
+    if !full_refreshed_dirs.is_empty() {
+        let now_ms = super::now_epoch_ms();
+        for dir in full_refreshed_dirs {
+            let (recent_ids, dir_path) = {
+                let Some(scan) = state.scans.iter().find(|s| s.dir == dir) else {
+                    continue;
+                };
+                let recent_ids = scan
+                    .ids
+                    .iter()
+                    .rev()
+                    .take(full_refresh_validate_recent)
+                    .copied()
+                    .collect::<Vec<_>>();
+                (recent_ids, scan.dir.clone())
+            };
+            let mut queued: usize = 0;
+            for id in recent_ids {
+                if queued >= full_refresh_validate_max_paths {
+                    break;
+                }
+                let path = dir_path.join(format!("Persistent.Mail.{id}"));
+                let key = path.to_string_lossy().to_string();
+                let Some(existing) = state.store.entries.get(&key).cloned() else {
+                    continue;
+                };
+
+                let meta = match fs::metadata(&path) {
+                    Ok(m) => m,
+                    Err(_) => continue,
+                };
+                let sig = match file_sig(&meta) {
+                    Ok(s) => s,
+                    Err(_) => continue,
+                };
+                if sig == existing {
+                    continue;
+                }
+                queued += 1;
+                state.store.entries.insert(key.clone(), sig.clone());
+                state.store_dirty_updates += 1;
+                state.enqueue_upload(QueuedUpload {
+                    path: key,
+                    sig,
+                    attempts: 0,
+                    not_before_ms: Some(now_ms.saturating_add(file_changed_delay_ms)),
+                });
+            }
+        }
+    }
+
+    did_refresh
+}
+
+pub(crate) async fn next_file(app: &AppHandle, state: &mut WatcherState) -> Option<QueuedUpload> {
+    for _ in 0..state.config.scan_budget_per_tick {
+        let (scan_idx, _best_id) = state
+            .scans
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, scan)| scan.peek_next_id().map(|id| (idx, id)))
+            .max_by_key(|(_, id)| *id)?;
+
+        let scan = &mut state.scans[scan_idx];
+        let id = scan.pop_next_id()?;
+        let path = scan.path_for_id(id);
+        let key = path.to_string_lossy().to_string();
+
+        if state.store.entries.contains_key(&key) {
+            continue;
+        }
+
+        let meta = match fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let sig = match file_sig(&meta) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let header = tauri::async_runtime::spawn_blocking({
+            let path = path.clone();
+            move || has_rok_fileheader_from_file(&path)
+        })
+        .await;
+
+        match header {
+            Ok(Ok(true)) => {
+                state.store.entries.insert(key, sig.clone());
+                state.store_dirty_updates += 1;
+                state.maybe_flush_store(app);
+                return Some(QueuedUpload {
+                    path: path.to_string_lossy().to_string(),
+                    sig,
+                    attempts: 0,
+                    not_before_ms: None,
+                });
+            }
+            Ok(Ok(false)) => {
+                state.store.entries.insert(key, sig);
+                state.store_dirty_updates += 1;
+                state.maybe_flush_store(app);
+            }
+            Ok(Err(e)) => {
+                emit_log(app, format!("Header check failed for {:?}: {}", path, e));
+            }
+            Err(e) => {
+                emit_log(
+                    app,
+                    format!("Header check task failed for {:?}: {}", path, e),
+                );
+            }
+        }
+    }
+
+    state.maybe_flush_store(app);
+    None
+}
+
+pub(crate) fn sync_fs_watches(
+    app: &AppHandle,
+    watcher: Option<&mut RecommendedWatcher>,
+    watched_dirs: &mut HashSet<PathBuf>,
+    desired_dirs: &[PathBuf],
+) {
+    let Some(watcher) = watcher else {
+        return;
+    };
+
+    let desired: HashSet<PathBuf> = desired_dirs.iter().cloned().collect();
+
+    for dir in watched_dirs
+        .difference(&desired)
+        .cloned()
+        .collect::<Vec<_>>()
+    {
+        if let Err(e) = watcher.unwatch(&dir) {
+            emit_log(app, format!("Failed to unwatch {:?}: {}", dir, e));
+        }
+        watched_dirs.remove(&dir);
+    }
+
+    for dir in desired
+        .difference(watched_dirs)
+        .cloned()
+        .collect::<Vec<_>>()
+    {
+        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            emit_log(app, format!("Failed to watch {:?}: {}", dir, e));
+            continue;
+        }
+        watched_dirs.insert(dir);
+    }
+}
+
+pub(crate) fn apply_fs_event(state: &mut WatcherState, path: PathBuf, now_ms: u128) {
+    let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+        return;
+    };
+    let Some(id) = parse_rok_mail_id(name) else {
+        return;
+    };
+
+    let meta = match fs::metadata(&path) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    let sig = match file_sig(&meta) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let key = path.to_string_lossy().to_string();
+    if let Some(existing) = state.store.entries.get(&key)
+        && *existing == sig
+    {
+        return;
+    }
+    state.store.entries.insert(key.clone(), sig.clone());
+    state.store_dirty_updates += 1;
+    state.enqueue_upload(QueuedUpload {
+        path: key,
+        sig,
+        attempts: 0,
+        not_before_ms: Some(now_ms.saturating_add(state.config.file_retry_delay_ms)),
+    });
+
+    if let Some(parent) = path.parent()
+        && let Some(scan) = state.scans.iter_mut().find(|s| s.dir == parent)
+    {
+        let _ = scan.known_ids.insert(id);
+        scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
+    }
+}
+
+fn has_rok_fileheader_from_file(path: &PathBuf) -> anyhow::Result<bool> {
+    let mut f = fs::File::open(path)
+        .with_context(|| format!("Failed to open file for header check: {:?}", path))?;
+    let mut buf = [0u8; 32];
+    let _ = f.read(&mut buf)?;
+    Ok(super::mail::has_rok_mail_header(&buf))
+}

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/state.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/state.rs
@@ -1,0 +1,281 @@
+use std::{
+    collections::{HashSet, VecDeque},
+    path::PathBuf,
+    time::Instant,
+};
+
+use tauri::AppHandle;
+
+use super::config::WatcherConfig;
+use super::emit_log;
+use super::store::{
+    ProcessedStore, QueuedUpload, UploadQueueStore, write_processed, write_upload_queue,
+};
+
+pub(crate) struct WatcherState {
+    pub(crate) config: WatcherConfig,
+    pub(crate) scans: Vec<super::scan::DirScan>,
+    pub(crate) dirs: Vec<PathBuf>,
+    pub(crate) dirs_last_read: Instant,
+    pub(crate) store: ProcessedStore,
+    pub(crate) store_dirty_updates: usize,
+    pub(crate) store_last_flush: Instant,
+    pub(crate) upload_queue: VecDeque<QueuedUpload>,
+    pub(crate) upload_queued_paths: HashSet<String>,
+    pub(crate) upload_queue_dirty_updates: usize,
+    pub(crate) upload_queue_last_flush: Instant,
+    pub(crate) scan_refreshes: u64,
+    pub(crate) store_flushes: u64,
+    pub(crate) upload_queue_flushes: u64,
+    pub(crate) hot_paths: VecDeque<String>,
+    pub(crate) hot_set: HashSet<String>,
+    pub(crate) hot_last_scan: Instant,
+}
+
+impl WatcherState {
+    pub(crate) fn new(
+        config: WatcherConfig,
+        store: ProcessedStore,
+        upload_queue_store: UploadQueueStore,
+    ) -> Self {
+        let mut upload_queue = VecDeque::new();
+        let mut upload_queued_paths = HashSet::new();
+        for item in upload_queue_store.items {
+            if upload_queued_paths.insert(item.path.clone()) {
+                upload_queue.push_back(item);
+            }
+        }
+
+        let refresh_interval = config.config_refresh_interval;
+        Self {
+            config,
+            scans: Vec::new(),
+            dirs: Vec::new(),
+            dirs_last_read: Instant::now()
+                .checked_sub(refresh_interval)
+                .unwrap_or_else(Instant::now),
+            store,
+            store_dirty_updates: 0,
+            store_last_flush: Instant::now(),
+            upload_queue,
+            upload_queued_paths,
+            upload_queue_dirty_updates: 0,
+            upload_queue_last_flush: Instant::now(),
+            scan_refreshes: 0,
+            store_flushes: 0,
+            upload_queue_flushes: 0,
+            hot_paths: VecDeque::new(),
+            hot_set: HashSet::new(),
+            hot_last_scan: Instant::now(),
+        }
+    }
+
+    pub(crate) fn maybe_flush_store(&mut self, app: &AppHandle) {
+        if self.store_dirty_updates == 0 {
+            return;
+        }
+        if self.store_dirty_updates < self.config.store_flush_every_updates
+            && self.store_last_flush.elapsed() < self.config.store_flush_interval
+        {
+            return;
+        }
+        if let Err(e) = write_processed(app, &self.config, &self.store) {
+            emit_log(app, format!("Failed to flush processed store: {}", e));
+            return;
+        }
+        self.store_dirty_updates = 0;
+        self.store_last_flush = Instant::now();
+        self.store_flushes += 1;
+    }
+
+    pub(crate) fn maybe_flush_upload_queue(&mut self, app: &AppHandle) {
+        if self.upload_queue_dirty_updates == 0 {
+            return;
+        }
+        if self.upload_queue_dirty_updates < self.config.queue_flush_every_updates
+            && self.upload_queue_last_flush.elapsed() < self.config.queue_flush_interval
+        {
+            return;
+        }
+        let store = UploadQueueStore {
+            version: 1,
+            items: self.upload_queue.iter().cloned().collect(),
+        };
+        if let Err(e) = write_upload_queue(app, &self.config, &store) {
+            emit_log(app, format!("Failed to flush upload queue: {}", e));
+            return;
+        }
+        self.upload_queue_dirty_updates = 0;
+        self.upload_queue_last_flush = Instant::now();
+        self.upload_queue_flushes += 1;
+    }
+
+    pub(crate) fn enqueue_upload(&mut self, item: QueuedUpload) {
+        let path = item.path.clone();
+        if !self.upload_queued_paths.insert(item.path.clone()) {
+            return;
+        }
+        self.upload_queue.push_back(item);
+        self.upload_queue_dirty_updates += 1;
+        self.track_hot_path(path);
+    }
+
+    pub(crate) fn pop_ready_upload(&mut self, now_ms: u128) -> Option<QueuedUpload> {
+        let len = self.upload_queue.len();
+        for _ in 0..len {
+            let item = self.upload_queue.pop_front()?;
+            if item.not_before_ms.is_some_and(|t| t > now_ms) {
+                self.upload_queue.push_back(item);
+                continue;
+            }
+            self.upload_queued_paths.remove(&item.path);
+            self.upload_queue_dirty_updates += 1;
+            return Some(item);
+        }
+        None
+    }
+
+    pub(crate) fn requeue_upload(&mut self, item: QueuedUpload) {
+        if self.upload_queued_paths.insert(item.path.clone()) {
+            self.upload_queue.push_back(item);
+            self.upload_queue_dirty_updates += 1;
+        }
+    }
+
+    pub(crate) fn maybe_rescan_hot(&mut self, now_ms: u128) {
+        if self.hot_last_scan.elapsed() < self.config.hot_rescan_interval {
+            return;
+        }
+        self.hot_last_scan = Instant::now();
+
+        for _ in 0..self.config.hot_rescan_budget {
+            let Some(path_str) = self.hot_paths.pop_front() else {
+                break;
+            };
+
+            let path = PathBuf::from(&path_str);
+            let Some(existing) = self.store.entries.get(&path_str).cloned() else {
+                self.hot_paths.push_back(path_str);
+                continue;
+            };
+
+            let meta = match std::fs::metadata(&path) {
+                Ok(m) => m,
+                Err(_) => {
+                    self.hot_paths.push_back(path_str);
+                    continue;
+                }
+            };
+            let sig = match super::store::file_sig(&meta) {
+                Ok(s) => s,
+                Err(_) => {
+                    self.hot_paths.push_back(path_str);
+                    continue;
+                }
+            };
+
+            if sig != existing {
+                self.store.entries.insert(path_str.clone(), sig.clone());
+                self.store_dirty_updates += 1;
+                self.enqueue_upload(QueuedUpload {
+                    path: path_str.clone(),
+                    sig,
+                    attempts: 0,
+                    not_before_ms: Some(now_ms.saturating_add(self.config.file_changed_delay_ms)),
+                });
+            }
+
+            self.hot_paths.push_back(path_str);
+        }
+    }
+
+    fn track_hot_path(&mut self, path: String) {
+        if self.hot_set.contains(&path) {
+            return;
+        }
+        if self.hot_paths.len() >= self.config.hot_tracked_limit
+            && let Some(old) = self.hot_paths.pop_front()
+        {
+            self.hot_set.remove(&old);
+        }
+        self.hot_set.insert(path.clone());
+        self.hot_paths.push_back(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::store::FileSig;
+    use super::*;
+
+    fn make_sig() -> FileSig {
+        FileSig {
+            size: 1,
+            modified: 2,
+        }
+    }
+
+    fn make_item(path: &str, not_before_ms: Option<u128>) -> QueuedUpload {
+        QueuedUpload {
+            path: path.to_string(),
+            sig: make_sig(),
+            attempts: 0,
+            not_before_ms,
+        }
+    }
+
+    #[test]
+    fn enqueue_upload_dedupes_paths() {
+        let mut state = WatcherState::new(
+            WatcherConfig::default(),
+            ProcessedStore::default(),
+            UploadQueueStore::default(),
+        );
+        let item = make_item("a", None);
+
+        state.enqueue_upload(item.clone());
+        state.enqueue_upload(item);
+
+        assert_eq!(state.upload_queue.len(), 1);
+        assert_eq!(state.upload_queued_paths.len(), 1);
+        assert_eq!(state.upload_queue_dirty_updates, 1);
+    }
+
+    #[test]
+    fn pop_ready_upload_respects_not_before() {
+        let mut state = WatcherState::new(
+            WatcherConfig::default(),
+            ProcessedStore::default(),
+            UploadQueueStore::default(),
+        );
+        let item = make_item("a", Some(150));
+
+        state.enqueue_upload(item);
+        assert!(state.pop_ready_upload(100).is_none());
+        assert_eq!(state.upload_queue.len(), 1);
+        assert!(state.upload_queued_paths.contains("a"));
+
+        let ready = state.pop_ready_upload(200).expect("expected ready upload");
+        assert_eq!(ready.path, "a");
+        assert!(state.upload_queue.is_empty());
+        assert!(!state.upload_queued_paths.contains("a"));
+    }
+
+    #[test]
+    fn requeue_upload_adds_only_once() {
+        let mut state = WatcherState::new(
+            WatcherConfig::default(),
+            ProcessedStore::default(),
+            UploadQueueStore::default(),
+        );
+        let item = make_item("a", None);
+
+        state.enqueue_upload(item.clone());
+        let popped = state.pop_ready_upload(0).expect("expected ready upload");
+        state.requeue_upload(popped);
+        state.requeue_upload(item);
+
+        assert_eq!(state.upload_queue.len(), 1);
+        assert_eq!(state.upload_queued_paths.len(), 1);
+    }
+}

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/store.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/store.rs
@@ -1,0 +1,157 @@
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fs, io,
+    io::Write,
+    path::{Path, PathBuf},
+    time::{Duration, SystemTime},
+};
+use tauri::{AppHandle, Manager};
+
+use super::config::WatcherConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct ProcessedStore {
+    pub(crate) entries: HashMap<String, FileSig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct UploadQueueStore {
+    pub(crate) version: u32,
+    pub(crate) items: Vec<QueuedUpload>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct QueuedUpload {
+    pub(crate) path: String,
+    pub(crate) sig: FileSig,
+    pub(crate) attempts: u32,
+    pub(crate) not_before_ms: Option<u128>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FileSig {
+    pub(crate) size: u64,
+    pub(crate) modified: u128,
+}
+
+pub(crate) fn delete_processed(app: &AppHandle, config: &WatcherConfig) -> anyhow::Result<()> {
+    let path = processed_file(app, config)?;
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("Failed removing {:?}", path))?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn delete_upload_queue(app: &AppHandle, config: &WatcherConfig) -> anyhow::Result<()> {
+    let path = upload_queue_file(app, config)?;
+    if path.exists() {
+        fs::remove_file(&path).with_context(|| format!("Failed removing {:?}", path))?;
+    }
+    Ok(())
+}
+
+pub(crate) fn file_sig(meta: &fs::Metadata) -> anyhow::Result<FileSig> {
+    let size = meta.len();
+    let modified_time = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let modified = modified_time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis();
+    Ok(FileSig { size, modified })
+}
+
+pub(crate) fn read_processed(
+    app: &AppHandle,
+    config: &WatcherConfig,
+) -> anyhow::Result<ProcessedStore> {
+    let path = processed_file(app, config)?;
+    if !path.exists() {
+        return Ok(ProcessedStore::default());
+    }
+    let data = fs::read(&path).with_context(|| format!("Failed reading {:?}", path))?;
+    if data.is_empty() {
+        return Ok(ProcessedStore::default());
+    }
+    let store: ProcessedStore =
+        serde_json::from_slice(&data).with_context(|| format!("Invalid JSON in {:?}", path))?;
+    Ok(store)
+}
+
+pub(crate) fn write_processed(
+    app: &AppHandle,
+    config: &WatcherConfig,
+    store: &ProcessedStore,
+) -> anyhow::Result<()> {
+    let path = processed_file(app, config)?;
+    let json = serde_json::to_vec(store).context("Failed to serialize processed store to JSON")?;
+    atomic_write(&path, &json).with_context(|| format!("Failed writing {:?}", path))?;
+    Ok(())
+}
+
+pub(crate) fn read_upload_queue(
+    app: &AppHandle,
+    config: &WatcherConfig,
+) -> anyhow::Result<UploadQueueStore> {
+    let path = upload_queue_file(app, config)?;
+    if !path.exists() {
+        return Ok(UploadQueueStore::default());
+    }
+    let data = fs::read(&path).with_context(|| format!("Failed reading {:?}", path))?;
+    if data.is_empty() {
+        return Ok(UploadQueueStore::default());
+    }
+    let store: UploadQueueStore =
+        serde_json::from_slice(&data).with_context(|| format!("Invalid JSON in {:?}", path))?;
+    Ok(store)
+}
+
+pub(crate) fn write_upload_queue(
+    app: &AppHandle,
+    config: &WatcherConfig,
+    store: &UploadQueueStore,
+) -> anyhow::Result<()> {
+    let path = upload_queue_file(app, config)?;
+    let json = serde_json::to_vec(store).context("Failed to serialize upload queue to JSON")?;
+    atomic_write(&path, &json).with_context(|| format!("Failed writing {:?}", path))?;
+    Ok(())
+}
+
+fn processed_file(app: &AppHandle, config: &WatcherConfig) -> anyhow::Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .context("Could not resolve app config directory")?;
+    fs::create_dir_all(&dir).context("Failed to create app config directory")?;
+    Ok(dir.join(config.processed_file_name))
+}
+
+fn upload_queue_file(app: &AppHandle, config: &WatcherConfig) -> anyhow::Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .context("Could not resolve app config directory")?;
+    fs::create_dir_all(&dir).context("Failed to create app config directory")?;
+    Ok(dir.join(config.upload_queue_file_name))
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    let tmp_path = path.with_extension("tmp");
+    let mut file = fs::File::create(&tmp_path)
+        .with_context(|| format!("Failed creating temp file {:?}", tmp_path))?;
+    file.write_all(bytes)
+        .with_context(|| format!("Failed writing temp file {:?}", tmp_path))?;
+
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        // Best-effort fallback for Windows rename semantics.
+        if e.kind() == io::ErrorKind::AlreadyExists {
+            let _ = fs::remove_file(path);
+            fs::rename(&tmp_path, path).with_context(|| format!("Failed replacing {:?}", path))?;
+        } else {
+            return Err(e).with_context(|| format!("Failed renaming {:?} -> {:?}", tmp_path, path));
+        }
+    }
+    Ok(())
+}

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/upload.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/upload.rs
@@ -1,0 +1,142 @@
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UploadStatus {
+    Stored,
+    Updated,
+    Skipped,
+    Unknown,
+}
+
+impl UploadStatus {
+    pub(crate) fn log_message(self, file_name: &str) -> String {
+        match self {
+            UploadStatus::Stored => format!("Stored new mail {}", file_name),
+            UploadStatus::Updated => {
+                format!("Updated mail {} (differs from existing)", file_name)
+            }
+            UploadStatus::Skipped => format!("Skipped mail {} (matches existing)", file_name),
+            UploadStatus::Unknown => format!("Uploaded {}", file_name),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UploadApiError {
+    pub(crate) status: Option<reqwest::StatusCode>,
+    pub(crate) retry_after: Option<std::time::Duration>,
+    pub(crate) message: String,
+}
+
+#[derive(Deserialize)]
+struct UploadResponse {
+    status: Option<String>,
+}
+
+pub(crate) async fn post_file_to_api(
+    client: &reqwest::Client,
+    api_url: &str,
+    file_name: &str,
+    bytes: Vec<u8>,
+) -> Result<UploadStatus, UploadApiError> {
+    let part = Part::bytes(bytes)
+        .file_name(file_name.to_string())
+        .mime_str("application/octet-stream")
+        .map_err(|e| UploadApiError {
+            status: None,
+            retry_after: None,
+            message: format!("failed to build upload payload: {e}"),
+        })?;
+    let form = Form::new().part("file", part);
+
+    let resp = client
+        .post(api_url)
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| UploadApiError {
+            status: None,
+            retry_after: None,
+            message: format!("failed to send mail to API: {e}"),
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let retry_after = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map(std::time::Duration::from_secs);
+        let text = resp.text().await.unwrap_or_default();
+        return Err(UploadApiError {
+            status: Some(status),
+            retry_after,
+            message: format!("API rejected upload: {} {}", status, text),
+        });
+    }
+
+    let status = resp
+        .json::<UploadResponse>()
+        .await
+        .ok()
+        .and_then(|resp| resp.status)
+        .as_deref()
+        .map(parse_upload_status)
+        .unwrap_or(UploadStatus::Unknown);
+
+    Ok(status)
+}
+
+pub(crate) fn upload_backoff(attempts: u32) -> Duration {
+    let seconds = 2u64.saturating_pow(attempts.min(10));
+    Duration::from_secs(seconds.clamp(2, 300))
+}
+
+pub(crate) fn is_retryable_status(status: Option<reqwest::StatusCode>) -> bool {
+    status.is_none_or(|s| s == reqwest::StatusCode::TOO_MANY_REQUESTS || s.is_server_error())
+}
+
+fn parse_upload_status(status: &str) -> UploadStatus {
+    match status.to_ascii_lowercase().as_str() {
+        "stored" => UploadStatus::Stored,
+        "updated" => UploadStatus::Updated,
+        "skipped" => UploadStatus::Skipped,
+        _ => UploadStatus::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_upload_status_is_case_insensitive() {
+        assert_eq!(parse_upload_status("stored"), UploadStatus::Stored);
+        assert_eq!(parse_upload_status("Updated"), UploadStatus::Updated);
+        assert_eq!(parse_upload_status("SKIPPED"), UploadStatus::Skipped);
+        assert_eq!(parse_upload_status("unknown"), UploadStatus::Unknown);
+    }
+
+    #[test]
+    fn upload_backoff_clamps_to_bounds() {
+        assert_eq!(upload_backoff(0), Duration::from_secs(2));
+        assert_eq!(upload_backoff(2), Duration::from_secs(4));
+        assert_eq!(upload_backoff(10), Duration::from_secs(300));
+        assert_eq!(upload_backoff(20), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn retryable_statuses_include_rate_limit_and_server_errors() {
+        assert!(is_retryable_status(None));
+        assert!(is_retryable_status(Some(
+            reqwest::StatusCode::TOO_MANY_REQUESTS
+        )));
+        assert!(is_retryable_status(Some(
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        )));
+        assert!(!is_retryable_status(Some(reqwest::StatusCode::BAD_REQUEST)));
+    }
+}

--- a/crates/rokbattles-tauri/src/App.tsx
+++ b/crates/rokbattles-tauri/src/App.tsx
@@ -56,11 +56,7 @@ function App() {
   const handleAdd = async () => {
     try {
       setIsAdding(true);
-      try {
-        await invoke("pause_watcher");
-      } catch (e) {
-        console.error("Failed to pause watcher", e);
-      }
+      await invoke("pause_watcher");
       const selection = await open({
         multiple: true,
         directory: true,
@@ -74,12 +70,8 @@ function App() {
     } catch (e) {
       console.error("Failed to add dirs", e);
     } finally {
-      try {
-        await invoke("resume_watcher");
-      } catch (e) {
-        console.error("Failed to resume watcher", e);
-      }
       setIsAdding(false);
+      await invoke("resume_watcher");
     }
   };
 

--- a/crates/rokbattles-tauri/src/App.tsx
+++ b/crates/rokbattles-tauri/src/App.tsx
@@ -56,6 +56,11 @@ function App() {
   const handleAdd = async () => {
     try {
       setIsAdding(true);
+      try {
+        await invoke("pause_watcher");
+      } catch (e) {
+        console.error("Failed to pause watcher", e);
+      }
       const selection = await open({
         multiple: true,
         directory: true,
@@ -69,6 +74,11 @@ function App() {
     } catch (e) {
       console.error("Failed to add dirs", e);
     } finally {
+      try {
+        await invoke("resume_watcher");
+      } catch (e) {
+        console.error("Failed to resume watcher", e);
+      }
       setIsAdding(false);
     }
   };
@@ -110,7 +120,7 @@ function App() {
             <button
               type="button"
               onClick={handleAdd}
-              disabled={isAdding}
+              disabled={isAdding || isReprocessing}
               className="inline-flex items-center gap-2 rounded-md bg-zinc-700 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-600 disabled:opacity-60"
             >
               {isAdding ? "Adding..." : "Add directory"}


### PR DESCRIPTION
- Break the watcher up into multiple files
- Change ingress url over to v1 route
- Remove redundant code
- Fix issue with app stalling when adding new directory