### PR TITLE
fix: stale items in upload queue/hot path & ensure fs events filtering

### DIFF
--- a/crates/rokbattles-tauri/src-tauri/src/watcher/mod.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/mod.rs
@@ -158,9 +158,8 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
 
             state.maybe_flush_store(&app);
             state.maybe_flush_upload_queue(&app);
-            state.maybe_rescan_hot(now_ms);
-
             let _ = refresh_scans_if_needed(&app, &mut state).await;
+            state.maybe_rescan_hot(now_ms);
             sync_fs_watches(&app, fs_watcher.as_mut(), &mut fs_watched_dirs, &state.dirs);
 
             for _ in 0..state.config.fs_event_budget {

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/scan.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/scan.rs
@@ -118,6 +118,18 @@ pub(crate) async fn refresh_scans_if_needed(app: &AppHandle, state: &mut Watcher
             .collect();
     }
 
+    let active_dirs = state.dirs.clone();
+    let pruned = state.prune_removed_dirs_state(&active_dirs);
+    if pruned > 0 {
+        emit_log(
+            app,
+            format!(
+                "Dropped {} stale watcher item(s) for directories that are no longer watched.",
+                pruned
+            ),
+        );
+    }
+
     let mut did_refresh = false;
     let mut refresh_count = 0u64;
     let mut full_refreshed_dirs: Vec<PathBuf> = Vec::new();
@@ -382,6 +394,10 @@ pub(crate) fn sync_fs_watches(
 }
 
 pub(crate) fn apply_fs_event(state: &mut WatcherState, path: PathBuf, now_ms: u128) {
+    if !state.dirs.iter().any(|dir| path.starts_with(dir)) {
+        return;
+    }
+
     let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
         return;
     };

--- a/crates/rokbattles-tauri/src-tauri/src/watcher/state.rs
+++ b/crates/rokbattles-tauri/src-tauri/src/watcher/state.rs
@@ -191,6 +191,37 @@ impl WatcherState {
         }
     }
 
+    pub(crate) fn prune_removed_dirs_state(&mut self, active_dirs: &[PathBuf]) -> usize {
+        let mut removed = 0usize;
+
+        let old_queue_len = self.upload_queue.len();
+        self.upload_queue
+            .retain(|item| path_belongs_to_any_active_dir(&item.path, active_dirs));
+        let queue_removed = old_queue_len.saturating_sub(self.upload_queue.len());
+        if queue_removed > 0 {
+            removed = removed.saturating_add(queue_removed);
+            self.upload_queued_paths = self
+                .upload_queue
+                .iter()
+                .map(|item| item.path.clone())
+                .collect::<HashSet<_>>();
+            self.upload_queue_dirty_updates = self
+                .upload_queue_dirty_updates
+                .saturating_add(queue_removed);
+        }
+
+        let old_hot_len = self.hot_paths.len();
+        self.hot_paths
+            .retain(|path| path_belongs_to_any_active_dir(path, active_dirs));
+        let hot_removed = old_hot_len.saturating_sub(self.hot_paths.len());
+        if hot_removed > 0 {
+            removed = removed.saturating_add(hot_removed);
+            self.hot_set = self.hot_paths.iter().cloned().collect::<HashSet<_>>();
+        }
+
+        removed
+    }
+
     fn track_hot_path(&mut self, path: String) {
         if self.hot_set.contains(&path) {
             return;
@@ -223,6 +254,11 @@ impl WatcherState {
             }
         }
     }
+}
+
+fn path_belongs_to_any_active_dir(path: &str, active_dirs: &[PathBuf]) -> bool {
+    let path = PathBuf::from(path);
+    active_dirs.iter().any(|dir| path.starts_with(dir))
 }
 
 #[cfg(test)]
@@ -299,5 +335,59 @@ mod tests {
 
         assert_eq!(state.upload_queue.len(), 1);
         assert_eq!(state.upload_queued_paths.len(), 1);
+    }
+
+    #[test]
+    fn prune_removed_dirs_state_drops_queue_and_hot_paths() {
+        let mut state = WatcherState::new(
+            WatcherConfig::default(),
+            ProcessedStore::default(),
+            UploadQueueStore::default(),
+        );
+        let active_dir = PathBuf::from("/active/mailcache");
+        state.enqueue_upload(make_item("/active/mailcache/Persistent.Mail.1", None));
+        state.enqueue_upload(make_item("/removed/mailcache/Persistent.Mail.2", None));
+        state
+            .hot_paths
+            .push_back("/active/mailcache/Persistent.Mail.1".to_string());
+        state
+            .hot_paths
+            .push_back("/removed/mailcache/Persistent.Mail.2".to_string());
+        state
+            .hot_set
+            .insert("/active/mailcache/Persistent.Mail.1".to_string());
+        state
+            .hot_set
+            .insert("/removed/mailcache/Persistent.Mail.2".to_string());
+
+        let removed = state.prune_removed_dirs_state(&[active_dir]);
+        assert!(removed >= 2);
+        assert_eq!(state.upload_queue.len(), 1);
+        assert!(
+            state
+                .hot_paths
+                .iter()
+                .all(|path| path == "/active/mailcache/Persistent.Mail.1")
+        );
+        assert!(
+            state
+                .upload_queued_paths
+                .contains("/active/mailcache/Persistent.Mail.1")
+        );
+        assert!(
+            state
+                .hot_set
+                .contains("/active/mailcache/Persistent.Mail.1")
+        );
+        assert!(
+            !state
+                .upload_queued_paths
+                .contains("/removed/mailcache/Persistent.Mail.2")
+        );
+        assert!(
+            !state
+                .hot_set
+                .contains("/removed/mailcache/Persistent.Mail.2")
+        );
     }
 }


### PR DESCRIPTION
- Prune stale queue/hot path entries when we refresh the watched directories
- Ignore FS events not currently being watched
- Add new tests