### PR TITLE
refactor: change end date of loot/resources to current date; table widths

### DIFF
--- a/site/src/components/account-loot/loot-breakdown-table.tsx
+++ b/site/src/components/account-loot/loot-breakdown-table.tsx
@@ -24,8 +24,8 @@ export function LootBreakdownTable({ rows }: LootBreakdownTableProps) {
       <TableHead>
         <TableRow>
           <TableHeader>{t("Name")}</TableHeader>
-          <TableHeader>{t("Amount")}</TableHeader>
-          <TableHeader>{t("Drops")}</TableHeader>
+          <TableHeader className="lg:w-36">{t("Amount")}</TableHeader>
+          <TableHeader className="lg:w-36">{t("Drops")}</TableHeader>
         </TableRow>
       </TableHead>
       <TableBody>

--- a/site/src/components/account-resources/resources-breakdown-table.tsx
+++ b/site/src/components/account-resources/resources-breakdown-table.tsx
@@ -24,9 +24,9 @@ export function ResourcesBreakdownTable({ rows }: ResourcesBreakdownTableProps) 
       <TableHead>
         <TableRow>
           <TableHeader>{t("Type")}</TableHeader>
-          <TableHeader>{t("Gain")}</TableHeader>
-          <TableHeader>{t("Bonus")}</TableHeader>
-          <TableHeader>{t("Total")}</TableHeader>
+          <TableHeader className="lg:w-48">{t("Gain")}</TableHeader>
+          <TableHeader className="lg:w-48">{t("Bonus")}</TableHeader>
+          <TableHeader className="lg:w-48">{t("Total")}</TableHeader>
         </TableRow>
       </TableHead>
       <TableBody>

--- a/site/src/hooks/use-loot.ts
+++ b/site/src/hooks/use-loot.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { LootQueryResult } from "@/lib/types/loot";
+import { toDateInput, todayUtcStartMillis } from "@/lib/loot/date";
 
 type LootOptions = {
   governorId: number | null | undefined;
@@ -24,7 +25,7 @@ function buildRangeParams(options: { startParam?: string | null; endParam?: stri
   const currentYear = new Date().getUTCFullYear();
   return new URLSearchParams({
     start: `${currentYear}-01-01`,
-    end: `${currentYear}-12-31`,
+    end: toDateInput(todayUtcStartMillis()),
   });
 }
 

--- a/site/src/hooks/use-loot.ts
+++ b/site/src/hooks/use-loot.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import type { LootQueryResult } from "@/lib/types/loot";
 import { toDateInput, todayUtcStartMillis } from "@/lib/loot/date";
+import type { LootQueryResult } from "@/lib/types/loot";
 
 type LootOptions = {
   governorId: number | null | undefined;

--- a/site/src/hooks/use-resources.ts
+++ b/site/src/hooks/use-resources.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { toDateInput, todayUtcStartMillis } from "@/lib/loot/date";
 import type { ResourcesQueryResult } from "@/lib/types/resources";
 
 type ResourcesOptions = {
@@ -24,7 +25,7 @@ function buildRangeParams(options: { startParam?: string | null; endParam?: stri
   const currentYear = new Date().getUTCFullYear();
   return new URLSearchParams({
     start: `${currentYear}-01-01`,
-    end: `${currentYear}-12-31`,
+    end: toDateInput(todayUtcStartMillis()),
   });
 }
 


### PR DESCRIPTION
- Update end date to current date in loot/resources
- Fix table width changing on each sub tab by using set widths on desktop