### PR TITLE
refactor: optimize mongo queries/indexes; reduce report aggregation allocations

### DIFF
--- a/crates/rokbattles-api/src/db/reports_store.rs
+++ b/crates/rokbattles-api/src/db/reports_store.rs
@@ -43,7 +43,13 @@ impl ReportsStore {
                 .keys(doc! { "metadata.mail_time": -1 })
                 .build(),
             IndexModel::builder()
+                .keys(doc! { "metadata.mail_receiver": 1, "metadata.mail_time": -1 })
+                .build(),
+            IndexModel::builder()
                 .keys(doc! { "sender.player_id": 1, "metadata.mail_time": -1 })
+                .build(),
+            IndexModel::builder()
+                .keys(doc! { "sender.player_id": 1, "sender.commanders.primary.id": 1, "metadata.mail_time": -1 })
                 .build(),
             IndexModel::builder()
                 .keys(doc! { "opponents.player_id": 1, "metadata.mail_time": -1 })
@@ -85,9 +91,6 @@ impl ReportsStore {
         }
 
         let duel_models = vec![
-            IndexModel::builder()
-                .keys(doc! { "metadata.mail_time": -1 })
-                .build(),
             IndexModel::builder()
                 .keys(doc! { "sender.duel.team_id": 1, "metadata.mail_time": 1 })
                 .build(),
@@ -169,6 +172,12 @@ impl ReportsStore {
                 .build(),
             IndexModel::builder()
                 .keys(doc! { "discordId": 1, "governorId": 1 })
+                .build(),
+            IndexModel::builder()
+                .keys(doc! { "discordId": 1, "createdAt": -1 })
+                .build(),
+            IndexModel::builder()
+                .keys(doc! { "discordId": 1, "default": -1, "createdAt": -1 })
                 .build(),
             IndexModel::builder()
                 .keys(doc! { "discordId": 1, "default": 1 })

--- a/crates/rokbattles-api/src/routes/auth/mod.rs
+++ b/crates/rokbattles-api/src/routes/auth/mod.rs
@@ -190,6 +190,7 @@ async fn load_claimed_governors(
     discord_id: &str,
 ) -> Result<Vec<ClaimedGovernor>, ApiError> {
     let options = FindOptions::builder()
+        .sort(doc! { "default": -1, "createdAt": -1 })
         .projection(doc! {
             "_id": 0,
             "governorId": 1,
@@ -207,36 +208,22 @@ async fn load_claimed_governors(
         .await
         .map_err(|error| ApiError::internal(error.to_string()))?;
 
-    let mut sortable_claims = Vec::new();
+    let mut claims = Vec::new();
     while let Some(next) = cursor.next().await {
         let document = next.map_err(|error| ApiError::internal(error.to_string()))?;
         let Some(governor_id) = document.get("governorId").and_then(bson_to_i64_exact) else {
             continue;
         };
 
-        sortable_claims.push(SortableClaim {
-            created_at_millis: claim_created_at_millis(&document),
-            claim: ClaimedGovernor {
-                governor_id,
-                governor_name: optional_string_field(&document, "governorName"),
-                governor_avatar: optional_string_field(&document, "governorAvatar"),
-                default: document.get_bool("default").unwrap_or(false),
-            },
+        claims.push(ClaimedGovernor {
+            governor_id,
+            governor_name: optional_string_field(&document, "governorName"),
+            governor_avatar: optional_string_field(&document, "governorAvatar"),
+            default: document.get_bool("default").unwrap_or(false),
         });
     }
 
-    sortable_claims.sort_by(|left, right| {
-        right
-            .claim
-            .default
-            .cmp(&left.claim.default)
-            .then_with(|| right.created_at_millis.cmp(&left.created_at_millis))
-    });
-
-    Ok(sortable_claims
-        .into_iter()
-        .map(|entry| entry.claim)
-        .collect())
+    Ok(claims)
 }
 
 fn optional_string_field(document: &Document, key: &str) -> Option<String> {
@@ -244,14 +231,6 @@ fn optional_string_field(document: &Document, key: &str) -> Option<String> {
         .get(key)
         .and_then(Bson::as_str)
         .map(ToString::to_string)
-}
-
-fn claim_created_at_millis(claim: &Document) -> i64 {
-    match claim.get("createdAt") {
-        Some(Bson::DateTime(value)) => value.timestamp_millis(),
-        Some(value) => bson_to_i64_exact(value).unwrap_or(0),
-        None => 0,
-    }
 }
 
 async fn exchange_discord_token(
@@ -311,12 +290,6 @@ async fn fetch_discord_profile(access_token: &str) -> Result<DiscordProfileRespo
         .map_err(|error| ApiError::internal(error.to_string()))
 }
 
-#[derive(Debug)]
-struct SortableClaim {
-    created_at_millis: i64,
-    claim: ClaimedGovernor,
-}
-
 #[derive(Debug, Deserialize)]
 struct DiscordCallbackQuery {
     code: Option<String>,
@@ -338,7 +311,7 @@ struct DiscordProfileResponse {
 
 #[cfg(test)]
 mod tests {
-    use mongodb::bson::{DateTime, doc};
+    use mongodb::bson::doc;
 
     use super::*;
 
@@ -355,15 +328,5 @@ mod tests {
         );
         assert_eq!(optional_string_field(&document, "governorAvatar"), None);
         assert_eq!(optional_string_field(&document, "missing"), None);
-    }
-
-    #[test]
-    fn reads_claim_created_at_millis_from_datetime() {
-        let created_at = DateTime::from_millis(1234);
-        let document = doc! {
-            "createdAt": created_at
-        };
-
-        assert_eq!(claim_created_at_millis(&document), 1234);
     }
 }

--- a/crates/rokbattles-api/src/routes/governor/pairings/aggregate.rs
+++ b/crates/rokbattles-api/src/routes/governor/pairings/aggregate.rs
@@ -44,9 +44,9 @@ pub(crate) fn aggregate_pairings(
             continue;
         }
 
-        for entry in flatten_pairing_entries(mail) {
+        for_each_pairing_entry(mail, |entry| {
             if entry.self_primary_commander_id <= 0 {
-                continue;
+                return;
             }
 
             let key = (
@@ -68,7 +68,7 @@ pub(crate) fn aggregate_pairings(
                 entry.delta,
                 entry.battle_duration_millis,
             );
-        }
+        });
     }
 
     let mut items = buckets.into_values().collect::<Vec<_>>();
@@ -93,10 +93,13 @@ pub(crate) fn aggregate_loadouts(
         let loadout = build_loadout_snapshot(mail, granularity);
         let key = build_loadout_key(&loadout);
 
-        for entry in flatten_pairing_entries(mail).into_iter().filter(|entry| {
-            entry.self_primary_commander_id == primary_commander_id
-                && entry.self_secondary_commander_id == secondary_commander_id
-        }) {
+        for_each_pairing_entry(mail, |entry| {
+            if entry.self_primary_commander_id != primary_commander_id
+                || entry.self_secondary_commander_id != secondary_commander_id
+            {
+                return;
+            }
+
             let bucket =
                 buckets
                     .entry(key.clone())
@@ -113,7 +116,7 @@ pub(crate) fn aggregate_loadouts(
                 entry.delta,
                 entry.battle_duration_millis,
             );
-        }
+        });
     }
 
     let mut items = buckets.into_values().collect::<Vec<_>>();
@@ -136,17 +139,6 @@ pub(crate) fn aggregate_opponents(
             continue;
         }
 
-        let entries = flatten_pairing_entries(mail)
-            .into_iter()
-            .filter(|entry| {
-                entry.self_primary_commander_id == primary_commander_id
-                    && entry.self_secondary_commander_id == secondary_commander_id
-            })
-            .collect::<Vec<_>>();
-        if entries.is_empty() {
-            continue;
-        }
-
         if granularity != OpponentGranularity::Overall {
             let lookup_granularity = match granularity {
                 OpponentGranularity::Simplified => LoadoutGranularity::Simplified,
@@ -160,7 +152,15 @@ pub(crate) fn aggregate_opponents(
             }
         }
 
-        for entry in entries {
+        let mut found_matching_entry = false;
+        for_each_pairing_entry(mail, |entry| {
+            if entry.self_primary_commander_id != primary_commander_id
+                || entry.self_secondary_commander_id != secondary_commander_id
+            {
+                return;
+            }
+
+            found_matching_entry = true;
             let key = (
                 entry.enemy_primary_commander_id,
                 entry.enemy_secondary_commander_id,
@@ -179,6 +179,10 @@ pub(crate) fn aggregate_opponents(
                 entry.delta,
                 entry.battle_duration_millis,
             );
+        });
+
+        if !found_matching_entry {
+            continue;
         }
     }
 
@@ -197,7 +201,7 @@ fn extract_event_time_millis(mail: &Document) -> Option<i64> {
     normalize_bson_timestamp_millis(mail.get_document("metadata").ok()?.get("mail_time"))
 }
 
-fn flatten_pairing_entries(mail: &Document) -> Vec<PairingEntry> {
+fn for_each_pairing_entry(mail: &Document, mut push: impl FnMut(PairingEntry)) {
     let self_primary_commander_id =
         nested_i64(mail, &["sender", "commanders", "primary", "id"]).unwrap_or_default();
     let self_secondary_commander_id =
@@ -225,9 +229,8 @@ fn flatten_pairing_entries(mail: &Document) -> Vec<PairingEntry> {
         left_player.cmp(&right_player)
     });
 
-    opponents
-        .into_iter()
-        .map(|opponent| PairingEntry {
+    for opponent in opponents {
+        push(PairingEntry {
             self_primary_commander_id,
             self_secondary_commander_id,
             enemy_primary_commander_id: nested_i64(opponent, &["commanders", "primary", "id"])
@@ -236,8 +239,8 @@ fn flatten_pairing_entries(mail: &Document) -> Vec<PairingEntry> {
                 .unwrap_or_default(),
             battle_duration_millis: extract_battle_duration_millis(mail, opponent),
             delta: extract_battle_delta(opponent),
-        })
-        .collect::<Vec<_>>()
+        });
+    }
 }
 
 fn extract_battle_duration_millis(mail: &Document, opponent: &Document) -> i64 {

--- a/crates/rokbattles-api/src/routes/reports/battle/list_mapper.rs
+++ b/crates/rokbattles-api/src/routes/reports/battle/list_mapper.rs
@@ -65,7 +65,7 @@ pub(super) fn build_report_dedupe_key(document: &Document) -> Option<String> {
 
     let mut attack_ids = extract_opponents(document)
         .into_iter()
-        .filter(is_valid_opponent)
+        .filter(|opponent| is_valid_opponent(opponent))
         .filter_map(extract_attack_id)
         .filter(|value| !value.is_empty())
         .collect::<Vec<_>>();
@@ -154,18 +154,17 @@ pub(crate) fn compute_trade_percent(sender_kill_points: i64, opponent_kill_point
     ((sender_kill_points as f64 / opponent_kill_points as f64) * 100.0).round() as i64
 }
 
-fn extract_opponents(document: &Document) -> Vec<Document> {
+fn extract_opponents(document: &Document) -> Vec<&Document> {
     document
         .get_array("opponents")
         .ok()
         .into_iter()
         .flatten()
         .filter_map(Bson::as_document)
-        .cloned()
         .collect()
 }
 
-fn extract_attack_id(opponent: Document) -> Option<String> {
+fn extract_attack_id(opponent: &Document) -> Option<String> {
     let attack = opponent.get_document("attack").ok()?;
     let raw_id = attack.get("id")?;
     Some(match raw_id {
@@ -177,11 +176,11 @@ fn extract_attack_id(opponent: Document) -> Option<String> {
     })
 }
 
-fn get_valid_sorted_opponents(opponents: &[Document]) -> Vec<Document> {
+fn get_valid_sorted_opponents<'a>(opponents: &'a [&Document]) -> Vec<&'a Document> {
     let mut valid = opponents
         .iter()
+        .copied()
         .filter(|opponent| is_valid_opponent(opponent))
-        .cloned()
         .collect::<Vec<_>>();
 
     valid.sort_by(|a, b| {
@@ -205,7 +204,7 @@ fn is_valid_opponent(opponent: &Document) -> bool {
     !INVALID_OPPONENT_PLAYER_IDS.contains(&player_id)
 }
 
-fn select_preferred_opponent(opponents: &[Document]) -> Option<&Document> {
+fn select_preferred_opponent<'a>(opponents: &'a [&Document]) -> Option<&'a Document> {
     for opponent in opponents {
         if has_non_null_field(opponent, "alliance_building_id")
             || has_non_null_field(opponent, "structure_id")
@@ -214,7 +213,7 @@ fn select_preferred_opponent(opponents: &[Document]) -> Option<&Document> {
         }
     }
 
-    opponents.first()
+    opponents.first().copied()
 }
 
 fn has_non_null_field(document: &Document, key: &str) -> bool {
@@ -224,7 +223,7 @@ fn has_non_null_field(document: &Document, key: &str) -> bool {
 fn resolve_summary_entry(
     document: &Document,
     side: &str,
-    opponents: &[Document],
+    opponents: &[&Document],
 ) -> ReportSummaryEntry {
     let fallback = build_fallback_summary(side, opponents);
     let source = nested_document(document, &["summary", side]);
@@ -251,7 +250,7 @@ fn resolve_summary_entry(
     }
 }
 
-fn build_fallback_summary(side: &str, opponents: &[Document]) -> ReportSummaryEntry {
+fn build_fallback_summary(side: &str, opponents: &[&Document]) -> ReportSummaryEntry {
     let mut summary = ReportSummaryEntry {
         troop_units: 0,
         dead: 0,
@@ -364,7 +363,8 @@ mod tests {
             },
         ];
 
-        let preferred = select_preferred_opponent(&opponents).expect("preferred opponent");
+        let opponent_refs = opponents.iter().collect::<Vec<_>>();
+        let preferred = select_preferred_opponent(&opponent_refs).expect("preferred opponent");
         assert_eq!(nested_i64(preferred, &["player_id"]), Some(101));
     }
 
@@ -399,7 +399,8 @@ mod tests {
             },
         ];
 
-        let summary = build_fallback_summary("opponent", &opponents);
+        let opponent_refs = opponents.iter().collect::<Vec<_>>();
+        let summary = build_fallback_summary("opponent", &opponent_refs);
         assert_eq!(summary.troop_units, 10);
         assert_eq!(summary.dead, 20);
         assert_eq!(summary.severely_wounded, 30);

--- a/crates/rokbattles-api/src/routes/reports/battle/list_mapper.rs
+++ b/crates/rokbattles-api/src/routes/reports/battle/list_mapper.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn prefers_garrison_opponent() {
-        let opponents = vec![
+        let opponents = [
             doc! {
                 "player_id": 100,
                 "start_tick": 1,
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn fallback_summary_ignores_invalid_opponents() {
-        let opponents = vec![
+        let opponents = [
             doc! {
                 "player_id": -2,
                 "battle_results": {


### PR DESCRIPTION
- Add index support for loot reads
- Add compound index for pairings
- Use mongo ordering & sort indexes for governor claims
- Removed unused indexes
- Reduce allocations in battle list mapping