### PR TITLE
fix: ensure type 15 has param 1 for individual aoo results

### DIFF
--- a/apps/mail-cli/src/run/classify.rs
+++ b/apps/mail-cli/src/run/classify.rs
@@ -37,7 +37,7 @@ fn detect_alliance_aoo_mail_type(root: &Value) -> Option<&'static str> {
 
     match body_type {
         14 if matches!(body_param, Some(1)) => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_RESULTS),
-        15 => Some(MAIL_TYPE_ALLIANCE_AOO_INDIVIDUAL_RESULTS),
+        15 if matches!(body_param, Some(1)) => Some(MAIL_TYPE_ALLIANCE_AOO_INDIVIDUAL_RESULTS),
         60 => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_RESULTS),
         61 => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_INFO),
         62 => Some(MAIL_TYPE_ALLIANCE_AOO_INDIVIDUAL_RESULTS),
@@ -113,7 +113,7 @@ mod tests {
         let custom_individual_results = json!({
             "type": "Alliance",
             "box": "AllianceBox",
-            "body": { "type": 15 }
+            "body": { "type": 15, "param": 1 }
         });
         assert_eq!(
             classify_processable_mail_type(&custom_individual_results),
@@ -137,6 +137,16 @@ mod tests {
             "type": "Alliance",
             "box": "AllianceBox",
             "body": { "type": 14, "param": 2 }
+        });
+        assert_eq!(classify_processable_mail_type(&payload), None);
+    }
+
+    #[test]
+    fn classify_processable_mail_type_rejects_type_15_alliance_mail_with_other_param() {
+        let payload = json!({
+            "type": "Alliance",
+            "box": "AllianceBox",
+            "body": { "type": 15, "param": 3 }
         });
         assert_eq!(classify_processable_mail_type(&payload), None);
     }

--- a/apps/rokbattles-ingress/src/handlers.rs
+++ b/apps/rokbattles-ingress/src/handlers.rs
@@ -326,7 +326,7 @@ fn detect_alliance_aoo_mail_type(root: &Value) -> Option<&'static str> {
     match body_type {
         // custom Ark match
         14 if matches!(body_param, Some(1)) => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_RESULTS),
-        15 => Some(MAIL_TYPE_ALLIANCE_AOO_INDIVIDUAL_RESULTS),
+        15 if matches!(body_param, Some(1)) => Some(MAIL_TYPE_ALLIANCE_AOO_INDIVIDUAL_RESULTS),
         // normal Ark match
         60 => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_RESULTS),
         61 => Some(MAIL_TYPE_ALLIANCE_AOO_BATTLE_INFO),
@@ -645,13 +645,27 @@ mod tests {
             "type": "Alliance",
             "box": "AllianceBox",
             "body": {
-                "type": 15
+                "type": 15,
+                "param": 1
             }
         });
         assert_eq!(
             extract_mail_type(&decoded).unwrap(),
             "AllianceAOOIndividualResults".to_string()
         );
+    }
+
+    #[test]
+    fn keeps_type_15_alliance_mail_when_param_is_not_one() {
+        let decoded = json!({
+            "type": "Alliance",
+            "box": "AllianceBox",
+            "body": {
+                "type": 15,
+                "param": 3
+            }
+        });
+        assert_eq!(extract_mail_type(&decoded).unwrap(), "Alliance".to_string());
     }
 
     #[test]

--- a/apps/rokbattles-processor/src/processing.rs
+++ b/apps/rokbattles-processor/src/processing.rs
@@ -213,7 +213,7 @@ fn detect_alliance_aoo_mail_type(root: &Value) -> Option<MailType> {
     match body_type {
         // custom Ark match
         14 if matches!(body_param, Some(1)) => Some(MailType::AllianceAOOBattleResults),
-        15 => Some(MailType::AllianceAOOIndividualResults),
+        15 if matches!(body_param, Some(1)) => Some(MailType::AllianceAOOIndividualResults),
         // normal Ark match
         60 => Some(MailType::AllianceAOOBattleResults),
         61 => Some(MailType::AllianceAOOBattleInfo),
@@ -399,11 +399,28 @@ mod tests {
             "type": "Alliance",
             "box": "AllianceBox",
             "body": {
-                "type": 15
+                "type": 15,
+                "param": 1
             }
         });
         let mail_type = extract_mail_type(&value).unwrap();
         assert_eq!(mail_type, MailType::AllianceAOOIndividualResults);
+    }
+
+    #[test]
+    fn extract_mail_type_rejects_alliance_custom_individual_results_with_other_param() {
+        let value = json!({
+            "type": "Alliance",
+            "box": "AllianceBox",
+            "body": {
+                "type": 15,
+                "param": 3
+            }
+        });
+        let err = extract_mail_type(&value).unwrap_err();
+        assert!(
+            matches!(err, ProcessorError::UnsupportedMailType(mail_type) if mail_type == "Alliance")
+        );
     }
 
     #[test]

--- a/apps/rokbattles-tauri/src-tauri/src/watcher/mail.rs
+++ b/apps/rokbattles-tauri/src-tauri/src/watcher/mail.rs
@@ -103,7 +103,7 @@ fn detect_alliance_aoo_mail_type(root: &Map<String, Value>) -> Option<&'static s
     match body_type {
         // custom Ark match
         14 if matches!(body_param, Some(1)) => Some(ALLIANCE_AOO_BATTLE_RESULTS_MAIL_TYPE),
-        15 => Some(ALLIANCE_AOO_INDIVIDUAL_RESULTS_MAIL_TYPE),
+        15 if matches!(body_param, Some(1)) => Some(ALLIANCE_AOO_INDIVIDUAL_RESULTS_MAIL_TYPE),
         // normal Ark match
         60 => Some(ALLIANCE_AOO_BATTLE_RESULTS_MAIL_TYPE),
         61 => Some(ALLIANCE_AOO_BATTLE_INFO_MAIL_TYPE),
@@ -263,7 +263,7 @@ mod tests {
         let custom_individual_results = json!({
             "type": "Alliance",
             "box": "AllianceBox",
-            "body": { "type": 15 }
+            "body": { "type": 15, "param": 1 }
         });
         assert_eq!(
             detect_supported_mail_type(&custom_individual_results),
@@ -287,6 +287,16 @@ mod tests {
             "type": "Alliance",
             "box": "AllianceBox",
             "body": { "type": 14, "param": 2 }
+        });
+        assert_eq!(detect_supported_mail_type(&payload), None);
+    }
+
+    #[test]
+    fn detect_supported_mail_type_rejects_type_15_alliance_mail_with_other_param() {
+        let payload = json!({
+            "type": "Alliance",
+            "box": "AllianceBox",
+            "body": { "type": 15, "param": 3 }
         });
         assert_eq!(detect_supported_mail_type(&payload), None);
     }

--- a/crates/mail-processor-alliance-aooindividualresults/src/metadata.rs
+++ b/crates/mail-processor-alliance-aooindividualresults/src/metadata.rs
@@ -105,7 +105,7 @@ mod tests {
             "time": 1234,
             "receiver": "player-1",
             "serverId": 55,
-            "body": { "type": 15 }
+            "body": { "type": 15, "param": 1 }
         });
         let extractor = MetadataExtractor::new();
         let section = extractor.extract(&input).unwrap();


### PR DESCRIPTION
param 3 is related to unsportmans like conduct which we don't want in our system; these files will be deleted from our system being deployed 