### PR TITLE
refactor: remove Apple Gatekeeper warning for macOS builds

### DIFF
--- a/site/src/content/docs/installation/macos.mdx
+++ b/site/src/content/docs/installation/macos.mdx
@@ -19,15 +19,3 @@ ROK Battles is available for both Apple Silicon and Intel Macs.
 ## Notes
 
 * If you are unsure which version to download, Apple Silicon covers the newer M-series Macs, while Intel is for older hardware.
-
-## "App is damaged" warning
-
-The current macOS build is not yet code signed or notarized. Because of that, Apple Gatekeeper may block the app after it is downloaded and show a message saying the app is damaged.
-
-If you see that warning after moving the app into `Applications`, run this command once:
-
-```sh
-xattr -d com.apple.quarantine /Applications/ROK\ Battles.app
-```
-
-After that, open the app again and it should launch normally.


### PR DESCRIPTION
We will be signing our macOS builds in the next version 