### PR TITLE
refactor: use sh instead of bash for legal sync

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -6,7 +6,7 @@
     "dev": "next -H 0.0.0.0",
     "build": "next build",
     "typecheck": "next typegen && tsc --noEmit",
-    "sync:legal": "bash ./scripts/sync-legal-docs.sh",
+    "sync:legal": "sh ./scripts/sync-legal-docs.sh",
     "generate:datasets": "node ./scripts/generate-datasets.mjs",
     "generate:messages": "node ./scripts/generate-messages.mjs"
   },

--- a/packages/site/scripts/sync-legal-docs.sh
+++ b/packages/site/scripts/sync-legal-docs.sh
@@ -1,18 +1,18 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 repo_url="https://github.com/rokbattles/legal.git"
 branch="main"
-script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-site_dir="$(cd -- "${script_dir}/.." && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+site_dir="$(cd "${script_dir}/.." && pwd)"
 destination="${site_dir}/legal"
 
-if [[ ! -e "${destination}" ]]; then
+if [ ! -e "${destination}" ]; then
   git clone --branch "${branch}" "${repo_url}" "${destination}"
   exit 0
 fi
 
-if [[ ! -d "${destination}/.git" ]]; then
+if [ ! -d "${destination}/.git" ]; then
   echo "${destination} already exists, but it is not a git repository." >&2
   exit 1
 fi


### PR DESCRIPTION
Bash isn't part of alpine, so we need to use sh