### PR TITLE
refactor: pin legal docs sync to commit sha; only allow file read from legal directory

### DIFF
--- a/packages/site/scripts/sync-legal-docs.sh
+++ b/packages/site/scripts/sync-legal-docs.sh
@@ -2,14 +2,15 @@
 set -eu
 
 repo_url="https://github.com/rokbattles/legal.git"
-branch="main"
+legal_commit="fe27a66dcc26d48c6fe0569cb7d10b9cde03ebc5"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 site_dir="$(cd "${script_dir}/.." && pwd)"
 destination="${site_dir}/legal"
 
 if [ ! -e "${destination}" ]; then
-  git clone --branch "${branch}" "${repo_url}" "${destination}"
-  exit 0
+  mkdir -p "${destination}"
+  git -C "${destination}" init
+  git -C "${destination}" remote add origin "${repo_url}"
 fi
 
 if [ ! -d "${destination}/.git" ]; then
@@ -18,6 +19,13 @@ if [ ! -d "${destination}/.git" ]; then
 fi
 
 git -C "${destination}" remote set-url origin "${repo_url}"
-git -C "${destination}" fetch --prune origin
-git -C "${destination}" checkout "${branch}"
-git -C "${destination}" pull --ff-only origin "${branch}"
+git -C "${destination}" fetch --depth=1 origin "${legal_commit}"
+git -C "${destination}" checkout --detach --force "${legal_commit}"
+git -C "${destination}" reset --hard "${legal_commit}"
+git -C "${destination}" clean -fdx
+
+current_commit="$(git -C "${destination}" rev-parse HEAD)"
+if [ "${current_commit}" != "${legal_commit}" ]; then
+  echo "Expected legal docs at ${legal_commit}, got ${current_commit}." >&2
+  exit 1
+fi

--- a/packages/site/src/lib/legal-docs.ts
+++ b/packages/site/src/lib/legal-docs.ts
@@ -1,5 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { lstat, readFile, realpath } from "node:fs/promises";
+import { isAbsolute, relative, resolve } from "node:path";
 
 export type LegalDocument = {
   slug: string;
@@ -26,7 +26,7 @@ const LEGAL_DOCUMENTS: LegalDocument[] = [
 ];
 
 const documentsBySlug = new Map(LEGAL_DOCUMENTS.map((doc) => [doc.slug, doc]));
-const legalBasePath = join(process.cwd(), "legal");
+const legalBasePath = resolve(process.cwd(), "legal");
 
 export function getLegalDocuments(): readonly LegalDocument[] {
   return LEGAL_DOCUMENTS;
@@ -42,13 +42,36 @@ export async function loadLegalDocument(
   const doc = getLegalDocument(slug);
   if (!doc) return undefined;
 
-  const filePath = join(legalBasePath, doc.filename);
+  const filePath = resolve(legalBasePath, doc.filename);
 
   try {
-    const content = await readFile(filePath, "utf-8");
+    const safeFilePath = await getSafeLegalDocumentPath(filePath);
+    const content = await readFile(safeFilePath, "utf-8");
     return { ...doc, content };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read legal document '${slug}' from ${filePath}: ${message}`);
   }
+}
+
+async function getSafeLegalDocumentPath(filePath: string): Promise<string> {
+  const baseStats = await lstat(legalBasePath);
+  if (!baseStats.isDirectory() || baseStats.isSymbolicLink()) {
+    throw new Error(`Legal documents path is not a real directory: ${legalBasePath}`);
+  }
+
+  const fileStats = await lstat(filePath);
+  if (!fileStats.isFile() || fileStats.isSymbolicLink()) {
+    throw new Error(`Legal document is not a regular file: ${filePath}`);
+  }
+
+  const baseRealPath = await realpath(legalBasePath);
+  const fileRealPath = await realpath(filePath);
+  const relativePath = relative(baseRealPath, fileRealPath);
+
+  if (relativePath.startsWith("..") || isAbsolute(relativePath) || relativePath === "") {
+    throw new Error(`Legal document resolves outside legal directory: ${filePath}`);
+  }
+
+  return fileRealPath;
 }


### PR DESCRIPTION
Pin the `sync:legal` script to a commit sha of our legal repository. The script will fetch the sha, checks it out detached, resets/clean the checkout and verifies the HEAD against the pinned commit. In addition, we restrict legal pages to only read files under the legal directory and reject symlinks or realpath escapes. 