### PR TITLE
feat: precompute Karuak Ceremony loot

### DIFF
--- a/crates/rokbattles-api/src/db/reports_store.rs
+++ b/crates/rokbattles-api/src/db/reports_store.rs
@@ -17,6 +17,7 @@ pub struct ReportsStore {
     mails_alliance_aooregistration: Collection<Document>,
     mails_system_barbarianfort: Collection<Document>,
     mails_system_kahartreasure: Collection<Document>,
+    mails_eventmemberlootreport: Collection<Document>,
     mails_barcanyonkillboss: Collection<Document>,
     mails_rss: Collection<Document>,
     claimed_governors: Collection<Document>,
@@ -24,6 +25,7 @@ pub struct ReportsStore {
     g_rok_prec_barbarianfort: Collection<Document>,
     g_rok_prec_baulur: Collection<Document>,
     g_rok_prec_kahartreasure: Collection<Document>,
+    g_rok_prec_karuakceremony: Collection<Document>,
     g_rok_prec_cmdr_pairings: Collection<Document>,
 }
 
@@ -40,6 +42,7 @@ impl ReportsStore {
             mails_alliance_aooregistration: db.collection("mails_alliance_aooregistration"),
             mails_system_barbarianfort: db.collection("mails_system_barbarianfort"),
             mails_system_kahartreasure: db.collection("mails_system_kahartreasure"),
+            mails_eventmemberlootreport: db.collection("mails_eventmemberlootreport"),
             mails_barcanyonkillboss: db.collection("mails_barcanyonkillboss"),
             mails_rss: db.collection("mails_rss"),
             claimed_governors: db.collection("claimedGovernors"),
@@ -47,6 +50,7 @@ impl ReportsStore {
             g_rok_prec_barbarianfort: db.collection("g_rok_prec_barbarianfort"),
             g_rok_prec_baulur: db.collection("g_rok_prec_baulur"),
             g_rok_prec_kahartreasure: db.collection("g_rok_prec_kahartreasure"),
+            g_rok_prec_karuakceremony: db.collection("g_rok_prec_karuakceremony"),
             g_rok_prec_cmdr_pairings: db.collection("g_rok_prec_cmdr_pairings"),
         }
     }
@@ -309,6 +313,15 @@ impl ReportsStore {
             self.g_rok_prec_kahartreasure.create_index(model).await?;
         }
 
+        self.g_rok_prec_karuakceremony
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! { "kind": 1 })
+                    .options(IndexOptions::builder().unique(true).build())
+                    .build(),
+            )
+            .await?;
+
         let precomputed_cmdr_pairing_models = vec![
             IndexModel::builder()
                 .keys(doc! { "primary_commander_id": 1, "secondary_commander_id": 1 })
@@ -363,6 +376,11 @@ impl ReportsStore {
         &self.mails_system_kahartreasure
     }
 
+    /// Access Karuak Ceremony member loot reports.
+    pub fn event_member_loot_report_collection(&self) -> &Collection<Document> {
+        &self.mails_eventmemberlootreport
+    }
+
     /// Access the bar canyon kill boss mail collection.
     pub fn barcanyonkillboss_collection(&self) -> &Collection<Document> {
         &self.mails_barcanyonkillboss
@@ -396,6 +414,11 @@ impl ReportsStore {
     /// Access precomputed Kahar treasure aggregates.
     pub fn precomputed_kahar_treasure_collection(&self) -> &Collection<Document> {
         &self.g_rok_prec_kahartreasure
+    }
+
+    /// Access precomputed Karuak Ceremony boss aggregates.
+    pub fn precomputed_karuak_ceremony_collection(&self) -> &Collection<Document> {
+        &self.g_rok_prec_karuakceremony
     }
 
     /// Access precomputed global commander pairing aggregates.

--- a/crates/rokbattles-jobs/src/lib.rs
+++ b/crates/rokbattles-jobs/src/lib.rs
@@ -9,5 +9,6 @@ pub mod precompute_barbarianfort;
 pub mod precompute_baulur;
 pub mod precompute_cmdr_pairings;
 pub mod precompute_kahar_treasure;
+pub mod precompute_karuak_ceremony;
 pub mod refresh_binds;
 pub mod scheduler;

--- a/crates/rokbattles-jobs/src/precompute_karuak_ceremony.rs
+++ b/crates/rokbattles-jobs/src/precompute_karuak_ceremony.rs
@@ -1,0 +1,204 @@
+//! Precompute aggregate reward data for Karuak Ceremony bosses.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures::StreamExt;
+use mongodb::{
+    Collection,
+    bson::{Bson, DateTime, Document, doc},
+};
+use rokbattles_api::db::ReportsStore;
+
+use crate::error::JobsError;
+
+const BOSS_IDS: [i64; 5] = [30_001, 30_002, 30_003, 30_004, 30_005];
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct KaruakCeremonyPrecomputeStats {
+    pub documents_read: usize,
+    pub results_counted: usize,
+    pub documents_written: usize,
+}
+
+pub async fn precompute_karuak_ceremony_data(
+    reports_store: &ReportsStore,
+) -> Result<KaruakCeremonyPrecomputeStats, JobsError> {
+    let (aggregates, mut stats) =
+        read_observed_reports(reports_store.event_member_loot_report_collection()).await?;
+    let output = reports_store.precomputed_karuak_ceremony_collection();
+    let refreshed_at = DateTime::now();
+
+    for boss_id in BOSS_IDS {
+        let aggregate = aggregates.get(&boss_id).cloned().unwrap_or_default();
+        output
+            .replace_one(
+                doc! { "kind": boss_id },
+                build_document(boss_id, &aggregate, refreshed_at),
+            )
+            .upsert(true)
+            .await?;
+        stats.documents_written += 1;
+    }
+
+    output.delete_many(doc! { "kind": { "$nin": BOSS_IDS.to_vec() } }).await?;
+    Ok(stats)
+}
+
+async fn read_observed_reports(
+    source: &Collection<Document>,
+) -> Result<(BTreeMap<i64, AggregateStats>, KaruakCeremonyPrecomputeStats), JobsError> {
+    let mut cursor = source
+        .find(doc! { "boss.id": { "$in": BOSS_IDS.to_vec() } })
+        .projection(doc! { "_id": 0, "boss.id": 1, "participants.loot": 1 })
+        .await?;
+    let mut aggregates = BTreeMap::new();
+    let mut stats = KaruakCeremonyPrecomputeStats::default();
+
+    while let Some(next) = cursor.next().await {
+        stats.documents_read += 1;
+        let document = next?;
+        let Some(boss_id) = nested_i64(&document, &["boss", "id"]) else { continue };
+        let aggregate = aggregates.entry(boss_id).or_default();
+        stats.results_counted += accumulate_document(&document, aggregate);
+    }
+    Ok((aggregates, stats))
+}
+
+fn accumulate_document(document: &Document, aggregate: &mut AggregateStats) -> usize {
+    let Some(Bson::Array(participants)) = document.get("participants") else { return 0 };
+    let mut counted = 0;
+    for participant in participants.iter().filter_map(Bson::as_document) {
+        let Some(Bson::Array(loot)) = participant.get("loot") else { continue };
+        aggregate.results += 1;
+        counted += 1;
+        let mut seen = BTreeSet::new();
+        for reward in loot.iter().filter_map(Bson::as_document) {
+            let (Some(reward_type), Some(sub_type), Some(quantity)) = (
+                direct_i32(reward, "type"),
+                direct_i32(reward, "sub_type"),
+                direct_i64(reward, "value"),
+            ) else {
+                continue;
+            };
+            let key = LootKey { reward_type, sub_type };
+            aggregate.loot.entry(key).or_default().record(quantity, seen.insert(key));
+        }
+    }
+    counted
+}
+
+fn build_document(kind: i64, stats: &AggregateStats, refreshed_at: DateTime) -> Document {
+    let loot = stats
+        .loot
+        .iter()
+        .map(|(key, value)| {
+            doc! {
+                "type": key.reward_type,
+                "sub_type": key.sub_type,
+                "results": usize_to_i64(value.seen),
+                "drop_rate": rate(value.seen, stats.results),
+                "quantity": { "min": value.min.unwrap_or(0), "max": value.max.unwrap_or(0) },
+                "total_quantity": value.total_quantity,
+                "average_quantity": rate_i64(value.total_quantity, value.seen),
+            }
+        })
+        .collect::<Vec<_>>();
+    doc! {
+        "kind": kind,
+        "loot": loot,
+        "totals": { "results": usize_to_i64(stats.results) },
+        "refreshed_at": refreshed_at,
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct AggregateStats {
+    results: usize,
+    loot: BTreeMap<LootKey, LootStats>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct LootKey {
+    reward_type: i32,
+    sub_type: i32,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LootStats {
+    seen: usize,
+    total_quantity: i64,
+    min: Option<i64>,
+    max: Option<i64>,
+}
+
+impl LootStats {
+    fn record(&mut self, quantity: i64, first_for_result: bool) {
+        if first_for_result {
+            self.seen += 1;
+        }
+        self.total_quantity += quantity;
+        self.min = Some(self.min.map_or(quantity, |value| value.min(quantity)));
+        self.max = Some(self.max.map_or(quantity, |value| value.max(quantity)));
+    }
+}
+
+fn nested_i64(document: &Document, path: &[&str]) -> Option<i64> {
+    let mut current = document;
+    for key in &path[..path.len() - 1] {
+        current = current.get_document(key).ok()?;
+    }
+    direct_i64(current, path[path.len() - 1])
+}
+fn direct_i32(document: &Document, key: &str) -> Option<i32> {
+    direct_i64(document, key).and_then(|v| i32::try_from(v).ok())
+}
+fn direct_i64(document: &Document, key: &str) -> Option<i64> {
+    match document.get(key)? {
+        Bson::Int32(v) => Some(i64::from(*v)),
+        Bson::Int64(v) => Some(*v),
+        Bson::Double(v) if v.fract() == 0.0 => Some(*v as i64),
+        _ => None,
+    }
+}
+fn rate(part: usize, total: usize) -> f64 {
+    if total == 0 { 0.0 } else { part as f64 / total as f64 }
+}
+fn rate_i64(total: i64, count: usize) -> f64 {
+    if count == 0 { 0.0 } else { total as f64 / count as f64 }
+}
+fn usize_to_i64(value: usize) -> i64 {
+    i64::try_from(value).unwrap_or(i64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use mongodb::bson::{DateTime, doc};
+
+    use super::*;
+
+    #[test]
+    fn aggregates_each_participant_as_one_result() {
+        let mut aggregate = AggregateStats::default();
+        let counted = accumulate_document(
+            &doc! { "participants": [
+                { "loot": [{ "type": 2, "sub_type": 17, "value": 1 }] },
+                { "loot": [{ "type": 2, "sub_type": 17, "value": 2 }, { "type": 2, "sub_type": 149, "value": 10 }] },
+            ] },
+            &mut aggregate,
+        );
+        assert_eq!(counted, 2);
+        assert_eq!(aggregate.results, 2);
+        assert_eq!(aggregate.loot[&LootKey { reward_type: 2, sub_type: 17 }].seen, 2);
+    }
+
+    #[test]
+    fn builds_poolless_boss_document_with_totals() {
+        let mut aggregate = AggregateStats { results: 2, ..Default::default() };
+        aggregate.loot.entry(LootKey { reward_type: 2, sub_type: 17 }).or_default().record(1, true);
+        let document = build_document(30_001, &aggregate, DateTime::from_millis(123));
+        assert_eq!(document.get_i64("kind"), Ok(30_001));
+        assert_eq!(document.get_document("totals").unwrap().get_i64("results"), Ok(2));
+        assert!(document.get_array("loot").is_ok());
+        assert!(!document.contains_key("pools"));
+    }
+}

--- a/crates/rokbattles-jobs/src/scheduler.rs
+++ b/crates/rokbattles-jobs/src/scheduler.rs
@@ -13,6 +13,7 @@ use crate::{
     precompute_baulur::precompute_baulur_data,
     precompute_cmdr_pairings::precompute_commander_pairings_data,
     precompute_kahar_treasure::precompute_kahar_treasure_data,
+    precompute_karuak_ceremony::precompute_karuak_ceremony_data,
     refresh_binds::refresh_claimed_governor_bindings,
 };
 
@@ -27,6 +28,8 @@ pub const PRECOMPUTE_BAULUR_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
 pub const PRECOMPUTE_KAHAR_TREASURE_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
+pub const PRECOMPUTE_KARUAK_CEREMONY_CRON: &str = "0 0 */8 * * *";
+/// Every 8 hours
 pub const PRECOMPUTE_COMMANDER_PAIRINGS_CRON: &str = "0 0 */8 * * *";
 
 /// Create the scheduler with the governor bind refresh job registered.
@@ -38,6 +41,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
     let barbarian_fort_lock = Arc::new(Mutex::new(()));
     let baulur_lock = Arc::new(Mutex::new(()));
     let kahar_treasure_lock = Arc::new(Mutex::new(()));
+    let karuak_ceremony_lock = Arc::new(Mutex::new(()));
     let commander_pairings_lock = Arc::new(Mutex::new(()));
 
     add_locked_job(
@@ -60,6 +64,26 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
                 Err(error) => {
                     error!(%error, "failed to refresh claimed governor binds");
                 }
+            }
+        },
+    )
+    .await?;
+
+    add_locked_job(
+        &scheduler,
+        PRECOMPUTE_KARUAK_CEREMONY_CRON,
+        Arc::clone(&reports_store),
+        karuak_ceremony_lock,
+        "Karuak Ceremony precompute is already running; skipping this tick",
+        |reports_store| async move {
+            match precompute_karuak_ceremony_data(&reports_store).await {
+                Ok(stats) => info!(
+                    documents_read = stats.documents_read,
+                    results_counted = stats.results_counted,
+                    documents_written = stats.documents_written,
+                    "precomputed Karuak Ceremony data"
+                ),
+                Err(error) => error!(%error, "failed to precompute Karuak Ceremony data"),
             }
         },
     )
@@ -227,7 +251,8 @@ where
 mod tests {
     use super::{
         PRECOMPUTE_BARBARIAN_CRON, PRECOMPUTE_BARBARIAN_FORT_CRON, PRECOMPUTE_BAULUR_CRON,
-        PRECOMPUTE_COMMANDER_PAIRINGS_CRON, PRECOMPUTE_KAHAR_TREASURE_CRON, REFRESH_BINDS_CRON,
+        PRECOMPUTE_COMMANDER_PAIRINGS_CRON, PRECOMPUTE_KAHAR_TREASURE_CRON,
+        PRECOMPUTE_KARUAK_CEREMONY_CRON, REFRESH_BINDS_CRON,
     };
 
     #[test]
@@ -258,5 +283,10 @@ mod tests {
     #[test]
     fn precompute_commander_pairings_cron_runs_every_eight_hours_utc() {
         assert_eq!(PRECOMPUTE_COMMANDER_PAIRINGS_CRON, "0 0 */8 * * *");
+    }
+
+    #[test]
+    fn precompute_karuak_ceremony_cron_runs_every_eight_hours_utc() {
+        assert_eq!(PRECOMPUTE_KARUAK_CEREMONY_CRON, "0 0 */8 * * *");
     }
 }


### PR DESCRIPTION
## Summary

Adds an eight-hour Karuak Ceremony precompute that aggregates participant loot into five boss documents before the commander-pairing job registration.

## Validation

- Rust formatting, Clippy, job tests, and a live one-off run pass; the run wrote five documents from 514 participant results.
