### PR TITLE
fix: add Kahar AP cost totals

### DIFF
--- a/crates/rokbattles-api/src/db/reports_store.rs
+++ b/crates/rokbattles-api/src/db/reports_store.rs
@@ -304,7 +304,7 @@ impl ReportsStore {
 
         let precomputed_kahar_treasure_models = vec![
             IndexModel::builder()
-                .keys(doc! { "key": 1 })
+                .keys(doc! { "kind": 1 })
                 .options(IndexOptions::builder().unique(true).build())
                 .build(),
         ];

--- a/crates/rokbattles-api/src/routes/loot_explorer/mod.rs
+++ b/crates/rokbattles-api/src/routes/loot_explorer/mod.rs
@@ -82,7 +82,7 @@ pub async fn get_kahar_treasure(
 ) -> Result<impl IntoResponse, ApiError> {
     let item = fetch_document::<RawKaharTreasureDocument, KaharTreasureDocument>(
         state.reports_store.precomputed_kahar_treasure_collection(),
-        doc! { "key": "all" },
+        doc! { "kind": "all" },
     )
     .await?
     .ok_or_else(|| ApiError::not_found("Kahar treasure data not found"))?;
@@ -338,7 +338,7 @@ impl From<RawBaulurDocument> for BaulurDocument {
 
 #[derive(Debug, Clone, Deserialize)]
 struct RawKaharTreasureDocument {
-    key: String,
+    kind: String,
     loot: Vec<LootDrop>,
     totals: KaharTreasureTotals,
     refreshed_at: DateTime,
@@ -347,7 +347,7 @@ struct RawKaharTreasureDocument {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct KaharTreasureDocument {
-    key: String,
+    kind: String,
     loot: Vec<LootDrop>,
     totals: KaharTreasureTotals,
     refreshed_at: String,
@@ -356,7 +356,7 @@ struct KaharTreasureDocument {
 impl From<RawKaharTreasureDocument> for KaharTreasureDocument {
     fn from(value: RawKaharTreasureDocument) -> Self {
         Self {
-            key: value.key,
+            kind: value.kind,
             loot: value.loot,
             totals: value.totals,
             refreshed_at: date_time_to_string(value.refreshed_at),
@@ -407,6 +407,7 @@ struct BaulurTotals {
 #[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 struct KaharTreasureTotals {
     results: i64,
+    ap_used: i64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -489,7 +490,7 @@ mod tests {
     #[test]
     fn kahar_treasure_document_maps_precomputed_shape_to_api_shape() {
         let raw = from_document::<RawKaharTreasureDocument>(doc! {
-            "key": "all",
+            "kind": "all",
             "loot": [
                 {
                     "type": 2,
@@ -501,15 +502,16 @@ mod tests {
                     "average_quantity": 5.0,
                 },
             ],
-            "totals": { "results": 17_i64 },
+            "totals": { "results": 17_i64, "ap_used": 3_400_i64 },
             "refreshed_at": DateTime::from_millis(1_783_480_000_000),
         })
         .expect("raw Kahar treasure document");
 
         let document = KaharTreasureDocument::from(raw);
 
-        assert_eq!(document.key, "all");
+        assert_eq!(document.kind, "all");
         assert_eq!(document.totals.results, 17);
+        assert_eq!(document.totals.ap_used, 3_400);
         assert_eq!(document.loot.len(), 1);
         assert!(document.refreshed_at.starts_with("2026-07-08T"));
     }

--- a/crates/rokbattles-jobs/src/precompute_kahar_treasure.rs
+++ b/crates/rokbattles-jobs/src/precompute_kahar_treasure.rs
@@ -12,6 +12,7 @@ use rokbattles_api::db::ReportsStore;
 use crate::error::JobsError;
 
 const KAHAR_TREASURE_AGGREGATE_KEY: &str = "all";
+const KAHAR_AP_COST: i64 = 200;
 
 /// Counts from one Kahar treasure precompute run.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -33,7 +34,7 @@ pub async fn precompute_kahar_treasure_data(
     let document = build_precomputed_document(&aggregate, refreshed_at);
 
     precomputed
-        .replace_one(doc! { "key": KAHAR_TREASURE_AGGREGATE_KEY }, document)
+        .replace_one(doc! { "kind": KAHAR_TREASURE_AGGREGATE_KEY }, document)
         .upsert(true)
         .await?;
     stats.documents_written += 1;
@@ -98,10 +99,11 @@ fn build_precomputed_document(stats: &AggregateStats, refreshed_at: DateTime) ->
         .collect::<Vec<_>>();
 
     doc! {
-        "key": KAHAR_TREASURE_AGGREGATE_KEY,
+        "kind": KAHAR_TREASURE_AGGREGATE_KEY,
         "loot": loot,
         "totals": {
             "results": usize_to_i64(stats.results),
+            "ap_used": usize_to_i64(stats.results).saturating_mul(KAHAR_AP_COST),
         },
         "refreshed_at": refreshed_at,
     }
@@ -260,7 +262,7 @@ mod tests {
 
         let document = build_precomputed_document(&stats, DateTime::now());
 
-        assert_eq!(document.get_str("key"), Ok(KAHAR_TREASURE_AGGREGATE_KEY));
+        assert_eq!(document.get_str("kind"), Ok(KAHAR_TREASURE_AGGREGATE_KEY));
         assert!(!document.contains_key("data"));
         assert!(!document.contains_key("loot_pools"));
         assert_eq!(
@@ -268,7 +270,7 @@ mod tests {
             Ok(2)
         );
         let totals = document.get_document("totals").expect("totals");
-        assert!(!totals.contains_key("ap_used"));
+        assert_eq!(totals.get_i64("ap_used"), Ok(400));
         assert!(!totals.contains_key("honor_points_gained"));
         assert!(!totals.contains_key("xp_gained"));
         let loot = document.get_array("loot").expect("loot");

--- a/packages/site/src/components/loot-explorer/kahar-treasure-explorer.tsx
+++ b/packages/site/src/components/loot-explorer/kahar-treasure-explorer.tsx
@@ -57,11 +57,14 @@ export function KaharTreasureExplorer() {
     <LootExplorerLayout active="kahars-treasure">
       <LootExplorerSummary
         generatedAt={item?.refreshedAt}
-        items={[{ label: t("Results"), value: item?.totals.results ?? 0 }]}
+        items={[
+          { label: t("Results"), value: item?.totals.results ?? 0 },
+          { label: t("AP used"), value: item?.totals.apUsed ?? 0 },
+        ]}
       />
       <section className="space-y-3">
         <div>
-          <Subheading>{t("Kahar's Treasure")}</Subheading>
+          <Subheading>{t("Kahar the Hidden")}</Subheading>
         </div>
         <LootTable loot={item?.loot ?? []} locale={locale} />
       </section>

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -382,7 +382,6 @@ msgstr "Baulurs"
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr "Kahar's Treasure"
@@ -450,6 +449,7 @@ msgstr "Results"
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr "AP used"
 
@@ -668,6 +668,10 @@ msgstr "This reward tier has been seen {count, plural, one {# time} other {# tim
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
 msgstr "n/a"
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
+msgstr "Kahar the Hidden"
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 #: src/components/platform-layout.tsx

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -391,7 +391,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -459,6 +458,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -676,6 +676,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -382,7 +382,6 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -450,6 +449,7 @@ msgstr ""
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 msgid "r8aMgv"
 msgstr ""
 
@@ -667,6 +667,10 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
+msgstr ""
+
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
+msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/lib/loot-explorer/api.ts
+++ b/packages/site/src/lib/loot-explorer/api.ts
@@ -79,10 +79,11 @@ export type BaulurLootDocument = {
 };
 
 export type KaharTreasureLootDocument = {
-  key: string;
+  kind: string;
   loot: LootDrop[];
   totals: {
     results: number;
+    apUsed: number;
   };
   refreshedAt: string;
 };


### PR DESCRIPTION
## Summary

Corrects the Kahar aggregate to use kind, accounts for the 200 AP cost per result, and displays AP usage and the Kahar the Hidden name in Loot Explorer.

## Validation

- Rust formatting, Clippy, targeted tests, Biome, and site TypeScript checks pass.
