### PR TITLE
fix: add personal Kahar AP costs

### DIFF
--- a/crates/rokbattles-api/src/routes/governor/loot/aggregate.rs
+++ b/crates/rokbattles-api/src/routes/governor/loot/aggregate.rs
@@ -15,6 +15,8 @@ use crate::{
     time_utils::normalize_bson_timestamp_millis,
 };
 
+const KAHAR_AP_COST: i64 = 200;
+
 #[derive(Debug, Default)]
 struct LootCategoryAggregate {
     reports: i64,
@@ -186,6 +188,7 @@ pub(crate) fn aggregate_personal_kahar_treasure_loot(
         }
 
         add_report(&mut aggregate);
+        aggregate.ap_used += KAHAR_AP_COST;
         add_loot(&mut aggregate, mail.loot.as_deref().unwrap_or_default());
     }
 
@@ -683,7 +686,7 @@ mod tests {
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].reports, 2);
         assert_eq!(groups[0].loot_total, 95_000);
-        assert_eq!(groups[0].ap_used, 0);
+        assert_eq!(groups[0].ap_used, 400);
         assert_eq!(groups[0].honor_gained, 0);
         assert_eq!(groups[0].xp_gained, 0);
     }

--- a/packages/site/src/components/account-loot/personal-loot-content.tsx
+++ b/packages/site/src/components/account-loot/personal-loot-content.tsx
@@ -175,8 +175,15 @@ export function PersonalLootContent({ active, endpoint, datasetLocale }: Persona
   }
 
   const summaryItems = (() => {
-    if (active === "baulurs" || active === "kahars-treasure") {
+    if (active === "baulurs") {
       return [{ label: t("Results"), value: data?.totals.results ?? 0 }];
+    }
+
+    if (active === "kahars-treasure") {
+      return [
+        { label: t("Results"), value: data?.totals.results ?? 0 },
+        { label: t("AP used"), value: data?.totals.apUsed ?? 0 },
+      ];
     }
 
     const items = [


### PR DESCRIPTION
## Summary

Adds the 200 AP cost per Kahar result to personal loot aggregation and displays the AP total in My Loot.

## Validation

- Rust formatting, Clippy, targeted tests, Biome, and site TypeScript checks pass.
