### PR TITLE
fix: restore Kahar's Treasure label

### DIFF
--- a/packages/site/src/components/loot-explorer/kahar-treasure-explorer.tsx
+++ b/packages/site/src/components/loot-explorer/kahar-treasure-explorer.tsx
@@ -64,7 +64,7 @@ export function KaharTreasureExplorer() {
       />
       <section className="space-y-3">
         <div>
-          <Subheading>{t("Kahar the Hidden")}</Subheading>
+          <Subheading>{t("Kahar's Treasure")}</Subheading>
         </div>
         <LootTable loot={item?.loot ?? []} locale={locale} />
       </section>

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -382,6 +382,7 @@ msgstr "Baulurs"
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr "Kahar's Treasure"
@@ -668,10 +669,6 @@ msgstr "This reward tier has been seen {count, plural, one {# time} other {# tim
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
 msgstr "n/a"
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
-msgstr "Kahar the Hidden"
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 #: src/components/platform-layout.tsx

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -391,6 +391,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -676,10 +677,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -382,6 +382,7 @@ msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
 msgid "c5aU-N"
 msgstr ""
@@ -667,10 +668,6 @@ msgstr ""
 
 #: src/components/loot-explorer/fort-explorer.tsx
 msgid "pFZfPa"
-msgstr ""
-
-#: src/components/loot-explorer/kahar-treasure-explorer.tsx
-msgid "Tpg7c5"
 msgstr ""
 
 #: src/components/loot-explorer/loot-explorer-layout.tsx


### PR DESCRIPTION
## Summary

Restores the Loot Explorer heading to “Kahar’s Treasure”. My Loot already retained the correct label and does not require a change.

## Validation

- Regenerated message catalogs.
- Biome and site TypeScript checks pass.
