### PR TITLE
feat: add Karuak Ceremony loot views

### DIFF
--- a/crates/rokbattles-api/src/routes/governor/loot/aggregate.rs
+++ b/crates/rokbattles-api/src/routes/governor/loot/aggregate.rs
@@ -7,7 +7,7 @@ use super::{
     query::{BarbarianLootNpc, BarbarianLootRequest, BaulurLootNpc, FortLootNpc, FortLootRequest},
     store::{
         BarbarianFortMailDocument, BattleMailDocument, BaulurMailDocument,
-        KaharTreasureMailDocument, LootEntryDocument,
+        KaharTreasureMailDocument, KaruakCeremonyMailDocument, LootEntryDocument,
     },
     types::{LootRewardAggregateResponse, PersonalLootGroupResponse},
 };
@@ -190,6 +190,36 @@ pub(crate) fn aggregate_personal_kahar_treasure_loot(
         add_report(&mut aggregate);
         aggregate.ap_used += KAHAR_AP_COST;
         add_loot(&mut aggregate, mail.loot.as_deref().unwrap_or_default());
+    }
+
+    into_personal_groups(HashMap::from([(None, aggregate)]))
+}
+
+pub(crate) fn aggregate_personal_karuak_ceremony_loot(
+    mails: Vec<KaruakCeremonyMailDocument>,
+    governor_id: i64,
+    range: &GovernorDateRange,
+) -> Vec<PersonalLootGroupResponse> {
+    let mut aggregate = LootCategoryAggregate::default();
+
+    for mail in mails {
+        let Some(event_time_millis) = extract_event_time_millis(
+            mail.metadata.as_ref().and_then(|meta| meta.mail_time.as_ref()),
+        ) else {
+            continue;
+        };
+        if event_time_millis < range.start_millis || event_time_millis >= range.end_millis {
+            continue;
+        }
+
+        for participant in mail.participants.unwrap_or_default() {
+            if participant.player_id.as_ref().and_then(parse_i64_loose) != Some(governor_id) {
+                continue;
+            }
+            add_report(&mut aggregate);
+            add_loot(&mut aggregate, participant.loot.as_deref().unwrap_or_default());
+            break;
+        }
     }
 
     into_personal_groups(HashMap::from([(None, aggregate)]))

--- a/crates/rokbattles-api/src/routes/governor/loot/mod.rs
+++ b/crates/rokbattles-api/src/routes/governor/loot/mod.rs
@@ -11,14 +11,16 @@ use self::{
     aggregate::{
         aggregate_personal_barbarian_loot, aggregate_personal_baulur_loot,
         aggregate_personal_fort_loot, aggregate_personal_kahar_treasure_loot,
+        aggregate_personal_karuak_ceremony_loot,
     },
     query::{
         parse_barbarian_loot_request, parse_baulur_loot_request, parse_fort_loot_request,
-        parse_kahar_treasure_loot_request,
+        parse_kahar_treasure_loot_request, parse_karuak_ceremony_loot_request,
     },
     store::{
         fetch_barbarian_battle_mails, fetch_barbarian_fort_mails, fetch_baulur_mails,
-        fetch_kahar_treasure_mails, fetch_marauder_battle_mails, fetch_marauder_encampment_mails,
+        fetch_kahar_treasure_mails, fetch_karuak_ceremony_mails, fetch_marauder_battle_mails,
+        fetch_marauder_encampment_mails,
     },
     types::PersonalLootResponse,
 };
@@ -78,6 +80,34 @@ pub async fn get_kahars_treasure(
     let time_match = request.range.build_mail_time_match();
     let mails = fetch_kahar_treasure_mails(&state, &mail_receiver, &time_match).await?;
     let groups = aggregate_personal_kahar_treasure_loot(mails, &request.range);
+    let response = PersonalLootResponse::new(request.range.start, request.range.end, groups);
+
+    Ok((StatusCode::OK, [("Cache-Control", "no-store")], Json(response)))
+}
+
+/// Returns personal Karuak Ceremony loot aggregates for a claimed governor.
+pub async fn get_karuak_ceremony(
+    State(state): State<Arc<AppState>>,
+    Path(governor_id_raw): Path<String>,
+    Query(params): Query<HashMap<String, String>>,
+    session: AuthenticatedSession,
+) -> Result<impl IntoResponse, ApiError> {
+    let governor_id = parse_governor_id_param(&governor_id_raw)?;
+    let request = parse_karuak_ceremony_loot_request(&params)?;
+
+    ensure_governor_claim_for_user(&state, &session.user.discord_id, governor_id).await?;
+
+    let mail_receiver = format!("player_{governor_id}");
+    let time_match = request.range.build_mail_time_match();
+    let mails = fetch_karuak_ceremony_mails(
+        &state,
+        &mail_receiver,
+        governor_id,
+        request.boss_id,
+        &time_match,
+    )
+    .await?;
+    let groups = aggregate_personal_karuak_ceremony_loot(mails, governor_id, &request.range);
     let response = PersonalLootResponse::new(request.range.start, request.range.end, groups);
 
     Ok((StatusCode::OK, [("Cache-Control", "no-store")], Json(response)))

--- a/crates/rokbattles-api/src/routes/governor/loot/query.rs
+++ b/crates/rokbattles-api/src/routes/governor/loot/query.rs
@@ -48,6 +48,20 @@ pub(crate) struct KaharTreasureLootRequest {
     pub range: GovernorDateRange,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct KaruakCeremonyLootRequest {
+    pub range: GovernorDateRange,
+    pub boss_id: i64,
+}
+
+const KARUAK_BOSSES: [(&str, i64); 5] = [
+    ("bladefist-andaal", 30_001),
+    ("bearkeeper-lukor", 30_002),
+    ("bruteshield-murdos", 30_003),
+    ("warmender-pache", 30_004),
+    ("solon-por", 30_005),
+];
+
 pub(crate) fn parse_barbarian_loot_request(
     params: &HashMap<String, String>,
 ) -> Result<BarbarianLootRequest, ApiError> {
@@ -100,6 +114,19 @@ pub(crate) fn parse_kahar_treasure_loot_request(
 ) -> Result<KaharTreasureLootRequest, ApiError> {
     let range = parse_default_governor_date_range(params)?;
     Ok(KaharTreasureLootRequest { range })
+}
+
+pub(crate) fn parse_karuak_ceremony_loot_request(
+    params: &HashMap<String, String>,
+) -> Result<KaruakCeremonyLootRequest, ApiError> {
+    let range = parse_default_governor_date_range(params)?;
+    let selected = params.get("type").map(String::as_str).unwrap_or(KARUAK_BOSSES[0].0);
+    let boss_id = KARUAK_BOSSES
+        .iter()
+        .find_map(|(key, id)| (*key == selected).then_some(*id))
+        .ok_or_else(|| ApiError::bad_request("Invalid type"))?;
+
+    Ok(KaruakCeremonyLootRequest { range, boss_id })
 }
 
 fn parse_levels(params: &HashMap<String, String>, key: &str) -> Result<Vec<i32>, ApiError> {
@@ -200,6 +227,16 @@ mod tests {
 
         assert_eq!(request.range.start, "2025-02-03");
         assert_eq!(request.range.end, "2025-02-04");
+    }
+
+    #[test]
+    fn parse_karuak_ceremony_loot_request_selects_each_boss() {
+        for (key, boss_id) in KARUAK_BOSSES {
+            let mut params = date_params();
+            params.insert("type".to_string(), key.to_string());
+            let request = parse_karuak_ceremony_loot_request(&params).expect("request");
+            assert_eq!(request.boss_id, boss_id);
+        }
     }
 
     #[test]

--- a/crates/rokbattles-api/src/routes/governor/loot/store.rs
+++ b/crates/rokbattles-api/src/routes/governor/loot/store.rs
@@ -109,6 +109,14 @@ pub(crate) struct KaharTreasureMailDocument {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct KaruakCeremonyMailDocument {
+    #[serde(default)]
+    pub metadata: Option<MailMetadataDocument>,
+    #[serde(default)]
+    pub participants: Option<Vec<BaulurParticipantDocument>>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 pub(crate) struct BaulurNpcDocument {
     #[serde(default, rename = "type")]
     pub npc_type: Option<Bson>,
@@ -286,6 +294,38 @@ pub(crate) async fn fetch_kahar_treasure_mails(
 
     fetch_collection_documents(
         state.reports_store.system_kahar_treasure_collection(),
+        filter,
+        options,
+    )
+    .await
+}
+
+pub(crate) async fn fetch_karuak_ceremony_mails(
+    state: &Arc<AppState>,
+    mail_receiver: &str,
+    governor_id: i64,
+    boss_id: i64,
+    time_match: &Document,
+) -> Result<Vec<KaruakCeremonyMailDocument>, ApiError> {
+    let options = FindOptions::builder()
+        .projection(doc! {
+            "_id": 0,
+            "metadata.mail_time": 1,
+            "participants.player_id": 1,
+            "participants.loot": 1,
+        })
+        .build();
+    let filter = doc! {
+        "$and": [
+            { "metadata.mail_receiver": mail_receiver },
+            { "boss.id": boss_id },
+            { "participants": { "$elemMatch": { "player_id": governor_id } } },
+            time_match.clone(),
+        ]
+    };
+
+    fetch_collection_documents(
+        state.reports_store.event_member_loot_report_collection(),
         filter,
         options,
     )

--- a/crates/rokbattles-api/src/routes/governor/mod.rs
+++ b/crates/rokbattles-api/src/routes/governor/mod.rs
@@ -26,6 +26,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/{governor_id}/loot/barbarians", get(loot::get_barbarians))
         .route("/{governor_id}/loot/barbarian-forts", get(loot::get_barbarian_forts))
         .route("/{governor_id}/loot/baulurs", get(loot::get_baulurs))
+        .route("/{governor_id}/loot/karuak-ceremony", get(loot::get_karuak_ceremony))
         .route("/{governor_id}/loot/kahars-treasure", get(loot::get_kahars_treasure))
         .route("/{governor_id}/resources", get(resources::get))
         .route("/{governor_id}/pairings", get(pairings::get))

--- a/crates/rokbattles-api/src/routes/loot_explorer/mod.rs
+++ b/crates/rokbattles-api/src/routes/loot_explorer/mod.rs
@@ -76,6 +76,26 @@ pub async fn get_baulurs(
     ))
 }
 
+/// Returns precomputed Karuak Ceremony boss loot documents.
+pub async fn get_karuak_ceremony(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let request = parse_kind_request(&params)?;
+    let items = fetch_documents::<RawKaruakCeremonyDocument, KaruakCeremonyDocument>(
+        state.reports_store.precomputed_karuak_ceremony_collection(),
+        request.filter(),
+        doc! { "kind": 1 },
+    )
+    .await?;
+
+    Ok((
+        StatusCode::OK,
+        [("Cache-Control", "public, max-age=3600")],
+        Json(KaruakCeremonyResponse { items }),
+    ))
+}
+
 /// Returns precomputed Kahar treasure loot.
 pub async fn get_kahar_treasure(
     State(state): State<Arc<AppState>>,
@@ -240,6 +260,12 @@ struct BaulurResponse {
     items: Vec<BaulurDocument>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct KaruakCeremonyResponse {
+    items: Vec<KaruakCeremonyDocument>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct RawBarbarianDocument {
     kind: i32,
@@ -337,6 +363,34 @@ impl From<RawBaulurDocument> for BaulurDocument {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct RawKaruakCeremonyDocument {
+    kind: i32,
+    loot: Vec<LootDrop>,
+    totals: KaruakCeremonyTotals,
+    refreshed_at: DateTime,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct KaruakCeremonyDocument {
+    kind: i32,
+    loot: Vec<LootDrop>,
+    totals: KaruakCeremonyTotals,
+    refreshed_at: String,
+}
+
+impl From<RawKaruakCeremonyDocument> for KaruakCeremonyDocument {
+    fn from(value: RawKaruakCeremonyDocument) -> Self {
+        Self {
+            kind: value.kind,
+            loot: value.loot,
+            totals: value.totals,
+            refreshed_at: date_time_to_string(value.refreshed_at),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct RawKaharTreasureDocument {
     kind: String,
     loot: Vec<LootDrop>,
@@ -400,6 +454,12 @@ struct FortTotals {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
 struct BaulurTotals {
+    results: i64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+struct KaruakCeremonyTotals {
     results: i64,
 }
 

--- a/crates/rokbattles-api/src/routes/mod.rs
+++ b/crates/rokbattles-api/src/routes/mod.rs
@@ -24,6 +24,7 @@ fn v1_router() -> Router<Arc<AppState>> {
         .route("/global/loot-explorer/barbarians", get(loot_explorer::get_barbarians))
         .route("/global/loot-explorer/barbarian-forts", get(loot_explorer::get_barbarian_forts))
         .route("/global/loot-explorer/baulurs", get(loot_explorer::get_baulurs))
+        .route("/global/loot-explorer/karuak-ceremony", get(loot_explorer::get_karuak_ceremony))
         .route("/global/loot-explorer/kahars-treasure", get(loot_explorer::get_kahar_treasure))
         .route("/report/battle/{id}", get(reports::battle::get_by_id))
         .route("/report/duelbattle2/{id}", get(reports::duelbattle2::get_by_id))

--- a/packages/site/src/app/(legacy)/account/loot/karuak-ceremony/page.tsx
+++ b/packages/site/src/app/(legacy)/account/loot/karuak-ceremony/page.tsx
@@ -1,0 +1,22 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { PersonalLootContent } from "@/components/account-loot/personal-loot-content";
+import { defaultLocale, isLocale, languageCookieName } from "@/i18n/config";
+import { requireCurrentUserWithGovernor } from "@/lib/require-user";
+
+export default async function Page() {
+  const user = await requireCurrentUserWithGovernor();
+  if (user.claimedGovernors[0]?.governorId == null) {
+    redirect("/account/settings/governors");
+  }
+
+  const localeFromCookie = (await cookies()).get(languageCookieName)?.value;
+  const datasetLocale = isLocale(localeFromCookie) ? localeFromCookie : defaultLocale;
+  return (
+    <PersonalLootContent
+      active="karuak-ceremony"
+      endpoint="karuak-ceremony"
+      datasetLocale={datasetLocale}
+    />
+  );
+}

--- a/packages/site/src/app/(legacy)/loot-explorer/karuak-ceremony/page.tsx
+++ b/packages/site/src/app/(legacy)/loot-explorer/karuak-ceremony/page.tsx
@@ -1,0 +1,7 @@
+import { KaruakCeremonyExplorer } from "@/components/loot-explorer/karuak-ceremony-explorer";
+import { resolveLootExplorerSearchParams } from "@/lib/loot-explorer/search-params";
+
+export default async function Page({ searchParams }: PageProps<"/loot-explorer/karuak-ceremony">) {
+  const parsed = await resolveLootExplorerSearchParams(searchParams);
+  return <KaruakCeremonyExplorer selectedType={parsed.type} />;
+}

--- a/packages/site/src/app/sitemap.ts
+++ b/packages/site/src/app/sitemap.ts
@@ -12,6 +12,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     "/loot-explorer/barbarians",
     "/loot-explorer/barbarian-forts",
     "/loot-explorer/baulurs",
+    "/loot-explorer/karuak-ceremony",
     "/loot-explorer/kahars-treasure",
     "/legal",
   ];

--- a/packages/site/src/components/account-loot/account-loot-layout.tsx
+++ b/packages/site/src/components/account-loot/account-loot-layout.tsx
@@ -6,12 +6,18 @@ import { useSearchParams } from "next/navigation";
 import { useExtracted } from "next-intl";
 import { Heading } from "@/components/ui/heading";
 
-export type AccountLootSection = "barbarians" | "barbarian-forts" | "baulurs" | "kahars-treasure";
+export type AccountLootSection =
+  | "barbarians"
+  | "barbarian-forts"
+  | "baulurs"
+  | "karuak-ceremony"
+  | "kahars-treasure";
 
 const sections: Array<{ key: AccountLootSection; href: string }> = [
   { key: "barbarians", href: "/account/loot/barbarians" },
   { key: "barbarian-forts", href: "/account/loot/barbarian-forts" },
   { key: "baulurs", href: "/account/loot/baulurs" },
+  { key: "karuak-ceremony", href: "/account/loot/karuak-ceremony" },
   { key: "kahars-treasure", href: "/account/loot/kahars-treasure" },
 ];
 
@@ -36,6 +42,7 @@ export function AccountLootLayout({
     barbarians: t("Barbarians"),
     "barbarian-forts": t("Barbarian Forts"),
     baulurs: t("Baulurs"),
+    "karuak-ceremony": t("Karuak Ceremony"),
     "kahars-treasure": t("Kahar's Treasure"),
   };
 
@@ -46,7 +53,7 @@ export function AccountLootLayout({
           <Heading>{t("My Loot")}</Heading>
           <p className="max-w-xl text-sm/6 text-zinc-600 dark:text-zinc-400">
             {t(
-              "Explore loot that you have received from Barbarians, Barbarian Forts, Baulurs, and Kahar's Treasure."
+              "Explore loot that you have received from Barbarians, Barbarian Forts, Baulurs, Karuak Ceremony, and Kahar's Treasure."
             )}
           </p>
         </div>

--- a/packages/site/src/components/account-loot/personal-loot-content.tsx
+++ b/packages/site/src/components/account-loot/personal-loot-content.tsx
@@ -21,6 +21,7 @@ import {
 import { formatLocalDateInput } from "@/lib/datetime";
 import { buildLootRewardRows } from "@/lib/loot/reward-rows";
 import type { LootExplorerOption } from "@/lib/loot-explorer/catalog";
+import { karuakBosses } from "@/lib/loot-explorer/catalog";
 import type { PersonalLootGroup } from "@/lib/types/loot";
 import { GovernorContext } from "@/providers/governor-context";
 
@@ -121,6 +122,24 @@ export function PersonalLootContent({ active, endpoint, datasetLocale }: Persona
       };
     }
 
+    if (active === "karuak-ceremony") {
+      const labels = new Map([
+        ["bladefist-andaal", t("Bladefist Andaal")],
+        ["bearkeeper-lukor", t("Bearkeeper Lukor")],
+        ["bruteshield-murdos", t("Bruteshield Murdos")],
+        ["warmender-pache", t("Warmender Pache")],
+        ["solon-por", t("Solon Por")],
+      ]);
+      return {
+        defaultType: karuakBosses[0].key,
+        typeOptions: karuakBosses.map((boss) => ({
+          value: boss.key,
+          label: labels.get(boss.key) ?? boss.label,
+        })),
+        showLevelFilter: false,
+      };
+    }
+
     return {
       defaultType: "barbarians",
       typeOptions: [
@@ -175,7 +194,7 @@ export function PersonalLootContent({ active, endpoint, datasetLocale }: Persona
   }
 
   const summaryItems = (() => {
-    if (active === "baulurs") {
+    if (active === "baulurs" || active === "karuak-ceremony") {
       return [{ label: t("Results"), value: data?.totals.results ?? 0 }];
     }
 

--- a/packages/site/src/components/loot-explorer/karuak-ceremony-explorer.tsx
+++ b/packages/site/src/components/loot-explorer/karuak-ceremony-explorer.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useExtracted, useLocale } from "next-intl";
+import { useEffect, useState } from "react";
+import { Subheading } from "@/components/ui/heading";
+import { fetchLootExplorerItems, type KaruakCeremonyLootDocument } from "@/lib/loot-explorer/api";
+import { findKaruakBoss, karuakBosses } from "@/lib/loot-explorer/catalog";
+import { LootExplorerFilters } from "./loot-explorer-filters";
+import { LootExplorerLayout } from "./loot-explorer-layout";
+import { LootExplorerStatus } from "./loot-explorer-status";
+import { LootExplorerSummary } from "./loot-explorer-summary";
+import { LootTable } from "./loot-table";
+
+export function KaruakCeremonyExplorer({ selectedType }: { selectedType?: string }) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const [items, setItems] = useState<KaruakCeremonyLootDocument[]>([]);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  useEffect(() => {
+    let ignore = false;
+    fetchLootExplorerItems<KaruakCeremonyLootDocument>("karuak-ceremony")
+      .then((response) => {
+        if (!ignore) {
+          setItems(response.items);
+          setStatus("ready");
+        }
+      })
+      .catch(() => {
+        if (!ignore) setStatus("error");
+      });
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  if (status === "loading") {
+    return (
+      <LootExplorerStatus active="karuak-ceremony" message={t("Loading loot explorer data...")} />
+    );
+  }
+  if (status === "error") {
+    return (
+      <LootExplorerStatus
+        active="karuak-ceremony"
+        message={t("Failed to load loot explorer data.")}
+      />
+    );
+  }
+
+  const boss = findKaruakBoss(selectedType, items);
+  const item = items.find((candidate) => candidate.kind === boss.kind);
+  const labels = new Map([
+    ["bladefist-andaal", t("Bladefist Andaal")],
+    ["bearkeeper-lukor", t("Bearkeeper Lukor")],
+    ["bruteshield-murdos", t("Bruteshield Murdos")],
+    ["warmender-pache", t("Warmender Pache")],
+    ["solon-por", t("Solon Por")],
+  ]);
+
+  return (
+    <LootExplorerLayout active="karuak-ceremony">
+      <LootExplorerFilters
+        typeOptions={karuakBosses.map((option) => ({
+          value: option.key,
+          label: labels.get(option.key) ?? option.label,
+        }))}
+        selectedType={boss.key}
+        showLevelFilter={false}
+      />
+      <LootExplorerSummary
+        generatedAt={item?.refreshedAt}
+        items={[{ label: t("Results"), value: item?.totals.results ?? 0 }]}
+      />
+      <section className="space-y-3">
+        <Subheading>{labels.get(boss.key) ?? boss.label}</Subheading>
+        <LootTable loot={item?.loot ?? []} locale={locale} />
+      </section>
+    </LootExplorerLayout>
+  );
+}

--- a/packages/site/src/components/loot-explorer/loot-explorer-layout.tsx
+++ b/packages/site/src/components/loot-explorer/loot-explorer-layout.tsx
@@ -3,12 +3,18 @@ import Link from "next/link";
 import { useExtracted } from "next-intl";
 import { Heading } from "@/components/ui/heading";
 
-export type LootExplorerSection = "barbarians" | "barbarian-forts" | "baulurs" | "kahars-treasure";
+export type LootExplorerSection =
+  | "barbarians"
+  | "barbarian-forts"
+  | "baulurs"
+  | "karuak-ceremony"
+  | "kahars-treasure";
 
 const sections: Array<{ key: LootExplorerSection; href: string }> = [
   { key: "barbarians", href: "/loot-explorer/barbarians" },
   { key: "barbarian-forts", href: "/loot-explorer/barbarian-forts" },
   { key: "baulurs", href: "/loot-explorer/baulurs" },
+  { key: "karuak-ceremony", href: "/loot-explorer/karuak-ceremony" },
   { key: "kahars-treasure", href: "/loot-explorer/kahars-treasure" },
 ];
 
@@ -24,6 +30,7 @@ export function LootExplorerLayout({
     barbarians: t("Barbarians"),
     "barbarian-forts": t("Barbarian Forts"),
     baulurs: t("Baulurs"),
+    "karuak-ceremony": t("Karuak Ceremony"),
     "kahars-treasure": t("Kahar's Treasure"),
   };
 

--- a/packages/site/src/hooks/use-personal-loot.ts
+++ b/packages/site/src/hooks/use-personal-loot.ts
@@ -4,7 +4,12 @@ import { useCallback, useEffect, useState } from "react";
 import { toDateInput, todayUtcStartMillis } from "@/lib/loot/date";
 import type { PersonalLootQueryResult } from "@/lib/types/loot";
 
-export type PersonalLootEndpoint = "barbarians" | "barbarian-forts" | "baulurs" | "kahars-treasure";
+export type PersonalLootEndpoint =
+  | "barbarians"
+  | "barbarian-forts"
+  | "baulurs"
+  | "karuak-ceremony"
+  | "kahars-treasure";
 
 type PersonalLootOptions = {
   governorId: number | null | undefined;

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr "Baulurs"
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr "Karuak Ceremony"
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,8 +398,8 @@ msgid "yF_GXb"
 msgstr "My Loot"
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
-msgstr "Explore loot that you have received from Barbarians, Barbarian Forts, Baulurs, and Kahar's Treasure."
+msgid "zwmya7"
+msgstr "Explore loot that you have received from Barbarians, Barbarian Forts, Baulurs, Karuak Ceremony, and Kahar's Treasure."
 
 #: src/components/account-loot/loot-breakdown-table.tsx
 msgid "HAlOn1"
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr "Miser Khaolak"
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr "Bladefist Andaal"
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr "Bearkeeper Lukor"
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr "Bruteshield Murdos"
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr "Warmender Pache"
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr "Solon Por"
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr "Marauders"
@@ -444,6 +474,7 @@ msgstr "Marauders"
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr "Results"
 
@@ -607,6 +638,7 @@ msgstr "Save"
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr "Loading loot explorer data..."
 
@@ -614,6 +646,7 @@ msgstr "Loading loot explorer data..."
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr "Failed to load loot explorer data."
 

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr "Guardar"
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -390,6 +390,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -402,7 +407,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -444,6 +449,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -453,6 +483,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -616,6 +647,7 @@ msgstr "Sauvegarder"
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -623,6 +655,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr "저장"
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -381,6 +381,11 @@ msgid "l7kWPA"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
+#: src/components/loot-explorer/loot-explorer-layout.tsx
+msgid "xRJGes"
+msgstr ""
+
+#: src/components/account-loot/account-loot-layout.tsx
 #: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
 #: src/components/loot-explorer/loot-explorer-layout.tsx
@@ -393,7 +398,7 @@ msgid "yF_GXb"
 msgstr ""
 
 #: src/components/account-loot/account-loot-layout.tsx
-msgid "en1tf5"
+msgid "zwmya7"
 msgstr ""
 
 #: src/components/account-loot/loot-breakdown-table.tsx
@@ -435,6 +440,31 @@ msgid "1j7NiE"
 msgstr ""
 
 #: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "SdCxJX"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "8_6Wn2"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "M3-BHu"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "HxOf0f"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
+msgid "tbfLQx"
+msgstr ""
+
+#: src/components/account-loot/personal-loot-content.tsx
 #: src/components/loot-explorer/barbarian-explorer.tsx
 msgid "4pFR10"
 msgstr ""
@@ -444,6 +474,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yaMHMB"
 msgstr ""
 
@@ -607,6 +638,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "sNAPQj"
 msgstr ""
 
@@ -614,6 +646,7 @@ msgstr ""
 #: src/components/loot-explorer/baulur-explorer.tsx
 #: src/components/loot-explorer/fort-explorer.tsx
 #: src/components/loot-explorer/kahar-treasure-explorer.tsx
+#: src/components/loot-explorer/karuak-ceremony-explorer.tsx
 msgid "yedWVm"
 msgstr ""
 

--- a/packages/site/src/lib/loot-explorer/api.ts
+++ b/packages/site/src/lib/loot-explorer/api.ts
@@ -88,7 +88,16 @@ export type KaharTreasureLootDocument = {
   refreshedAt: string;
 };
 
-type LootExplorerEndpoint = "barbarians" | "barbarian-forts" | "baulurs";
+export type KaruakCeremonyLootDocument = {
+  kind: number;
+  loot: LootDrop[];
+  totals: {
+    results: number;
+  };
+  refreshedAt: string;
+};
+
+type LootExplorerEndpoint = "barbarians" | "barbarian-forts" | "baulurs" | "karuak-ceremony";
 
 export async function fetchLootExplorerItems<T>(
   endpoint: LootExplorerEndpoint

--- a/packages/site/src/lib/loot-explorer/catalog.ts
+++ b/packages/site/src/lib/loot-explorer/catalog.ts
@@ -2,6 +2,7 @@ import type {
   BarbarianFortLootDocument,
   BarbarianLootDocument,
   BaulurLootDocument,
+  KaruakCeremonyLootDocument,
 } from "@/lib/loot-explorer/api";
 
 export type LootExplorerOption = {
@@ -60,6 +61,14 @@ export const baulurFamilies = [
   { key: "miser-khaolak", label: "Miser Khaolak", kind: 102_000_063 },
 ] as const;
 
+export const karuakBosses = [
+  { key: "bladefist-andaal", label: "Bladefist Andaal", kind: 30_001 },
+  { key: "bearkeeper-lukor", label: "Bearkeeper Lukor", kind: 30_002 },
+  { key: "bruteshield-murdos", label: "Bruteshield Murdos", kind: 30_003 },
+  { key: "warmender-pache", label: "Warmender Pache", kind: 30_004 },
+  { key: "solon-por", label: "Solon Por", kind: 30_005 },
+] as const;
+
 export function findBarbarianFamily(
   key: string | undefined,
   items: BarbarianLootDocument[]
@@ -93,6 +102,17 @@ export function findBaulurFamily(key: string | undefined, items: BaulurLootDocum
   return (
     baulurFamilies.find((family) => items.some((item) => item.kind === family.kind)) ??
     baulurFamilies[0]
+  );
+}
+
+export function findKaruakBoss(key: string | undefined, items: KaruakCeremonyLootDocument[]) {
+  const requested = karuakBosses.find((boss) => boss.key === key);
+  if (requested && items.some((item) => item.kind === requested.kind)) {
+    return requested;
+  }
+
+  return (
+    karuakBosses.find((boss) => items.some((item) => item.kind === boss.kind)) ?? karuakBosses[0]
   );
 }
 


### PR DESCRIPTION
## Summary

- expose Karuak Ceremony loot through global and governor API routes
- add five-boss filters to Loot Explorer and My Loot
- add Karuak Ceremony tabs before Kahar's Treasure, with date filters for personal loot

## Validation

- `cargo test -p rokbattles-api`
- `pnpm --dir packages/site typecheck`
- `pnpm --dir packages/site build`
- `pnpm exec biome check packages/site/src crates/rokbattles-api/src`
