### PR TITLE
refactor: remove ingress lossless storage

### DIFF
--- a/crates/rokbattles-ingress/src/handlers.rs
+++ b/crates/rokbattles-ingress/src/handlers.rs
@@ -107,9 +107,6 @@ pub async fn upload(
         let compressed = compress_mail_value(&decoded, state.config.zstd_level)?;
         let now = DateTime::now();
 
-        let lossless_doc = decode_lossless_doc(&buffer)?;
-        let lossless_compressed = compress_mail_value(&lossless_doc, state.config.zstd_level)?;
-
         match action {
             UploadAction::Insert => {
                 let raw_doc = doc! {
@@ -129,23 +126,6 @@ pub async fn upload(
                     .insert_raw(raw_doc)
                     .await
                     .map_err(|error| ApiError::database(error.to_string()))?;
-
-                let lossless_doc = doc! {
-                    "mail_id": &mail_id,
-                    "mail_attack_count": attack_count,
-                    "user_agent": &user_agent,
-                    "mail_value": Bson::Binary(Binary {
-                        subtype: BinarySubtype::Generic,
-                        bytes: lossless_compressed,
-                    }),
-                    "createdAt": now,
-                    "updatedAt": now,
-                };
-                state
-                    .storage
-                    .insert_lossless(lossless_doc)
-                    .await
-                    .map_err(|error| ApiError::database(error.to_string()))?;
             }
             UploadAction::Update => {
                 let raw_update = doc! {
@@ -161,21 +141,6 @@ pub async fn upload(
                 state
                     .storage
                     .update_raw(&mail_id, raw_update)
-                    .await
-                    .map_err(|error| ApiError::database(error.to_string()))?;
-
-                let lossless_update = doc! {
-                    "mail_attack_count": attack_count,
-                    "user_agent": &user_agent,
-                    "mail_value": Bson::Binary(Binary {
-                        subtype: BinarySubtype::Generic,
-                        bytes: lossless_compressed,
-                    }),
-                    "updatedAt": now,
-                };
-                state
-                    .storage
-                    .update_lossless(&mail_id, lossless_update)
                     .await
                     .map_err(|error| ApiError::database(error.to_string()))?;
             }
@@ -461,12 +426,6 @@ fn compress_mail_value(decoded: &Value, zstd_level: i32) -> Result<Vec<u8>, ApiE
         serde_json::to_vec(decoded).map_err(|error| ApiError::internal(error.to_string()))?;
     zstd::stream::encode_all(Cursor::new(json), zstd_level)
         .map_err(|error| ApiError::internal(error.to_string()))
-}
-
-fn decode_lossless_doc(buffer: &[u8]) -> Result<Value, ApiError> {
-    let lossless = mail_decoder::decode_lossless(buffer)
-        .map_err(|error| ApiError::decode_failed(error.to_string()))?;
-    Ok(mail_decoder::lossless_to_json(&lossless))
 }
 
 #[cfg(test)]

--- a/crates/rokbattles-ingress/src/storage.rs
+++ b/crates/rokbattles-ingress/src/storage.rs
@@ -11,7 +11,6 @@ use rokbattles_bson::bson_to_i64;
 #[derive(Debug, Clone)]
 pub struct Storage {
     raw: Collection<Document>,
-    raw_lossless: Collection<Document>,
     compressed_raw: Collection<Document>,
 }
 
@@ -30,11 +29,7 @@ pub struct ExistingCompressedRawMail {
 impl Storage {
     /// Bind storage helpers to the configured database.
     pub fn new(db: mongodb::Database) -> Self {
-        Self {
-            raw: db.collection("mails_raw"),
-            raw_lossless: db.collection("mails_raw_lossless"),
-            compressed_raw: db.collection("g_rok_mails"),
-        }
+        Self { raw: db.collection("mails_raw"), compressed_raw: db.collection("g_rok_mails") }
     }
 
     /// Create indexes used by the upload paths.
@@ -44,8 +39,7 @@ impl Storage {
             .options(IndexOptions::builder().unique(true).build())
             .build();
 
-        self.raw.create_index(mail_id_index.clone()).await?;
-        self.raw_lossless.create_index(mail_id_index).await?;
+        self.raw.create_index(mail_id_index).await?;
 
         let compressed_mail_id_index = IndexModel::builder()
             .keys(doc! { "mail.id": 1 })
@@ -113,22 +107,6 @@ impl Storage {
     /// Update an existing raw mail document.
     pub async fn update_raw(&self, mail_id: &str, update: Document) -> mongodb::error::Result<()> {
         self.raw.update_one(doc! { "mail_id": mail_id }, doc! { "$set": update }).await?;
-        Ok(())
-    }
-
-    /// Insert a new lossless mail document.
-    pub async fn insert_lossless(&self, doc: Document) -> mongodb::error::Result<()> {
-        self.raw_lossless.insert_one(doc).await?;
-        Ok(())
-    }
-
-    /// Update an existing lossless mail document.
-    pub async fn update_lossless(
-        &self,
-        mail_id: &str,
-        update: Document,
-    ) -> mongodb::error::Result<()> {
-        self.raw_lossless.update_one(doc! { "mail_id": mail_id }, doc! { "$set": update }).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- stop writing lossless copies during ingress uploads
- remove ingress storage and indexing for `mails_raw_lossless`

## Validation

- `cargo test -p rokbattles-ingress --locked`
- `cargo clippy -p rokbattles-ingress --all-targets --locked -- -D warnings`
