### PR TITLE
fix(api): index Karuak loot and precompute queries

### DIFF
--- a/crates/rokbattles-api/src/db/reports_store.rs
+++ b/crates/rokbattles-api/src/db/reports_store.rs
@@ -234,6 +234,19 @@ impl ReportsStore {
             self.mails_barcanyonkillboss.create_index(model).await?;
         }
 
+        self.mails_eventmemberlootreport
+            .create_index(
+                IndexModel::builder()
+                    .keys(doc! {
+                        "metadata.mail_receiver": 1,
+                        "participants.player_id": 1,
+                        "boss.id": 1,
+                        "metadata.mail_time": -1,
+                    })
+                    .build(),
+            )
+            .await?;
+
         let rss_models = vec![
             IndexModel::builder()
                 .keys(doc! { "metadata.mail_receiver": 1, "metadata.mail_time": -1 })

--- a/crates/rokbattles-api/src/db/reports_store.rs
+++ b/crates/rokbattles-api/src/db/reports_store.rs
@@ -246,6 +246,9 @@ impl ReportsStore {
                     .build(),
             )
             .await?;
+        self.mails_eventmemberlootreport
+            .create_index(IndexModel::builder().keys(doc! { "boss.id": 1 }).build())
+            .await?;
 
         let rss_models = vec![
             IndexModel::builder()


### PR DESCRIPTION
Adds compound indexing for authenticated Karuak Ceremony personal loot queries and boss indexing for the scheduled precompute scan.

The existing unique `kind` index continues to cover loot explorer reads and precompute writes.

Validated with API and jobs checks and tests.
