### PR TITLE
fix(resources): narrow date filter columns

### DIFF
--- a/packages/site/src/components/account-resources/resources-filters-client.tsx
+++ b/packages/site/src/components/account-resources/resources-filters-client.tsx
@@ -87,7 +87,7 @@ export function ResourcesFiltersClient({
   };
 
   return (
-    <div className="grid gap-4 md:grid-cols-2" aria-busy={isPending ? "true" : undefined}>
+    <div className="grid gap-4 md:grid-cols-4" aria-busy={isPending ? "true" : undefined}>
       <Field className="space-y-2">
         <Label htmlFor="resources-start-date">{t("Start date")}</Label>
         <Input


### PR DESCRIPTION
## What changed

- changed the My Resources date-filter grid from two to four equal columns at medium widths and above
- kept the start and end date inputs in the first two tracks, leaving the last two tracks empty
- preserved the existing single-column mobile layout

## Why

The date inputs previously consumed half of the available row each. The requested layout gives each input one quarter of the row and reserves the remaining half for future or intentionally empty space.

## Validation

- `pnpm --filter @rokbattles/site typecheck`
- `pnpm exec biome check packages/site/src/components/account-resources/resources-filters-client.tsx`
- `git diff --check`

Runtime MCP verification was not available because this repository currently uses Next.js 16.2.10 and that workflow requires Next.js 16.3 or newer.
