### PR TITLE
fix(reports): align participant sections

### DIFF
--- a/packages/site/src/components/olympian-arena/duel-participant-card.tsx
+++ b/packages/site/src/components/olympian-arena/duel-participant-card.tsx
@@ -71,7 +71,7 @@ export function DuelParticipantCard({
   const showSecondary = hasCommander(secondary);
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="grid gap-5 lg:row-span-3 lg:grid-rows-subgrid">
       <div className="flex items-start gap-3">
         <GameAvatar
           avatarUrl={participant.avatarUrl || null}
@@ -96,7 +96,7 @@ export function DuelParticipantCard({
         </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="contents lg:block">
         {showPrimary || showSecondary ? (
           <div className="space-y-2">
             <Subheading>{t("Commanders")}</Subheading>
@@ -106,6 +106,8 @@ export function DuelParticipantCard({
             </div>
           </div>
         ) : null}
+      </div>
+      <div className="contents lg:block">
         {displayBuffs.length > 0 ? (
           <div className="space-y-2">
             <Subheading>{t("Troop Buffs")}</Subheading>

--- a/packages/site/src/components/olympian-arena/duel-report-entry-card.tsx
+++ b/packages/site/src/components/olympian-arena/duel-report-entry-card.tsx
@@ -34,7 +34,7 @@ export default function DuelReportEntryCard({ entry }: DuelEntryCardProps) {
         <DuelResultsChart results={battleResults} />
       </section>
 
-      <section className="grid gap-8 lg:grid-cols-2">
+      <section className="grid gap-8 lg:grid-cols-2 lg:gap-y-5">
         <DuelParticipantCard participant={sender} isWinner={outcome?.winner === "sender"} />
         <DuelParticipantCard participant={opponent} isWinner={outcome?.winner === "opponent"} />
       </section>

--- a/packages/site/src/components/report/report-entry-card.tsx
+++ b/packages/site/src/components/report/report-entry-card.tsx
@@ -44,7 +44,7 @@ export function ReportEntryCard({ entry }: ReportEntryCardProps) {
           <ReportBattleResultsChart results={battleResults} />
         </section>
       ) : null}
-      <section className="grid gap-8 lg:grid-cols-2">
+      <section className="grid gap-8 lg:grid-cols-2 lg:gap-y-5">
         <ReportParticipantCard participant={selfParticipant} showArtifacts={!omitArtifacts} />
         <ReportParticipantCard participant={enemyParticipant} showArtifacts={!omitArtifacts} />
       </section>

--- a/packages/site/src/components/report/report-participant-card.tsx
+++ b/packages/site/src/components/report/report-participant-card.tsx
@@ -48,7 +48,7 @@ export function ReportParticipantCard({
   const showSecondary = hasCommander(secondaryCommander);
 
   return (
-    <div className="flex flex-col gap-5">
+    <div className="grid gap-5 lg:row-span-6 lg:grid-rows-subgrid">
       <div className="flex items-start gap-3">
         <GameAvatar
           avatarUrl={participant?.avatar_url ?? null}
@@ -69,7 +69,7 @@ export function ReportParticipantCard({
         </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="contents lg:block">
         {showPrimary || showSecondary ? (
           <div className="space-y-2">
             <Subheading>{t("Commanders")}</Subheading>
@@ -82,9 +82,17 @@ export function ReportParticipantCard({
             </div>
           </div>
         ) : null}
+      </div>
+      <div className="contents lg:block">
         <ReportEquipmentSection tokens={equipmentTokens} />
+      </div>
+      <div className="contents lg:block">
         {showArtifacts ? <ReportArtifactSection tokens={artifactTokens} /> : null}
+      </div>
+      <div className="contents lg:block">
         <ReportRelicSection relics={relics} />
+      </div>
+      <div className="contents lg:block">
         <ReportArmamentSection buffs={armamentBuffs} inscriptions={inscriptionIds} />
       </div>
     </div>


### PR DESCRIPTION
## What changed

- aligned battle-report participant identity, commander, equipment, artifact, relic, and armament sections across both columns
- aligned duel-report participant identity, commander, and troop-buff sections across both columns
- retained the naturally stacked layout below the desktop breakpoint
- reserved desktop rows for optional sections so missing data does not reintroduce staggered content

## Why

Each participant column previously laid out its sections independently. Different commander, equipment, or optional-section heights caused subsequent headings and content to start at different vertical positions. Shared CSS subgrid rows now size each corresponding section from the taller of the two participants.

## Validation

- `pnpm --filter @rokbattles/site typecheck`
- `pnpm --filter @rokbattles/site build`
- `pnpm exec biome check packages/site/src/components/report/report-entry-card.tsx packages/site/src/components/report/report-participant-card.tsx packages/site/src/components/olympian-arena/duel-report-entry-card.tsx packages/site/src/components/olympian-arena/duel-participant-card.tsx`
- `npx react-doctor@latest --verbose --scope changed` (100/100, no issues)
- `git diff --check`

Runtime MCP verification was not available because this repository currently uses Next.js 16.2.10 and that workflow requires Next.js 16.3 or newer.
