### PR TITLE
fix(settings): remove governor ID prefix

### DIFF
--- a/packages/site/src/components/account-binds/bind-list-item.tsx
+++ b/packages/site/src/components/account-binds/bind-list-item.tsx
@@ -31,9 +31,7 @@ export function BindListItem({ bind, isPending, onSetDefault, onUnlink }: BindLi
           </p>
           {bind.default ? <Badge color="emerald">{t("Default")}</Badge> : null}
         </div>
-        <p className="text-xs text-zinc-500 dark:text-zinc-400">
-          {t("ID {id}", { id: bind.governorId.toString() })}
-        </p>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">{bind.governorId.toString()}</p>
       </div>
 
       <div className="ml-auto shrink-0">

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -303,10 +303,6 @@ msgstr "Unlink bind"
 msgid "lKv8ex"
 msgstr "Default"
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr "ID {id}"
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr "You can only bind up to three governors."

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -312,10 +312,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr "Défaut"
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr "Vous ne pouvez lier qu'un maximum de trois gouverneurs."

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -303,10 +303,6 @@ msgstr ""
 msgid "lKv8ex"
 msgstr ""
 
-#: src/components/account-binds/bind-list-item.tsx
-msgid "tx_jZ_"
-msgstr ""
-
 #: src/components/account-binds/binds-claim-form.tsx
 msgid "K994jQ"
 msgstr ""


### PR DESCRIPTION
## What changed

- removed the literal `ID` prefix from governor IDs in the bound-governor list
- kept the descriptive Governor ID copy in the claim form unchanged
- regenerated all site message catalogs to remove the unused extracted message

## Why

The settings list already provides enough context for the numeric governor identifier, so the repeated `ID` label added unnecessary visual noise.

## Validation

- `pnpm --filter @rokbattles/site generate:messages`
- `pnpm --filter @rokbattles/site typecheck`
- `pnpm exec biome check packages/site/src/components/account-binds/bind-list-item.tsx`
- `npx react-doctor@latest --verbose --scope changed` (100/100)
- `git diff --check`
