### PR TITLE
feat(reports): display auxiliary skills

### DIFF
--- a/crates/services/rokbattles-api/src/routes/reports/battle/detail_mapper.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/detail_mapper.rs
@@ -5,12 +5,12 @@ use core_bson::{
 use mongodb::bson::{Bson, Document, doc};
 
 use super::types::{
-    BattleReportAlliance, BattleReportArmament, BattleReportAttack, BattleReportBattleResult,
-    BattleReportBattleResults, BattleReportCastle, BattleReportCommander, BattleReportCommanderSet,
-    BattleReportCommanderSkill, BattleReportDetail, BattleReportMetadata, BattleReportNpc,
-    BattleReportOpponent, BattleReportPlayer, BattleReportRelic, BattleReportSummary,
-    BattleReportSummaryEntry, BattleReportSupportSkill, BattleReportSupportSkills,
-    BattleReportTimeline,
+    BattleReportAlliance, BattleReportArmament, BattleReportAttack, BattleReportAuxiliarySkill,
+    BattleReportBattleResult, BattleReportBattleResults, BattleReportCastle, BattleReportCommander,
+    BattleReportCommanderSet, BattleReportCommanderSkill, BattleReportDetail, BattleReportMetadata,
+    BattleReportNpc, BattleReportOpponent, BattleReportPlayer, BattleReportRelic,
+    BattleReportSummary, BattleReportSummaryEntry, BattleReportSupportSkill,
+    BattleReportSupportSkills, BattleReportTimeline,
 };
 
 pub(super) fn build_battle_detail_filter(report_id: &str) -> Document {
@@ -41,6 +41,9 @@ pub(super) fn build_battle_detail_projection() -> Document {
         "sender.support_skills.skills.hero_id",
         "sender.support_skills.skills.skill_id",
         "sender.support_skills.skills.skill_level",
+        "sender.auxiliary_skills.hero_id",
+        "sender.auxiliary_skills.level",
+        "sender.auxiliary_skills.skill_id",
         "sender.commanders.primary.id",
         "sender.commanders.primary.awakened",
         "sender.commanders.primary.level",
@@ -95,6 +98,9 @@ pub(super) fn build_battle_detail_projection() -> Document {
         "opponents.support_skills.skills.hero_id",
         "opponents.support_skills.skills.skill_id",
         "opponents.support_skills.skills.skill_level",
+        "opponents.auxiliary_skills.hero_id",
+        "opponents.auxiliary_skills.level",
+        "opponents.auxiliary_skills.skill_id",
         "opponents.commanders.primary.id",
         "opponents.commanders.primary.awakened",
         "opponents.commanders.primary.level",
@@ -192,6 +198,7 @@ fn map_detail_player(document: Option<&Document>) -> BattleReportPlayer {
         app_uid: nested_i64_exact(document, &["app_uid"]),
         commanders: map_detail_commanders(document),
         support_skills: map_detail_support_skills(nested_document(document, &["support_skills"])),
+        auxiliary_skills: map_detail_auxiliary_skills(document),
     }
 }
 
@@ -288,6 +295,22 @@ fn map_detail_support_skill_entries(document: &Document) -> Vec<BattleReportSupp
         .collect()
 }
 
+fn map_detail_auxiliary_skills(document: &Document) -> Vec<BattleReportAuxiliarySkill> {
+    let Some(skills) = nested_array(document, &["auxiliary_skills"]) else {
+        return Vec::new();
+    };
+
+    skills
+        .iter()
+        .filter_map(Bson::as_document)
+        .map(|skill| BattleReportAuxiliarySkill {
+            hero_id: nested_i64_exact(skill, &["hero_id"]).unwrap_or_default(),
+            level: nested_i64_exact(skill, &["level"]).unwrap_or_default(),
+            skill_id: nested_i64_exact(skill, &["skill_id"]).unwrap_or_default(),
+        })
+        .collect()
+}
+
 fn map_detail_summary(document: Option<&Document>) -> BattleReportSummary {
     let Some(document) = document else {
         return BattleReportSummary::default();
@@ -338,6 +361,8 @@ fn map_detail_opponent(document: &Document) -> BattleReportOpponent {
         castle: base.castle,
         app_uid: base.app_uid,
         commanders: base.commanders,
+        support_skills: base.support_skills,
+        auxiliary_skills: base.auxiliary_skills,
         start_tick,
         end_tick: nested_i64(document, &["end_tick"]).unwrap_or(start_tick),
         attack: BattleReportAttack {
@@ -422,6 +447,8 @@ mod tests {
         assert_eq!(projection.get_i32("sender.commanders.primary.skills.id").ok(), Some(1));
         assert_eq!(projection.get_i32("sender.support_skills.enable").ok(), Some(1));
         assert_eq!(projection.get_i32("sender.support_skills.skills.skill_id").ok(), Some(1));
+        assert_eq!(projection.get_i32("sender.auxiliary_skills.skill_id").ok(), Some(1));
+        assert_eq!(projection.get_i32("opponents.auxiliary_skills.skill_id").ok(), Some(1));
         assert_eq!(
             projection.get_i32("opponents.battle_results.opponent.kill_points").ok(),
             Some(1)
@@ -454,6 +481,9 @@ mod tests {
                         { "hero_id": 10_i64, "skill_id": 101_i64, "skill_level": 5_i64 },
                     ],
                 },
+                "auxiliary_skills": [
+                    { "hero_id": 20_i64, "level": 4_i64, "skill_id": 202_i64 },
+                ],
                 "commanders": {
                     "primary": {
                         "id": 10_i64,
@@ -503,6 +533,13 @@ mod tests {
                     "start_tick": 60_i64,
                     "attack": { "x": 1_i64, "y": 2_i64 },
                     "npc": { "type": 5_i64, "b_type": 8_i64 },
+                    "support_skills": {
+                        "enable": false,
+                        "skills": [],
+                    },
+                    "auxiliary_skills": [
+                        { "hero_id": 30_i64, "level": 3_i64, "skill_id": 303_i64 },
+                    ],
                     "battle_results": {
                         "sender": {
                             "kill_points": 40_i64,
@@ -529,9 +566,12 @@ mod tests {
         assert_eq!(mapped.sender.support_skills.enable, Some(true));
         assert_eq!(mapped.sender.support_skills.skills.len(), 1);
         assert_eq!(mapped.sender.support_skills.skills[0].skill_id, 101);
+        assert_eq!(mapped.sender.auxiliary_skills[0].skill_id, 202);
         assert_eq!(mapped.summary.sender.kill_points, Some(100));
         assert_eq!(mapped.opponents.len(), 1);
         assert_eq!(mapped.opponents[0].npc.r#type, Some(5));
+        assert_eq!(mapped.opponents[0].support_skills.enable, Some(false));
+        assert_eq!(mapped.opponents[0].auxiliary_skills[0].skill_id, 303);
         assert_eq!(mapped.timeline.start_tick, 50);
     }
 

--- a/crates/services/rokbattles-api/src/routes/reports/battle/types.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/types.rs
@@ -112,6 +112,7 @@ pub(crate) struct BattleReportPlayer {
     pub app_uid: Option<i64>,
     pub commanders: BattleReportCommanderSet,
     pub support_skills: BattleReportSupportSkills,
+    pub auxiliary_skills: Vec<BattleReportAuxiliarySkill>,
 }
 
 #[derive(Debug, Serialize, Default)]
@@ -184,6 +185,14 @@ pub(crate) struct BattleReportSupportSkill {
 
 #[derive(Debug, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct BattleReportAuxiliarySkill {
+    pub hero_id: i64,
+    pub level: i64,
+    pub skill_id: i64,
+}
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct BattleReportSummary {
     pub sender: BattleReportSummaryEntry,
     pub opponent: BattleReportSummaryEntry,
@@ -214,6 +223,8 @@ pub(crate) struct BattleReportOpponent {
     pub castle: BattleReportCastle,
     pub app_uid: Option<i64>,
     pub commanders: BattleReportCommanderSet,
+    pub support_skills: BattleReportSupportSkills,
+    pub auxiliary_skills: Vec<BattleReportAuxiliarySkill>,
     pub start_tick: i64,
     pub end_tick: i64,
     pub attack: BattleReportAttack,

--- a/packages/site/src/components/report/report-participant-card.tsx
+++ b/packages/site/src/components/report/report-participant-card.tsx
@@ -78,7 +78,10 @@ export function ReportParticipantCard({
                 <ReportCommanderRow commander={primaryCommander} formation={primaryFormation} />
               ) : null}
               {showSecondary ? <ReportCommanderRow commander={secondaryCommander} /> : null}
-              <ReportSupportSkills supportSkills={participant?.support_skills} />
+              <ReportSupportSkills
+                supportSkills={participant?.support_skills}
+                auxiliarySkills={participant?.auxiliary_skills}
+              />
             </div>
           </div>
         ) : null}

--- a/packages/site/src/components/report/report-support-skills.tsx
+++ b/packages/site/src/components/report/report-support-skills.tsx
@@ -3,20 +3,26 @@
 import { ReportSkillSlot } from "@/components/report/report-skill-slot";
 import { resolveLocale } from "@/i18n/locale";
 import { getCommanderSkillName, getCommanderSkillSpriteUrls } from "@/lib/commander";
-import type { RawSupportSkillsInfo } from "@/lib/types/raw-report";
+import type { RawAuxiliarySkillInfo, RawSupportSkillsInfo } from "@/lib/types/raw-report";
 
 type ReportSupportSkillsProps = {
   supportSkills?: RawSupportSkillsInfo | null;
+  auxiliarySkills?: RawAuxiliarySkillInfo[] | null;
 };
 
-export function ReportSupportSkills({ supportSkills }: ReportSupportSkillsProps) {
+export function ReportSupportSkills({ supportSkills, auxiliarySkills }: ReportSupportSkillsProps) {
   const locale = resolveLocale();
-
-  if (!supportSkills?.enable) {
-    return null;
-  }
-
-  const skills = supportSkills.skills ?? [];
+  const skills = supportSkills?.enable
+    ? (supportSkills.skills ?? []).map((skill) => ({
+        heroId: skill.hero_id,
+        level: skill.skill_level,
+        skillId: skill.skill_id,
+      }))
+    : (auxiliarySkills ?? []).map((skill) => ({
+        heroId: skill.hero_id,
+        level: skill.level,
+        skillId: skill.skill_id,
+      }));
 
   if (skills.length === 0) {
     return null;
@@ -26,14 +32,14 @@ export function ReportSupportSkills({ supportSkills }: ReportSupportSkillsProps)
     <div className="flex justify-end">
       <div className="flex flex-wrap justify-end gap-1.5">
         {skills.map((skill) => {
-          const spriteUrls = getCommanderSkillSpriteUrls(skill.hero_id, skill.skill_id);
-          const skillName = getCommanderSkillName(skill.hero_id, skill.skill_id, locale);
+          const spriteUrls = getCommanderSkillSpriteUrls(skill.heroId, skill.skillId);
+          const skillName = getCommanderSkillName(skill.heroId, skill.skillId, locale);
 
           return (
             <ReportSkillSlot
-              key={`${skill.hero_id}-${skill.skill_id}-${skill.skill_level}`}
+              key={`${skill.heroId}-${skill.skillId}-${skill.level}`}
               spriteUrls={spriteUrls}
-              level={skill.skill_level}
+              level={skill.level}
               alt={skillName}
               title={skillName}
             />

--- a/packages/site/src/lib/report/battle-mail-adapter.ts
+++ b/packages/site/src/lib/report/battle-mail-adapter.ts
@@ -1,4 +1,5 @@
 import type {
+  BattleAuxiliarySkill,
   BattleDetailedResult,
   BattleMail,
   BattleOpponent,
@@ -120,6 +121,14 @@ function mapSupportSkill(skill: BattleSupportSkill) {
   };
 }
 
+function mapAuxiliarySkill(skill: BattleAuxiliarySkill) {
+  return {
+    hero_id: skill.heroId,
+    level: skill.level,
+    skill_id: skill.skillId,
+  };
+}
+
 function mapPlayerToParticipant(
   player: BattlePlayer,
   npc?: { type: number | null; bType: number | null } | null
@@ -158,6 +167,7 @@ function mapPlayerToParticipant(
       enable: player.supportSkills?.enable ?? undefined,
       skills: [...(player.supportSkills?.skills ?? [])].map(mapSupportSkill),
     },
+    auxiliary_skills: [...(player.auxiliarySkills ?? [])].map(mapAuxiliarySkill),
     formation: player.commanders.primary.formation ?? undefined,
     equipment: player.commanders.primary.equipment ?? undefined,
     equipment_2: player.commanders.secondary.equipment ?? undefined,

--- a/packages/site/src/lib/types/battle.ts
+++ b/packages/site/src/lib/types/battle.ts
@@ -36,6 +36,7 @@ export type BattlePlayer = {
   appUid: number | null;
   commanders: BattleCommanderSet;
   supportSkills: BattleSupportSkills;
+  auxiliarySkills: readonly BattleAuxiliarySkill[];
 };
 
 export type BattleAlliance = {
@@ -86,6 +87,12 @@ export type BattleSupportSkill = {
   heroId: number;
   skillId: number;
   skillLevel: number;
+};
+
+export type BattleAuxiliarySkill = {
+  heroId: number;
+  level: number;
+  skillId: number;
 };
 
 export type BattleAttack = {

--- a/packages/site/src/lib/types/raw-report.ts
+++ b/packages/site/src/lib/types/raw-report.ts
@@ -55,6 +55,7 @@ export interface RawParticipantInfo {
   primary_commander?: RawCommanderInfo;
   secondary_commander?: RawCommanderInfo;
   support_skills?: RawSupportSkillsInfo | null;
+  auxiliary_skills?: RawAuxiliarySkillInfo[] | null;
   equipment?: string;
   equipment_2?: string;
   formation?: number;
@@ -71,6 +72,12 @@ export interface RawSupportSkillInfo {
   hero_id: number;
   skill_id: number;
   skill_level: number;
+}
+
+export interface RawAuxiliarySkillInfo {
+  hero_id: number;
+  level: number;
+  skill_id: number;
 }
 
 export interface RawOverview {


### PR DESCRIPTION
## Summary

- expose sender and opponent `auxiliarySkills` in Battle report detail responses
- preserve auxiliary skills through the site Battle mail adapter
- show auxiliary skills in the support-skill slot when support skills are not enabled
- preserve enabled support skills as the preferred display
- carry the already-projected opponent support skills through the API response

## Stacked on

- #740 `feat(battle): extract auxiliary skills`

## Validation

- `cargo test -p rokbattles-api routes::reports::battle`
- `cargo clippy -p rokbattles-api --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm --filter @rokbattles/site typecheck`
- `pnpm exec biome ci .`
- `pnpm --filter @rokbattles/site generate:datasets`
- `pnpm --filter @rokbattles/site generate:messages`
- `pnpm --filter @rokbattles/site build`
- `npx react-doctor@latest --verbose --scope changed` (100/100)

Runtime MCP verification was unavailable because this repository uses Next 16.2.10; the Next runtime workflow requires 16.3 or newer.