### PR TITLE
feat(pairings): add battle type filters

### DIFF
--- a/crates/services/rokbattles-api/src/routes/governor/pairings/mod.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/mod.rs
@@ -39,9 +39,15 @@ pub async fn get(
 
     ensure_governor_claim_for_user(&state, &session.user.discord_id, governor_id).await?;
 
-    let mails =
-        fetch_pairings_mails(&state, governor_id, &request.range, None, &request.exclude_types)
-            .await?;
+    let mails = fetch_pairings_mails(
+        &state,
+        governor_id,
+        &request.range,
+        None,
+        &request.exclude_activities,
+        &request.exclude_battles,
+    )
+    .await?;
     let items = aggregate_pairings(&mails, &request.range);
     let response = PairingsResponse {
         range: PairingsRange { start: request.range.start, end: request.range.end },
@@ -68,7 +74,8 @@ pub async fn get_loadouts(
         governor_id,
         &request.range,
         Some(request.primary_commander_id),
-        &request.exclude_types,
+        &request.exclude_activities,
+        &request.exclude_battles,
     )
     .await?;
     let items = aggregate_loadouts(
@@ -103,7 +110,8 @@ pub async fn get_opponents(
         governor_id,
         &request.range,
         Some(request.primary_commander_id),
-        &request.exclude_types,
+        &request.exclude_activities,
+        &request.exclude_battles,
     )
     .await?;
     let items = aggregate_opponents(

--- a/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
@@ -8,23 +8,33 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PairingsReportType {
+pub(crate) enum PairingsActivity {
     Home,
     Ark,
     Kvk,
     Strife,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PairingsBattleType {
+    OpenField,
+    Swarming,
+    Rally,
+    Garrison,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct PairingsRequest {
     pub range: GovernorDateRange,
-    pub exclude_types: Vec<PairingsReportType>,
+    pub exclude_activities: Vec<PairingsActivity>,
+    pub exclude_battles: Vec<PairingsBattleType>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct PairingLoadoutsRequest {
     pub range: GovernorDateRange,
-    pub exclude_types: Vec<PairingsReportType>,
+    pub exclude_activities: Vec<PairingsActivity>,
+    pub exclude_battles: Vec<PairingsBattleType>,
     pub primary_commander_id: i64,
     pub secondary_commander_id: i64,
     pub granularity: LoadoutGranularity,
@@ -33,7 +43,8 @@ pub(crate) struct PairingLoadoutsRequest {
 #[derive(Debug, Clone)]
 pub(crate) struct PairingOpponentsRequest {
     pub range: GovernorDateRange,
-    pub exclude_types: Vec<PairingsReportType>,
+    pub exclude_activities: Vec<PairingsActivity>,
+    pub exclude_battles: Vec<PairingsBattleType>,
     pub primary_commander_id: i64,
     pub secondary_commander_id: i64,
     pub granularity: OpponentGranularity,
@@ -57,15 +68,19 @@ pub(crate) fn parse_pairings_request(
     params: &HashMap<String, String>,
 ) -> Result<PairingsRequest, ApiError> {
     let range = parse_default_governor_date_range(params)?;
-    let exclude_types = parse_exclude_types(params.get("excludeTypes").map(String::as_str))?;
-    Ok(PairingsRequest { range, exclude_types })
+    let exclude_activities =
+        parse_exclude_activities(params.get("excludeActivities").map(String::as_str))?;
+    let exclude_battles = parse_exclude_battles(params.get("excludeBattles").map(String::as_str))?;
+    Ok(PairingsRequest { range, exclude_activities, exclude_battles })
 }
 
 pub(crate) fn parse_pairing_loadouts_request(
     params: &HashMap<String, String>,
 ) -> Result<PairingLoadoutsRequest, ApiError> {
     let range = parse_default_governor_date_range(params)?;
-    let exclude_types = parse_exclude_types(params.get("excludeTypes").map(String::as_str))?;
+    let exclude_activities =
+        parse_exclude_activities(params.get("excludeActivities").map(String::as_str))?;
+    let exclude_battles = parse_exclude_battles(params.get("excludeBattles").map(String::as_str))?;
     let primary_commander_id = parse_positive_required_i64(params, "primary", "Invalid pairing")?;
     let secondary_commander_id =
         parse_non_negative_required_i64(params, "secondary", "Invalid pairing")?;
@@ -73,7 +88,8 @@ pub(crate) fn parse_pairing_loadouts_request(
 
     Ok(PairingLoadoutsRequest {
         range,
-        exclude_types,
+        exclude_activities,
+        exclude_battles,
         primary_commander_id,
         secondary_commander_id,
         granularity,
@@ -84,7 +100,9 @@ pub(crate) fn parse_pairing_opponents_request(
     params: &HashMap<String, String>,
 ) -> Result<PairingOpponentsRequest, ApiError> {
     let range = parse_default_governor_date_range(params)?;
-    let exclude_types = parse_exclude_types(params.get("excludeTypes").map(String::as_str))?;
+    let exclude_activities =
+        parse_exclude_activities(params.get("excludeActivities").map(String::as_str))?;
+    let exclude_battles = parse_exclude_battles(params.get("excludeBattles").map(String::as_str))?;
     let primary_commander_id = parse_positive_required_i64(params, "primary", "Invalid pairing")?;
     let secondary_commander_id =
         parse_non_negative_required_i64(params, "secondary", "Invalid pairing")?;
@@ -100,7 +118,8 @@ pub(crate) fn parse_pairing_opponents_request(
 
     Ok(PairingOpponentsRequest {
         range,
-        exclude_types,
+        exclude_activities,
+        exclude_battles,
         primary_commander_id,
         secondary_commander_id,
         granularity,
@@ -108,16 +127,16 @@ pub(crate) fn parse_pairing_opponents_request(
     })
 }
 
-pub(crate) fn build_excluded_report_type_conditions(
-    exclude_types: &[PairingsReportType],
+pub(crate) fn build_excluded_activity_conditions(
+    exclude_activities: &[PairingsActivity],
 ) -> Vec<Document> {
-    exclude_types
+    exclude_activities
         .iter()
         .copied()
         .map(|filter_type| match filter_type {
-            PairingsReportType::Kvk => doc! { "metadata.kvk": true },
-            PairingsReportType::Ark => doc! { "metadata.mail_role": "dungeon" },
-            PairingsReportType::Home => doc! {
+            PairingsActivity::Kvk => doc! { "metadata.kvk": true },
+            PairingsActivity::Ark => doc! { "metadata.mail_role": "dungeon" },
+            PairingsActivity::Home => doc! {
                 "$and": [
                     { "metadata.kvk": { "$ne": true } },
                     { "metadata.mail_role": { "$ne": "dungeon" } },
@@ -129,7 +148,7 @@ pub(crate) fn build_excluded_report_type_conditions(
                     }
                 ]
             },
-            PairingsReportType::Strife => doc! {
+            PairingsActivity::Strife => doc! {
                 "$and": [
                     { "sender.supreme_strife.battle_id": { "$exists": true, "$nin": [Bson::Null, Bson::String(String::new())] } },
                     { "sender.supreme_strife.team_id": { "$exists": true, "$nin": [Bson::Null, Bson::Int32(0), Bson::Int64(0)] } },
@@ -139,28 +158,130 @@ pub(crate) fn build_excluded_report_type_conditions(
         .collect()
 }
 
-fn parse_exclude_types(raw: Option<&str>) -> Result<Vec<PairingsReportType>, ApiError> {
+pub(crate) fn build_excluded_battle_type_conditions(
+    exclude_battles: &[PairingsBattleType],
+) -> Vec<Document> {
+    exclude_battles
+        .iter()
+        .copied()
+        .map(|battle_type| doc! { "$expr": battle_type_expression(battle_type) })
+        .collect()
+}
+
+fn battle_type_expression(battle_type: PairingsBattleType) -> Document {
+    let sender_garrison = sender_garrison_expression();
+    let sender_rally = sender_rally_expression();
+    let opponent_rally_or_garrison = opponent_rally_or_garrison_expression();
+
+    match battle_type {
+        PairingsBattleType::Garrison => sender_garrison,
+        PairingsBattleType::Rally => doc! {
+            "$and": [
+                { "$not": [sender_garrison] },
+                sender_rally,
+            ]
+        },
+        PairingsBattleType::Swarming => doc! {
+            "$and": [
+                { "$not": [sender_garrison] },
+                { "$not": [sender_rally] },
+                opponent_rally_or_garrison,
+            ]
+        },
+        PairingsBattleType::OpenField => doc! {
+            "$and": [
+                { "$not": [sender_garrison] },
+                { "$not": [sender_rally] },
+                { "$not": [opponent_rally_or_garrison] },
+            ]
+        },
+    }
+}
+
+fn sender_garrison_expression() -> Document {
+    doc! {
+        "$or": [
+            { "$ne": [{ "$ifNull": ["$sender.alliance_building_id", Bson::Null] }, Bson::Null] },
+            { "$ne": [{ "$ifNull": ["$sender.structure_id", Bson::Null] }, Bson::Null] },
+        ]
+    }
+}
+
+fn sender_rally_expression() -> Document {
+    doc! {
+        "$in": ["$sender.rally", [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)]]
+    }
+}
+
+fn opponent_rally_or_garrison_expression() -> Document {
+    doc! {
+        "$gt": [
+            {
+                "$size": {
+                    "$filter": {
+                        "input": { "$ifNull": ["$opponents", []] },
+                        "as": "opponent",
+                        "cond": {
+                            "$or": [
+                                { "$in": ["$$opponent.rally", [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)]] },
+                                { "$ne": [{ "$ifNull": ["$$opponent.alliance_building_id", Bson::Null] }, Bson::Null] },
+                                { "$ne": [{ "$ifNull": ["$$opponent.structure_id", Bson::Null] }, Bson::Null] },
+                            ]
+                        }
+                    }
+                }
+            },
+            0,
+        ]
+    }
+}
+
+fn parse_exclude_activities(raw: Option<&str>) -> Result<Vec<PairingsActivity>, ApiError> {
     let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
         return Ok(Vec::new());
     };
 
-    let mut exclude_types = Vec::new();
+    let mut exclude_activities = Vec::new();
 
     for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
         let parsed = match value {
-            "home" => PairingsReportType::Home,
-            "ark" => PairingsReportType::Ark,
-            "kvk" => PairingsReportType::Kvk,
-            "strife" => PairingsReportType::Strife,
-            _ => return Err(ApiError::bad_request("Invalid excludeTypes")),
+            "home" => PairingsActivity::Home,
+            "ark" => PairingsActivity::Ark,
+            "kvk" => PairingsActivity::Kvk,
+            "strife" => PairingsActivity::Strife,
+            _ => return Err(ApiError::bad_request("Invalid excludeActivities")),
         };
 
-        if !exclude_types.contains(&parsed) {
-            exclude_types.push(parsed);
+        if !exclude_activities.contains(&parsed) {
+            exclude_activities.push(parsed);
         }
     }
 
-    Ok(exclude_types)
+    Ok(exclude_activities)
+}
+
+fn parse_exclude_battles(raw: Option<&str>) -> Result<Vec<PairingsBattleType>, ApiError> {
+    let Some(raw) = raw.map(str::trim).filter(|value| !value.is_empty()) else {
+        return Ok(Vec::new());
+    };
+
+    let mut exclude_battles = Vec::new();
+
+    for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
+        let parsed = match value {
+            "open-field" => PairingsBattleType::OpenField,
+            "swarming" => PairingsBattleType::Swarming,
+            "rally" => PairingsBattleType::Rally,
+            "garrison" => PairingsBattleType::Garrison,
+            _ => return Err(ApiError::bad_request("Invalid excludeBattles")),
+        };
+
+        if !exclude_battles.contains(&parsed) {
+            exclude_battles.push(parsed);
+        }
+    }
+
+    Ok(exclude_battles)
 }
 
 fn parse_loadout_granularity(raw: Option<&str>) -> Result<LoadoutGranularity, ApiError> {
@@ -248,21 +369,105 @@ mod tests {
     }
 
     #[test]
-    fn parse_pairings_request_parses_exclude_types() {
-        let request = parse_pairings_request(&HashMap::from([(
-            "excludeTypes".to_string(),
-            "ark,kvk,ark".to_string(),
-        )]))
-        .expect("request");
-        assert_eq!(request.exclude_types, vec![PairingsReportType::Ark, PairingsReportType::Kvk]);
+    fn parse_pairings_request_defaults_to_include_all_battles() {
+        let request = parse_pairings_request(&HashMap::new()).expect("request");
+
+        assert_eq!((request.exclude_activities, request.exclude_battles), (vec![], vec![]));
     }
 
     #[test]
-    fn parse_pairings_request_rejects_invalid_exclude_type() {
+    fn parse_pairings_request_parses_excluded_activities() {
         let request = parse_pairings_request(&HashMap::from([(
-            "excludeTypes".to_string(),
+            "excludeActivities".to_string(),
+            "ark,kvk,ark".to_string(),
+        )]))
+        .expect("request");
+        assert_eq!(request.exclude_activities, vec![PairingsActivity::Ark, PairingsActivity::Kvk]);
+    }
+
+    #[test]
+    fn parse_pairings_request_parses_excluded_battles() {
+        let request = parse_pairings_request(&HashMap::from([(
+            "excludeBattles".to_string(),
+            "open-field,swarming,rally,garrison,swarming".to_string(),
+        )]))
+        .expect("request");
+
+        assert_eq!(
+            request.exclude_battles,
+            vec![
+                PairingsBattleType::OpenField,
+                PairingsBattleType::Swarming,
+                PairingsBattleType::Rally,
+                PairingsBattleType::Garrison,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_pairings_request_rejects_invalid_excluded_activity() {
+        let request = parse_pairings_request(&HashMap::from([(
+            "excludeActivities".to_string(),
             "unknown".to_string(),
         )]));
         assert!(request.is_err());
+    }
+
+    #[test]
+    fn parse_pairings_request_rejects_invalid_excluded_battle() {
+        let request = parse_pairings_request(&HashMap::from([(
+            "excludeBattles".to_string(),
+            "duel".to_string(),
+        )]));
+        assert!(request.is_err());
+    }
+
+    #[test]
+    fn garrison_battle_condition_matches_sender_structure_fields() {
+        assert_eq!(
+            battle_type_expression(PairingsBattleType::Garrison),
+            sender_garrison_expression()
+        );
+    }
+
+    #[test]
+    fn rally_battle_condition_excludes_sender_garrisons() {
+        assert_eq!(
+            battle_type_expression(PairingsBattleType::Rally),
+            doc! {
+                "$and": [
+                    { "$not": [sender_garrison_expression()] },
+                    sender_rally_expression(),
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn swarming_battle_condition_requires_special_opponent_only() {
+        assert_eq!(
+            battle_type_expression(PairingsBattleType::Swarming),
+            doc! {
+                "$and": [
+                    { "$not": [sender_garrison_expression()] },
+                    { "$not": [sender_rally_expression()] },
+                    opponent_rally_or_garrison_expression(),
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn open_field_battle_condition_excludes_all_special_marches() {
+        assert_eq!(
+            battle_type_expression(PairingsBattleType::OpenField),
+            doc! {
+                "$and": [
+                    { "$not": [sender_garrison_expression()] },
+                    { "$not": [sender_rally_expression()] },
+                    { "$not": [opponent_rally_or_garrison_expression()] },
+                ]
+            }
+        );
     }
 }

--- a/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
@@ -161,78 +161,73 @@ pub(crate) fn build_excluded_activity_conditions(
 pub(crate) fn build_excluded_battle_type_conditions(
     exclude_battles: &[PairingsBattleType],
 ) -> Vec<Document> {
-    exclude_battles
-        .iter()
-        .copied()
-        .map(|battle_type| doc! { "$expr": battle_type_expression(battle_type) })
-        .collect()
+    exclude_battles.iter().copied().map(battle_type_condition).collect()
 }
 
-fn battle_type_expression(battle_type: PairingsBattleType) -> Document {
-    let sender_garrison = sender_garrison_expression();
-    let sender_rally = sender_rally_expression();
-    let opponent_rally_or_garrison = opponent_rally_or_garrison_expression();
-
+fn battle_type_condition(battle_type: PairingsBattleType) -> Document {
     match battle_type {
-        PairingsBattleType::Garrison => sender_garrison,
+        PairingsBattleType::Garrison => sender_garrison_condition(),
         PairingsBattleType::Rally => doc! {
             "$and": [
-                { "$not": [sender_garrison] },
-                sender_rally,
+                sender_not_garrison_condition(),
+                sender_rally_condition(),
             ]
         },
         PairingsBattleType::Swarming => doc! {
             "$and": [
-                { "$not": [sender_garrison] },
-                { "$not": [sender_rally] },
-                opponent_rally_or_garrison,
+                sender_not_garrison_condition(),
+                sender_not_rally_condition(),
+                opponent_rally_or_garrison_condition(),
             ]
         },
         PairingsBattleType::OpenField => doc! {
             "$and": [
-                { "$not": [sender_garrison] },
-                { "$not": [sender_rally] },
-                { "$not": [opponent_rally_or_garrison] },
+                sender_not_garrison_condition(),
+                sender_not_rally_condition(),
+                { "$nor": [opponent_rally_or_garrison_condition()] },
             ]
         },
     }
 }
 
-fn sender_garrison_expression() -> Document {
+fn sender_garrison_condition() -> Document {
+    doc! { "$or": sender_garrison_field_conditions() }
+}
+
+fn sender_not_garrison_condition() -> Document {
+    doc! { "$nor": sender_garrison_field_conditions() }
+}
+
+fn sender_garrison_field_conditions() -> Vec<Document> {
+    vec![
+        doc! { "sender.alliance_building_id": { "$exists": true, "$ne": Bson::Null } },
+        doc! { "sender.structure_id": { "$exists": true, "$ne": Bson::Null } },
+    ]
+}
+
+fn sender_rally_condition() -> Document {
     doc! {
-        "$or": [
-            { "$ne": [{ "$ifNull": ["$sender.alliance_building_id", Bson::Null] }, Bson::Null] },
-            { "$ne": [{ "$ifNull": ["$sender.structure_id", Bson::Null] }, Bson::Null] },
-        ]
+        "sender.rally": { "$in": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] }
     }
 }
 
-fn sender_rally_expression() -> Document {
+fn sender_not_rally_condition() -> Document {
     doc! {
-        "$in": ["$sender.rally", [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)]]
+        "sender.rally": { "$nin": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] }
     }
 }
 
-fn opponent_rally_or_garrison_expression() -> Document {
+fn opponent_rally_or_garrison_condition() -> Document {
     doc! {
-        "$gt": [
-            {
-                "$size": {
-                    "$filter": {
-                        "input": { "$ifNull": ["$opponents", []] },
-                        "as": "opponent",
-                        "cond": {
-                            "$or": [
-                                { "$in": ["$$opponent.rally", [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)]] },
-                                { "$ne": [{ "$ifNull": ["$$opponent.alliance_building_id", Bson::Null] }, Bson::Null] },
-                                { "$ne": [{ "$ifNull": ["$$opponent.structure_id", Bson::Null] }, Bson::Null] },
-                            ]
-                        }
-                    }
-                }
-            },
-            0,
-        ]
+        "opponents": {
+            "$elemMatch": {
+                "$or": [
+                    { "rally": { "$in": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] } },
+                    { "alliance_building_id": { "$exists": true, "$ne": Bson::Null } },
+                    { "structure_id": { "$exists": true, "$ne": Bson::Null } },
+                ]
+            }
+        }
     }
 }
 
@@ -425,19 +420,19 @@ mod tests {
     #[test]
     fn garrison_battle_condition_matches_sender_structure_fields() {
         assert_eq!(
-            battle_type_expression(PairingsBattleType::Garrison),
-            sender_garrison_expression()
+            battle_type_condition(PairingsBattleType::Garrison),
+            sender_garrison_condition()
         );
     }
 
     #[test]
     fn rally_battle_condition_excludes_sender_garrisons() {
         assert_eq!(
-            battle_type_expression(PairingsBattleType::Rally),
+            battle_type_condition(PairingsBattleType::Rally),
             doc! {
                 "$and": [
-                    { "$not": [sender_garrison_expression()] },
-                    sender_rally_expression(),
+                    sender_not_garrison_condition(),
+                    sender_rally_condition(),
                 ]
             }
         );
@@ -446,12 +441,12 @@ mod tests {
     #[test]
     fn swarming_battle_condition_requires_special_opponent_only() {
         assert_eq!(
-            battle_type_expression(PairingsBattleType::Swarming),
+            battle_type_condition(PairingsBattleType::Swarming),
             doc! {
                 "$and": [
-                    { "$not": [sender_garrison_expression()] },
-                    { "$not": [sender_rally_expression()] },
-                    opponent_rally_or_garrison_expression(),
+                    sender_not_garrison_condition(),
+                    sender_not_rally_condition(),
+                    opponent_rally_or_garrison_condition(),
                 ]
             }
         );
@@ -460,12 +455,12 @@ mod tests {
     #[test]
     fn open_field_battle_condition_excludes_all_special_marches() {
         assert_eq!(
-            battle_type_expression(PairingsBattleType::OpenField),
+            battle_type_condition(PairingsBattleType::OpenField),
             doc! {
                 "$and": [
-                    { "$not": [sender_garrison_expression()] },
-                    { "$not": [sender_rally_expression()] },
-                    { "$not": [opponent_rally_or_garrison_expression()] },
+                    sender_not_garrison_condition(),
+                    sender_not_rally_condition(),
+                    { "$nor": [opponent_rally_or_garrison_condition()] },
                 ]
             }
         );

--- a/crates/services/rokbattles-api/src/routes/governor/pairings/store.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/store.rs
@@ -9,7 +9,10 @@ use crate::{
     error::ApiError,
     routes::governor::{
         date_range::GovernorDateRange,
-        pairings::query::{PairingsReportType, build_excluded_report_type_conditions},
+        pairings::query::{
+            PairingsActivity, PairingsBattleType, build_excluded_activity_conditions,
+            build_excluded_battle_type_conditions,
+        },
         store_utils::fetch_collection_documents,
     },
     state::AppState,
@@ -21,7 +24,8 @@ pub(crate) async fn fetch_pairings_mails(
     governor_id: i64,
     range: &GovernorDateRange,
     primary_commander_id: Option<i64>,
-    exclude_types: &[PairingsReportType],
+    exclude_activities: &[PairingsActivity],
+    exclude_battles: &[PairingsBattleType],
 ) -> Result<Vec<Document>, ApiError> {
     let mut and_filters = vec![
         doc! { "sender.player_id": governor_id },
@@ -33,9 +37,8 @@ pub(crate) async fn fetch_pairings_mails(
         and_filters.push(doc! { "sender.commanders.primary.id": primary_commander_id });
     }
 
-    let excluded_conditions = build_excluded_report_type_conditions(exclude_types);
-    if !excluded_conditions.is_empty() {
-        and_filters.push(doc! { "$nor": excluded_conditions });
+    if let Some(exclusion_filter) = build_exclusion_filter(exclude_activities, exclude_battles) {
+        and_filters.push(exclusion_filter);
     }
 
     let filter = doc! { "$and": and_filters };
@@ -68,4 +71,40 @@ pub(crate) async fn fetch_pairings_mails(
         .build();
 
     fetch_collection_documents(state.reports_store.battle_collection(), filter, options).await
+}
+
+fn build_exclusion_filter(
+    exclude_activities: &[PairingsActivity],
+    exclude_battles: &[PairingsBattleType],
+) -> Option<Document> {
+    let mut excluded_conditions = build_excluded_activity_conditions(exclude_activities);
+    excluded_conditions.extend(build_excluded_battle_type_conditions(exclude_battles));
+    (!excluded_conditions.is_empty()).then(|| doc! { "$nor": excluded_conditions })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusion_filter_is_absent_when_everything_is_included() {
+        assert_eq!(build_exclusion_filter(&[], &[]), None);
+    }
+
+    #[test]
+    fn exclusion_filter_combines_activities_and_battles() {
+        let filter =
+            build_exclusion_filter(&[PairingsActivity::Kvk], &[PairingsBattleType::Swarming]);
+
+        assert_eq!(
+            filter,
+            Some(doc! {
+                "$nor": [
+                    doc! { "metadata.kvk": true },
+                    build_excluded_battle_type_conditions(&[PairingsBattleType::Swarming])
+                        .remove(0),
+                ]
+            })
+        );
+    }
 }

--- a/packages/site/src/components/my-pairings/my-pairings-content.tsx
+++ b/packages/site/src/components/my-pairings/my-pairings-content.tsx
@@ -15,7 +15,8 @@ import type {
   LoadoutGranularity,
   LoadoutSnapshot,
   OpponentGranularity,
-  PairingsReportType,
+  PairingsActivity,
+  PairingsBattleType,
 } from "@/lib/pairings";
 import { GovernorContext } from "@/providers/governor-context";
 
@@ -105,7 +106,8 @@ export function MyPairingsContent() {
 
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
-  const [excludedReportTypes, setExcludedReportTypes] = useState<PairingsReportType[]>([]);
+  const [excludedActivities, setExcludedActivities] = useState<PairingsActivity[]>([]);
+  const [excludedBattles, setExcludedBattles] = useState<PairingsBattleType[]>([]);
   const hasCustomRange = Boolean(startDate && endDate);
   const rangeStartDate = hasCustomRange ? startDate : undefined;
   const rangeEndDate = hasCustomRange ? endDate : undefined;
@@ -117,7 +119,8 @@ export function MyPairingsContent() {
     governorId: activeGovernor?.governorId,
     startDate: rangeStartDate,
     endDate: rangeEndDate,
-    excludeTypes: excludedReportTypes,
+    excludeActivities: excludedActivities,
+    excludeBattles: excludedBattles,
   });
   const [selectedPairingKey, setSelectedPairingKey] = useState<string | null>(null);
   const [loadoutGranularity, setLoadoutGranularity] = useState<LoadoutGranularity>("simplified");
@@ -181,7 +184,8 @@ export function MyPairingsContent() {
     granularity: loadoutGranularity,
     startDate: rangeStartDate,
     endDate: rangeEndDate,
-    excludeTypes: excludedReportTypes,
+    excludeActivities: excludedActivities,
+    excludeBattles: excludedBattles,
   });
   const loadoutsResetKey = useMemo(
     () =>
@@ -191,7 +195,8 @@ export function MyPairingsContent() {
         loadoutGranularity,
         rangeStartDate ?? "none",
         rangeEndDate ?? "none",
-        excludedReportTypes.join(",") || "none",
+        excludedActivities.join(",") || "none",
+        excludedBattles.join(",") || "none",
         canLoadLoadouts ? "ready" : "idle",
       ].join("|"),
     [
@@ -200,7 +205,8 @@ export function MyPairingsContent() {
       loadoutGranularity,
       rangeStartDate,
       rangeEndDate,
-      excludedReportTypes,
+      excludedActivities,
+      excludedBattles,
       canLoadLoadouts,
     ]
   );
@@ -212,7 +218,8 @@ export function MyPairingsContent() {
         loadoutGranularity,
         rangeStartDate ?? "none",
         rangeEndDate ?? "none",
-        excludedReportTypes.join(",") || "none",
+        excludedActivities.join(",") || "none",
+        excludedBattles.join(",") || "none",
       ].join("|"),
     [
       selectedPairingKey,
@@ -220,7 +227,8 @@ export function MyPairingsContent() {
       loadoutGranularity,
       rangeStartDate,
       rangeEndDate,
-      excludedReportTypes,
+      excludedActivities,
+      excludedBattles,
     ]
   );
 
@@ -400,7 +408,8 @@ export function MyPairingsContent() {
     loadoutKey: opponentLoadoutKey,
     startDate: rangeStartDate,
     endDate: rangeEndDate,
-    excludeTypes: excludedReportTypes,
+    excludeActivities: excludedActivities,
+    excludeBattles: excludedBattles,
   });
 
   useEffect(() => {
@@ -449,8 +458,10 @@ export function MyPairingsContent() {
         endDate={endDate}
         onStartDateChange={setStartDate}
         onEndDateChange={setEndDate}
-        excludedReportTypes={excludedReportTypes}
-        onExcludedReportTypesChange={setExcludedReportTypes}
+        excludedActivities={excludedActivities}
+        onExcludedActivitiesChange={setExcludedActivities}
+        excludedBattles={excludedBattles}
+        onExcludedBattlesChange={setExcludedBattles}
       />
       <PairingsLoadouts
         pairingsLoading={pairingsLoading}

--- a/packages/site/src/components/my-pairings/pairings-filters.tsx
+++ b/packages/site/src/components/my-pairings/pairings-filters.tsx
@@ -6,9 +6,10 @@ import { Input } from "@/components/ui/input";
 import { Listbox, ListboxLabel, ListboxOption } from "@/components/ui/listbox";
 import { formatLocalDateInput } from "@/lib/datetime";
 import {
-  formatExcludedPairingsReportTypes,
+  formatExcludedPairingsFilters,
   type LoadoutGranularity,
-  type PairingsReportType,
+  type PairingsActivity,
+  type PairingsBattleType,
 } from "@/lib/pairings";
 
 type PairingOption = {
@@ -27,8 +28,10 @@ type PairingsFiltersProps = {
   endDate: string;
   onStartDateChange: (value: string) => void;
   onEndDateChange: (value: string) => void;
-  excludedReportTypes: PairingsReportType[];
-  onExcludedReportTypesChange: (value: PairingsReportType[]) => void;
+  excludedActivities: PairingsActivity[];
+  onExcludedActivitiesChange: (value: PairingsActivity[]) => void;
+  excludedBattles: PairingsBattleType[];
+  onExcludedBattlesChange: (value: PairingsBattleType[]) => void;
 };
 
 export function PairingsFilters({
@@ -42,22 +45,28 @@ export function PairingsFilters({
   endDate,
   onStartDateChange,
   onEndDateChange,
-  excludedReportTypes,
-  onExcludedReportTypesChange,
+  excludedActivities,
+  onExcludedActivitiesChange,
+  excludedBattles,
+  onExcludedBattlesChange,
 }: PairingsFiltersProps) {
   const t = useExtracted();
   const minDate = "2025-01-01";
   const maxDate = formatLocalDateInput(new Date());
-  const excludeTypeLabels: Record<PairingsReportType, string> = {
+  const activityLabels: Record<PairingsActivity, string> = {
     ark: t("Ark of Osiris"),
     home: t("Home"),
     kvk: t("KVK"),
     strife: t("Supreme Strife"),
   };
-  const excludedTypeSummary = formatExcludedPairingsReportTypes(
-    excludedReportTypes,
-    excludeTypeLabels
-  );
+  const battleLabels: Record<PairingsBattleType, string> = {
+    "open-field": t("Open Field"),
+    swarming: t("Swarming"),
+    rally: t("Rally"),
+    garrison: t("Garrison"),
+  };
+  const excludedActivitySummary = formatExcludedPairingsFilters(excludedActivities, activityLabels);
+  const excludedBattleSummary = formatExcludedPairingsFilters(excludedBattles, battleLabels);
 
   return (
     <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -110,16 +119,16 @@ export function PairingsFilters({
         </Listbox>
       </Field>
       <Field className="space-y-2">
-        <Label>{t("Exclude battles")}</Label>
-        <Listbox<PairingsReportType>
-          aria-label={t("Exclude battles")}
-          value={excludedReportTypes}
-          onChange={onExcludedReportTypesChange}
+        <Label>{t("Exclude activities")}</Label>
+        <Listbox<PairingsActivity>
+          aria-label={t("Exclude activities")}
+          value={excludedActivities}
+          onChange={onExcludedActivitiesChange}
           multiple
           placeholder={t("None")}
           renderValue={() =>
-            excludedTypeSummary ? (
-              <span className="block truncate">{excludedTypeSummary}</span>
+            excludedActivitySummary ? (
+              <span className="block truncate">{excludedActivitySummary}</span>
             ) : (
               <span className="block truncate text-zinc-500">{t("None")}</span>
             )
@@ -136,6 +145,36 @@ export function PairingsFilters({
           </ListboxOption>
           <ListboxOption value="home">
             <ListboxLabel>{t("Home")}</ListboxLabel>
+          </ListboxOption>
+        </Listbox>
+      </Field>
+      <Field className="space-y-2">
+        <Label>{t("Exclude battles")}</Label>
+        <Listbox<PairingsBattleType>
+          aria-label={t("Exclude battles")}
+          value={excludedBattles}
+          onChange={onExcludedBattlesChange}
+          multiple
+          placeholder={t("None")}
+          renderValue={() =>
+            excludedBattleSummary ? (
+              <span className="block truncate">{excludedBattleSummary}</span>
+            ) : (
+              <span className="block truncate text-zinc-500">{t("None")}</span>
+            )
+          }
+        >
+          <ListboxOption value="open-field">
+            <ListboxLabel>{t("Open Field")}</ListboxLabel>
+          </ListboxOption>
+          <ListboxOption value="swarming">
+            <ListboxLabel>{t("Swarming")}</ListboxLabel>
+          </ListboxOption>
+          <ListboxOption value="rally">
+            <ListboxLabel>{t("Rally")}</ListboxLabel>
+          </ListboxOption>
+          <ListboxOption value="garrison">
+            <ListboxLabel>{t("Garrison")}</ListboxLabel>
           </ListboxOption>
         </Listbox>
       </Field>

--- a/packages/site/src/hooks/use-pairing-loadouts.ts
+++ b/packages/site/src/hooks/use-pairing-loadouts.ts
@@ -6,7 +6,8 @@ import type {
   LoadoutGranularity,
   PairingLoadoutsResponse,
   PairingLoadoutsResult,
-  PairingsReportType,
+  PairingsActivity,
+  PairingsBattleType,
 } from "@/lib/pairings";
 import { buildPairingsRangeParams, PAIRINGS_GENERIC_ERROR } from "@/lib/pairings";
 
@@ -17,7 +18,8 @@ export function usePairingLoadouts(options: {
   granularity: LoadoutGranularity;
   startDate?: string;
   endDate?: string;
-  excludeTypes?: PairingsReportType[];
+  excludeActivities?: PairingsActivity[];
+  excludeBattles?: PairingsBattleType[];
 }): PairingLoadoutsResult {
   const {
     governorId,
@@ -26,7 +28,8 @@ export function usePairingLoadouts(options: {
     granularity,
     startDate,
     endDate,
-    excludeTypes,
+    excludeActivities,
+    excludeBattles,
   } = options;
   const [data, setData] = useState<LoadoutAggregate[]>([]);
   const [loading, setLoading] = useState(false);
@@ -49,7 +52,12 @@ export function usePairingLoadouts(options: {
     setLoading(true);
     setError(null);
 
-    const params = buildPairingsRangeParams({ startDate, endDate, excludeTypes });
+    const params = buildPairingsRangeParams({
+      startDate,
+      endDate,
+      excludeActivities,
+      excludeBattles,
+    });
     params.set("primary", String(primaryCommanderId));
     params.set("secondary", String(secondaryCommanderId));
     params.set("granularity", granularity);
@@ -80,7 +88,8 @@ export function usePairingLoadouts(options: {
     granularity,
     startDate,
     endDate,
-    excludeTypes,
+    excludeActivities,
+    excludeBattles,
   ]);
 
   useEffect(() => {

--- a/packages/site/src/hooks/use-pairing-opponents.ts
+++ b/packages/site/src/hooks/use-pairing-opponents.ts
@@ -6,7 +6,8 @@ import type {
   OpponentGranularity,
   PairingOpponentsResponse,
   PairingOpponentsResult,
-  PairingsReportType,
+  PairingsActivity,
+  PairingsBattleType,
 } from "@/lib/pairings";
 import { buildPairingsRangeParams, PAIRINGS_GENERIC_ERROR } from "@/lib/pairings";
 
@@ -18,7 +19,8 @@ export function usePairingOpponents(options: {
   loadoutKey?: string | null;
   startDate?: string;
   endDate?: string;
-  excludeTypes?: PairingsReportType[];
+  excludeActivities?: PairingsActivity[];
+  excludeBattles?: PairingsBattleType[];
 }): PairingOpponentsResult {
   const {
     governorId,
@@ -28,7 +30,8 @@ export function usePairingOpponents(options: {
     loadoutKey,
     startDate,
     endDate,
-    excludeTypes,
+    excludeActivities,
+    excludeBattles,
   } = options;
   const [data, setData] = useState<OpponentAggregate[]>([]);
   const [loading, setLoading] = useState(false);
@@ -58,7 +61,12 @@ export function usePairingOpponents(options: {
     setLoading(true);
     setError(null);
 
-    const params = buildPairingsRangeParams({ startDate, endDate, excludeTypes });
+    const params = buildPairingsRangeParams({
+      startDate,
+      endDate,
+      excludeActivities,
+      excludeBattles,
+    });
     params.set("primary", String(primaryCommanderId));
     params.set("secondary", String(secondaryCommanderId));
     params.set("granularity", granularity);
@@ -93,7 +101,8 @@ export function usePairingOpponents(options: {
     loadoutKey,
     startDate,
     endDate,
-    excludeTypes,
+    excludeActivities,
+    excludeBattles,
   ]);
 
   useEffect(() => {

--- a/packages/site/src/hooks/use-pairings.ts
+++ b/packages/site/src/hooks/use-pairings.ts
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useState } from "react";
 import type {
   PairingAggregate,
+  PairingsActivity,
+  PairingsBattleType,
   PairingsRange,
-  PairingsReportType,
   PairingsResponse,
   PairingsResult,
 } from "@/lib/pairings";
@@ -21,11 +22,12 @@ type PairingsOptions = {
   governorId: number | null | undefined;
   startDate?: string;
   endDate?: string;
-  excludeTypes?: PairingsReportType[];
+  excludeActivities?: PairingsActivity[];
+  excludeBattles?: PairingsBattleType[];
 };
 
 export function usePairings(options: PairingsOptions): PairingsResult {
-  const { governorId, startDate, endDate, excludeTypes } = options;
+  const { governorId, startDate, endDate, excludeActivities, excludeBattles } = options;
   const [pairings, setPairings] = useState<PairingAggregate[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -44,7 +46,12 @@ export function usePairings(options: PairingsOptions): PairingsResult {
     setError(null);
 
     try {
-      const params = buildPairingsRangeParams({ startDate, endDate, excludeTypes });
+      const params = buildPairingsRangeParams({
+        startDate,
+        endDate,
+        excludeActivities,
+        excludeBattles,
+      });
       const res = await fetch(`/proxy/v1/governor/${governorId}/pairings?${params}`, {
         cache: "no-store",
       });
@@ -65,7 +72,7 @@ export function usePairings(options: PairingsOptions): PairingsResult {
     } finally {
       setLoading(false);
     }
-  }, [governorId, startDate, endDate, excludeTypes]);
+  }, [governorId, startDate, endDate, excludeActivities, excludeBattles]);
 
   useEffect(() => {
     setPairings([]);

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "جرحي بسيطة"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "leicht verletzt"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr "Supreme Strife"
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr "Open Field"
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr "Swarming"
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr "Rally"
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr "Garrison"
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr "Loadout granularity"
 
@@ -886,13 +903,17 @@ msgid "244wra"
 msgstr "Exact"
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
-msgstr "Exclude battles"
+msgid "CieiKz"
+msgstr "Exclude activities"
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
 msgstr "None"
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
+msgstr "Exclude battles"
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
 msgid "ouEHpA"
@@ -1225,10 +1246,6 @@ msgstr "Troop Units"
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Slightly Wounded"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr "Rally"
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,13 +903,17 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
 msgstr "Ninguno"
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
+msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
 msgid "ouEHpA"
@@ -1225,10 +1246,6 @@ msgstr "Unidades de tropas"
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Levemente Heridos"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -883,6 +883,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -895,12 +912,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1234,10 +1255,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Blessés légers"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Luka Ringan"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Ferito lievemente"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "軽傷"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,13 +903,17 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
 msgstr "없음"
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
+msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
 msgid "ouEHpA"
@@ -1225,10 +1246,6 @@ msgstr "병과 유닛"
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "경상"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Tercedera Ringan"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Lekko ranni"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Levemente ferida"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Легко ранен"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "บาดเจ็บเล็กน้อย"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Hafif Yaralı"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "Bị thương nhẹ"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "轻伤"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -874,6 +874,23 @@ msgid "Mro8Zx"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
+msgid "cHoIky"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "hAEZYZ"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+#: src/components/report/report-participant-card.tsx
+msgid "RJ-ZIh"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "2pQ4w5"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
 msgid "StqoPN"
 msgstr ""
 
@@ -886,12 +903,16 @@ msgid "244wra"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
-msgid "XuzWOu"
+msgid "CieiKz"
 msgstr ""
 
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "450Fty"
+msgstr ""
+
+#: src/components/my-pairings/pairings-filters.tsx
+msgid "XuzWOu"
 msgstr ""
 
 #: src/components/my-pairings/pairings-loadout-breakdown.tsx
@@ -1225,10 +1246,6 @@ msgstr ""
 #: src/components/reports/reports-overview-summary-card.tsx
 msgid "1ISgLB"
 msgstr "輕傷"
-
-#: src/components/report/report-participant-card.tsx
-msgid "RJ-ZIh"
-msgstr ""
 
 #: src/components/report/report-relic-section.tsx
 msgid "Ft8yjo"

--- a/packages/site/src/lib/pairings.ts
+++ b/packages/site/src/lib/pairings.ts
@@ -2,14 +2,16 @@ import type { EquipmentToken } from "@/lib/report/parsers";
 
 export const PAIRINGS_GENERIC_ERROR = "Failed to load pairings.";
 
-export type PairingsReportType = "ark" | "home" | "kvk" | "strife";
+export type PairingsActivity = "ark" | "home" | "kvk" | "strife";
+export type PairingsBattleType = "open-field" | "swarming" | "rally" | "garrison";
 
 export function buildPairingsRangeParams(options: {
   startDate?: string;
   endDate?: string;
-  excludeTypes?: PairingsReportType[];
+  excludeActivities?: PairingsActivity[];
+  excludeBattles?: PairingsBattleType[];
 }) {
-  const { startDate, endDate, excludeTypes } = options;
+  const { startDate, endDate, excludeActivities, excludeBattles } = options;
   const params =
     startDate && endDate
       ? new URLSearchParams({ start: startDate, end: endDate })
@@ -18,22 +20,26 @@ export function buildPairingsRangeParams(options: {
           end: `${new Date().getUTCFullYear()}-12-31`,
         });
 
-  if (excludeTypes && excludeTypes.length > 0) {
-    params.set("excludeTypes", excludeTypes.join(","));
+  if (excludeActivities && excludeActivities.length > 0) {
+    params.set("excludeActivities", excludeActivities.join(","));
+  }
+
+  if (excludeBattles && excludeBattles.length > 0) {
+    params.set("excludeBattles", excludeBattles.join(","));
   }
 
   return params;
 }
 
-export function formatExcludedPairingsReportTypes(
-  excludeTypes: PairingsReportType[],
-  options: Record<PairingsReportType, string>
+export function formatExcludedPairingsFilters<T extends string>(
+  excluded: T[],
+  options: Record<T, string>
 ) {
-  if (excludeTypes.length === 0) {
+  if (excluded.length === 0) {
     return null;
   }
 
-  return excludeTypes.map((type) => options[type]).join(", ");
+  return excluded.map((value) => options[value]).join(", ");
 }
 
 export type PairingTotals = {


### PR DESCRIPTION
## Summary

- rename the existing My Pairings report-type filter to `Exclude activities` and rename its API parameter to `excludeActivities`
- add an `Exclude battles` multi-select for Open Field, Swarming, Rally, and Garrison, defaulting to no exclusions
- thread both filters through pairings, loadout, and opponent requests and aggregation queries
- classify reports with mutually exclusive precedence: Garrison, Rally, Swarming, then Open Field
- use native Mongo match and `$elemMatch` predicates instead of `$expr`/`$filter` for battle classification
- add API parsing, classification-condition, default-inclusion, and combined-filter regression coverage

## Classification

- **Garrison:** the sender has an alliance building ID or structure ID
- **Rally:** the non-garrison sender has `rally = true`
- **Swarming:** the sender is neither a rally nor garrison and at least one opponent is a rally or garrison
- **Open Field:** neither the sender nor any opponent is a rally or garrison

The processed Battle samples contain examples of all four categories, with no sender records that conflict between Rally and Garrison.

## Query and index review

The three endpoints share two query shapes, both already covered by existing ESR-ordered compound indexes:

- pairings: `sender.player_id` equality + `metadata.mail_time` range
- loadouts/opponents: `sender.player_id` and sender primary commander equality + `metadata.mail_time` range

No index was added. Activity and battle exclusions are negative residual predicates after the selective governor/date scan, while `$expr` cannot use the multikey opponent indexes. Additional rally/structure indexes would increase write and storage overhead without reducing the candidate documents examined.

MongoDB 8.0.24 `explain("executionStats")` was run against 41,800 representative documents derived from all 38 processed Battle samples, including 38,000 reports for the measured governor and the repository's 19 battle indexes. Every scenario used an index and avoided `COLLSCAN`. The native rewrite preserved result counts and documents examined for Open Field, Swarming, Rally, and Garrison. Median query time across seven runs improved by approximately 15%, 49%, 54%, and 10%, respectively. A 2025 date-range query selected `(sender.player_id, metadata.mail_time)`, while primary-commander queries selected `(sender.player_id, sender.commanders.primary.id, metadata.mail_time)`. Excluding all four battle types produced an empty plan with zero keys and documents examined.

Mongo references: [ESR guideline](https://www.mongodb.com/docs/manual/tutorial/equality-sort-range-guideline/), [`$expr` multikey limitation](https://www.mongodb.com/docs/manual/core/indexes/index-types/index-multikey/#expr).

## Validation

- `cargo test -p rokbattles-api` (122 passed)
- `cargo clippy -p rokbattles-api --all-targets --all-features --locked -- -D warnings`
- `pnpm --filter @rokbattles/site typecheck`
- `pnpm --filter @rokbattles/site build`
- `pnpm exec biome check` on changed site source files
- `npx react-doctor@latest --verbose --scope changed` (no changed-code diagnostics)