### PR TITLE
feat(battle): extract lost land script schema

### DIFF
--- a/crates/mail/processors/battle/src/metadata.rs
+++ b/crates/mail/processors/battle/src/metadata.rs
@@ -2,7 +2,7 @@
 
 use mail_sdk::{
     ExtractError, Extractor, Section, extract_base_metadata, optional_bool_field,
-    require_string_field, require_u64_field,
+    optional_u64_field, require_string_field, require_u64_field,
 };
 use serde_json::{Map, Value};
 
@@ -33,11 +33,13 @@ impl Extractor for MetadataExtractor {
         let report_id = require_u64_field(content, "Id")?;
         let mail_role = require_string_field(content, "Role")?;
         let kvk = resolve_kvk(&mail_role, content, metadata.server_id)?;
+        let ll_script_schema = optional_u64_field(content, "LLScriptSchema")?;
 
         let mut section = metadata.into_section();
         section.insert("report_id", Value::from(report_id));
         section.insert("mail_role", Value::String(mail_role));
         section.insert("kvk", Value::Bool(kvk));
+        section.insert("ll_script_schema", ll_script_schema.map_or(Value::Null, Value::from));
         Ok(section)
     }
 }
@@ -246,5 +248,57 @@ mod tests {
         let section = extractor.extract(&input).unwrap();
         let fields = section.fields();
         assert_eq!(fields["kvk"], json!(false));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(320)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(320));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_zero_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(0)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(0));
+    }
+
+    #[test]
+    fn metadata_extractor_uses_null_when_ll_script_schema_is_absent() {
+        let input = metadata_input_with_ll_script_schema(None);
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], Value::Null);
+    }
+
+    fn metadata_input_with_ll_script_schema(ll_script_schema: Option<Value>) -> Value {
+        let mut input = json!({
+            "id": "mail-1",
+            "time": 1234,
+            "receiver": "player-1",
+            "serverId": 55,
+            "body": {
+                "content": {
+                    "Id": 18930744,
+                    "Role": "gsmp",
+                    "isConquerSeason": true,
+                    "SelfChar": {
+                        "COSId": 10
+                    }
+                }
+            }
+        });
+
+        if let Some(value) = ll_script_schema {
+            input["body"]["content"]["LLScriptSchema"] = value;
+        }
+
+        input
     }
 }

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1002579517552941234",
     "mail_receiver": "player_110176153",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "100439187175234501131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 304,
     "mail_id": "10121648172261838131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10163399175529366525",
     "mail_receiver": "player_129397124",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "10200933177249262113",
     "mail_receiver": "player_53517007",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10224136175529255431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036544617552967227",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036588117552967397",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036600917552967417",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 0,
     "mail_id": "104653012170810554331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "106171761165497242010",
     "mail_receiver": "player_32180759",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "1409019176893142331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "152526555167004536031",
     "mail_receiver": "player_71738515",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "16125090175544125330",
     "mail_receiver": "player_34961809",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 0,
     "mail_id": "16210617176935008431",
     "mail_receiver": "player_71738515",
     "mail_role": "dungeon",

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "18895907175034307923",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "2225911117695327552",
     "mail_receiver": "player_32523681",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "28700881175578047431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "29048795175579066131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "30346123155694137715",
     "mail_receiver": "player_14022209",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "31709368176977161019",
     "mail_receiver": "player_47043938",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 810,
     "mail_id": "32282022178380122828",
     "mail_receiver": "player_83629727",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "33830971176980291131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "41633096157514072311",
     "mail_receiver": "player_23984527",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 819,
     "mail_id": "47051167177023603224",
     "mail_receiver": "player_12210123",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "485440176891031331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "53118177176782122317",
     "mail_receiver": "player_37556801",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "54530308177357763431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "58600202175658527723",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "60719727166813248216",
     "mail_receiver": "player_12607995",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "67826590176494996531",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "69428020161978725321",
     "mail_receiver": "player_4361125",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "7948875176322794831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "80922048176537396031",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407016178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407037178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 412,
     "mail_id": "8421200117137313126",
     "mail_receiver": "player_46387535",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "914085176607419831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",


### PR DESCRIPTION
## Summary

- extract `LLScriptSchema` into battle report metadata as `ll_script_schema`
- preserve the report value exactly, including `0`
- return `null` when older reports do not include the field
- regenerate the tracked Battle sample outputs

## Why

`LLScriptSchema` identifies the Lost Land map script associated with a battle report when that information is available. Exposing the raw value allows consumers to classify reports by their Lost Land map without treating reports that omit the field as belonging to a particular map.

## Validation

- `cargo test -p mail-processor-battle`
- `cargo clippy -p mail-processor-battle --all-targets --locked -- -D warnings`
- `cargo fmt --check`
- regenerated all tracked `samples/Battle` outputs with `mail-cli`
- verified every generated `ll_script_schema` matches its decoded source
