### PR TITLE
feat(battle): extract player server season

### DIFF
--- a/crates/mail/processors/battle/src/metadata.rs
+++ b/crates/mail/processors/battle/src/metadata.rs
@@ -2,7 +2,7 @@
 
 use mail_sdk::{
     ExtractError, Extractor, Section, extract_base_metadata, optional_bool_field,
-    require_string_field, require_u64_field,
+    optional_u64_field, require_string_field, require_u64_field,
 };
 use serde_json::{Map, Value};
 
@@ -33,11 +33,13 @@ impl Extractor for MetadataExtractor {
         let report_id = require_u64_field(content, "Id")?;
         let mail_role = require_string_field(content, "Role")?;
         let kvk = resolve_kvk(&mail_role, content, metadata.server_id)?;
+        let ll_script_schema = optional_u64_field(content, "LLScriptSchema")?;
 
         let mut section = metadata.into_section();
         section.insert("report_id", Value::from(report_id));
         section.insert("mail_role", Value::String(mail_role));
         section.insert("kvk", Value::Bool(kvk));
+        section.insert("ll_script_schema", ll_script_schema.map_or(Value::Null, Value::from));
         Ok(section)
     }
 }
@@ -246,5 +248,57 @@ mod tests {
         let section = extractor.extract(&input).unwrap();
         let fields = section.fields();
         assert_eq!(fields["kvk"], json!(false));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(320)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(320));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_zero_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(0)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(0));
+    }
+
+    #[test]
+    fn metadata_extractor_uses_null_when_ll_script_schema_is_absent() {
+        let input = metadata_input_with_ll_script_schema(None);
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], Value::Null);
+    }
+
+    fn metadata_input_with_ll_script_schema(ll_script_schema: Option<Value>) -> Value {
+        let mut input = json!({
+            "id": "mail-1",
+            "time": 1234,
+            "receiver": "player-1",
+            "serverId": 55,
+            "body": {
+                "content": {
+                    "Id": 18930744,
+                    "Role": "gsmp",
+                    "isConquerSeason": true,
+                    "SelfChar": {
+                        "COSId": 10
+                    }
+                }
+            }
+        });
+
+        if let Some(value) = ll_script_schema {
+            input["body"]["content"]["LLScriptSchema"] = value;
+        }
+
+        input
     }
 }

--- a/crates/mail/processors/battle/src/player.rs
+++ b/crates/mail/processors/battle/src/player.rs
@@ -57,6 +57,7 @@ pub(crate) fn extract_player_fields(
     let support_skills = extract_support_skills(player)?;
     let auxiliary_skills = extract_auxiliary_skills(player)?;
     let (app_id, app_uid) = extract_app_identity(player)?;
+    let server_season = optional_string_field(player, "SerSeason")?;
     let (avatar_url, frame_url) = parse_avatar(player)?;
     let supreme_strife = extract_supreme_strife(player)?;
 
@@ -94,6 +95,10 @@ pub(crate) fn extract_player_fields(
     fields.insert("auxiliary_skills".to_string(), auxiliary_skills);
     fields.insert("app_id".to_string(), app_id.map(Value::from).unwrap_or(Value::Null));
     fields.insert("app_uid".to_string(), app_uid.map(Value::from).unwrap_or(Value::Null));
+    fields.insert(
+        "server_season".to_string(),
+        server_season.map(Value::String).unwrap_or(Value::Null),
+    );
     fields.insert("avatar_url".to_string(), avatar_url);
     fields.insert("frame_url".to_string(), frame_url);
     fields.insert("supreme_strife".to_string(), supreme_strife);
@@ -527,6 +532,33 @@ mod tests {
         player.remove("COSId");
         let fields = extract_player_fields(&player).unwrap();
         assert_eq!(fields.get("kingdom_id"), Some(&json!(null)));
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_server_season() {
+        let mut player = base_player();
+        player.insert("SerSeason".to_string(), json!("100"));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["server_season"], json!("100"));
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_empty_server_season() {
+        let mut player = base_player();
+        player.insert("SerSeason".to_string(), json!(""));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["server_season"], json!(""));
+    }
+
+    #[test]
+    fn extract_player_fields_uses_null_when_server_season_is_absent() {
+        let fields = extract_player_fields(&base_player()).unwrap();
+
+        assert_eq!(fields["server_season"], Value::Null);
     }
 
     #[test]

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -185,6 +185,7 @@
       "player_id": 130014943,
       "player_name": "xAvarice",
       "rally": null,
+      "server_season": "100",
       "start_tick": 312472,
       "structure_id": null,
       "support_skills": {
@@ -325,6 +326,7 @@
     "player_id": 110176153,
     "player_name": "F7yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1002579517552941234",
     "mail_receiver": "player_110176153",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -192,6 +192,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -402,6 +403,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -608,6 +610,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -818,6 +821,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -1024,6 +1028,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -1522,6 +1527,7 @@
       "player_id": 80837230,
       "player_name": "西伯利亞狼",
       "rally": true,
+      "server_season": "100",
       "start_tick": 109490,
       "structure_id": null,
       "support_skills": {
@@ -1749,6 +1755,7 @@
     "player_id": 71738515,
     "player_name": "agent G",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "100439187175234501131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 304,
     "mail_id": "10121648172261838131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -196,6 +196,7 @@
       "player_id": 89554760,
       "player_name": "KanomTᵒᵐ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120717,
       "structure_id": null,
       "support_skills": {
@@ -928,6 +929,7 @@
       "player_id": 59351306,
       "player_name": "SOMTAM Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120689,
       "structure_id": null,
       "support_skills": {
@@ -1462,6 +1464,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120793,
       "structure_id": null,
       "support_skills": {
@@ -1668,6 +1671,7 @@
       "player_id": 149352350,
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -1878,6 +1882,7 @@
       "player_id": 149352350,
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2084,6 +2089,7 @@
       "player_id": 23016065,
       "player_name": "Mr Jeep",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120719,
       "structure_id": null,
       "support_skills": {
@@ -2294,6 +2300,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2504,6 +2511,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -2718,6 +2726,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120705,
       "structure_id": null,
       "support_skills": {
@@ -2909,6 +2918,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120704,
       "structure_id": null,
       "support_skills": {
@@ -3119,6 +3129,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -3329,6 +3340,7 @@
       "player_id": 148711145,
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3539,6 +3551,7 @@
       "player_id": 148711145,
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3753,6 +3766,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120712,
       "structure_id": null,
       "support_skills": {
@@ -3959,6 +3973,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120709,
       "structure_id": null,
       "support_skills": {
@@ -4169,6 +4184,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -4379,6 +4395,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120711,
       "structure_id": null,
       "support_skills": {
@@ -4589,6 +4606,7 @@
       "player_id": 5221475,
       "player_name": "Mr nuer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -4799,6 +4817,7 @@
       "player_id": 5221475,
       "player_name": "Mr nuer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120769,
       "structure_id": null,
       "support_skills": {
@@ -5009,6 +5028,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120702,
       "structure_id": null,
       "support_skills": {
@@ -5208,6 +5228,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120783,
       "structure_id": null,
       "support_skills": {
@@ -5418,6 +5439,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120777,
       "structure_id": null,
       "support_skills": {
@@ -5628,6 +5650,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -5830,6 +5853,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6040,6 +6064,7 @@
       "player_id": 10824810,
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6246,6 +6271,7 @@
       "player_id": 10824810,
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -6456,6 +6482,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -6666,6 +6693,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120779,
       "structure_id": null,
       "support_skills": {
@@ -6872,6 +6900,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7082,6 +7111,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -7292,6 +7322,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7502,6 +7533,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120790,
       "structure_id": null,
       "support_skills": {
@@ -7716,6 +7748,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120787,
       "structure_id": null,
       "support_skills": {
@@ -7926,6 +7959,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120788,
       "structure_id": null,
       "support_skills": {
@@ -8132,6 +8166,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120789,
       "structure_id": null,
       "support_skills": {
@@ -8342,6 +8377,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -8817,6 +8853,7 @@
     "player_id": 34961809,
     "player_name": "비아티나",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10163399175529366525",
     "mail_receiver": "player_129397124",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 312015,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 129397124,
     "player_name": "F6yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -214,6 +214,7 @@
       "player_id": 56779522,
       "player_name": "Raha ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315491,
       "structure_id": null,
       "support_skills": {
@@ -560,6 +561,7 @@
     "player_id": 20075558,
     "player_name": "jën x ƒaräɀ",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "10200933177249262113",
     "mail_receiver": "player_53517007",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -192,6 +192,7 @@
       "player_id": 129155556,
       "player_name": "ˢNinoveraptor",
       "rally": null,
+      "server_season": "100",
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -387,6 +388,7 @@
       "player_id": 129155556,
       "player_name": "ˢNinoveraptor",
       "rally": null,
+      "server_season": "100",
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -527,6 +529,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10224136175529255431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315072,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036544617552967227",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036588117552967397",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315089,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315091,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036600917552967417",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -480,6 +480,7 @@
       "player_id": 18285347,
       "player_name": "ミ K H A L I D",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505754,
       "structure_id": null,
       "support_skills": {
@@ -671,6 +672,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -862,6 +864,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1061,6 +1064,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1260,6 +1264,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -1451,6 +1456,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505876,
       "structure_id": null,
       "support_skills": {
@@ -1646,6 +1652,7 @@
       "player_id": 154193427,
       "player_name": "ミ Solgaleo ミ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505790,
       "structure_id": null,
       "support_skills": {
@@ -1841,6 +1848,7 @@
       "player_id": 153947353,
       "player_name": "bedebuh",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505772,
       "structure_id": null,
       "support_skills": {
@@ -2036,6 +2044,7 @@
       "player_id": 156028467,
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -2227,6 +2236,7 @@
       "player_id": 151201578,
       "player_name": "Nicossss",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -2422,6 +2432,7 @@
       "player_id": 156028467,
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505840,
       "structure_id": null,
       "support_skills": {
@@ -2625,6 +2636,7 @@
       "player_id": 153873531,
       "player_name": "Lelouchhシ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505811,
       "structure_id": null,
       "support_skills": {
@@ -2824,6 +2836,7 @@
       "player_id": 142651363,
       "player_name": "香水じゅん",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505799,
       "structure_id": null,
       "support_skills": {
@@ -3019,6 +3032,7 @@
       "player_id": 153434524,
       "player_name": "TANSAA",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -3214,6 +3228,7 @@
       "player_id": 155144299,
       "player_name": "ヅYusekeᵀᴴ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505835,
       "structure_id": null,
       "support_skills": {
@@ -3405,6 +3420,7 @@
       "player_id": 153434524,
       "player_name": "TANSAA",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505786,
       "structure_id": null,
       "support_skills": {
@@ -3600,6 +3616,7 @@
       "player_id": 154838551,
       "player_name": "ExCalìbur",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -4068,6 +4085,7 @@
     "player_id": 71738515,
     "player_name": "ᵀᴼバニー",
     "rally": true,
+    "server_season": "3",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 0,
     "mail_id": "104653012170810554331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1089,6 +1089,7 @@
       "player_id": 21580496,
       "player_name": "Ni丶大佑",
       "rally": null,
+      "server_season": null,
       "start_tick": 962476,
       "structure_id": null,
       "support_skills": {
@@ -1267,6 +1268,7 @@
       "player_id": 20107958,
       "player_name": "Ni 丶毒城",
       "rally": null,
+      "server_season": null,
       "start_tick": 962493,
       "structure_id": null,
       "support_skills": {
@@ -1437,6 +1439,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1615,6 +1618,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1793,6 +1797,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -1950,6 +1955,7 @@
       "player_id": 22795846,
       "player_name": "不放大極靈",
       "rally": null,
+      "server_season": null,
       "start_tick": 962521,
       "structure_id": null,
       "support_skills": {
@@ -2124,6 +2130,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -2294,6 +2301,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962529,
       "structure_id": null,
       "support_skills": {
@@ -2472,6 +2480,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2646,6 +2655,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2824,6 +2834,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -2998,6 +3009,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962574,
       "structure_id": null,
       "support_skills": {
@@ -3168,6 +3180,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962588,
       "structure_id": null,
       "support_skills": {
@@ -3342,6 +3355,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962595,
       "structure_id": null,
       "support_skills": {
@@ -3520,6 +3534,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -3698,6 +3713,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962603,
       "structure_id": null,
       "support_skills": {
@@ -3880,6 +3896,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962610,
       "structure_id": null,
       "support_skills": {
@@ -4054,6 +4071,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -4228,6 +4246,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4406,6 +4425,7 @@
       "player_id": 40988463,
       "player_name": "相思鸟",
       "rally": null,
+      "server_season": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4584,6 +4604,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962652,
       "structure_id": null,
       "support_skills": {
@@ -4754,6 +4775,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962666,
       "structure_id": null,
       "support_skills": {
@@ -4928,6 +4950,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962680,
       "structure_id": null,
       "support_skills": {
@@ -5098,6 +5121,7 @@
       "player_id": 3781975,
       "player_name": "Ni Ball Master",
       "rally": null,
+      "server_season": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -5272,6 +5296,7 @@
       "player_id": 40988463,
       "player_name": "相思鸟",
       "rally": null,
+      "server_season": null,
       "start_tick": 962694,
       "structure_id": null,
       "support_skills": {
@@ -5450,6 +5475,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962701,
       "structure_id": null,
       "support_skills": {
@@ -5624,6 +5650,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -6261,6 +6288,7 @@
     "player_id": 32180759,
     "player_name": "GRRRRRRREAT",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "106171761165497242010",
     "mail_receiver": "player_32180759",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "1409019176893142331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -154,6 +154,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 35058,
       "structure_id": null,
       "support_skills": {
@@ -285,6 +286,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "152526555167004536031",
     "mail_receiver": "player_71738515",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -189,6 +189,7 @@
       "player_id": 72217206,
       "player_name": "Queen SammyJo",
       "rally": null,
+      "server_season": null,
       "start_tick": 1378409,
       "structure_id": null,
       "support_skills": {
@@ -488,6 +489,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -196,6 +196,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458684,
       "structure_id": null,
       "support_skills": {
@@ -402,6 +403,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458683,
       "structure_id": null,
       "support_skills": {
@@ -612,6 +614,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458697,
       "structure_id": null,
       "support_skills": {
@@ -822,6 +825,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1028,6 +1032,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1183,6 +1188,7 @@
     "player_id": 34961809,
     "player_name": "Viatina乂Fayst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "16125090175544125330",
     "mail_receiver": "player_34961809",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -268,6 +268,7 @@
       "player_id": 116551956,
       "player_name": "TEDDY916",
       "rally": true,
+      "server_season": "-1",
       "start_tick": 444,
       "structure_id": null,
       "support_skills": {
@@ -466,6 +467,7 @@
     "player_id": 129213098,
     "player_name": "ˢ vashido",
     "rally": null,
+    "server_season": "-1",
     "structure_id": 109,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 0,
     "mail_id": "16210617176935008431",
     "mail_receiver": "player_71738515",
     "mail_role": "dungeon",

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "18895907175034307923",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -9052,6 +9052,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627430,
       "structure_id": null,
       "support_skills": {
@@ -9262,6 +9263,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627539,
       "structure_id": null,
       "support_skills": {
@@ -9471,6 +9473,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627514,
       "structure_id": null,
       "support_skills": {
@@ -9678,6 +9681,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627557,
       "structure_id": null,
       "support_skills": {
@@ -9867,6 +9871,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627614,
       "structure_id": null,
       "support_skills": {
@@ -10066,6 +10071,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10265,6 +10271,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627653,
       "structure_id": null,
       "support_skills": {
@@ -10464,6 +10471,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10625,6 +10633,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -10832,6 +10841,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -11005,6 +11015,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627730,
       "structure_id": null,
       "support_skills": {
@@ -11167,6 +11178,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627732,
       "structure_id": null,
       "support_skills": {
@@ -11366,6 +11378,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627738,
       "structure_id": null,
       "support_skills": {
@@ -11572,6 +11585,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627769,
       "structure_id": null,
       "support_skills": {
@@ -11773,6 +11787,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627772,
       "structure_id": null,
       "support_skills": {
@@ -11968,6 +11983,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627789,
       "structure_id": null,
       "support_skills": {
@@ -12165,6 +12181,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627827,
       "structure_id": null,
       "support_skills": {
@@ -12360,6 +12377,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627830,
       "structure_id": null,
       "support_skills": {
@@ -12565,6 +12583,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627831,
       "structure_id": null,
       "support_skills": {
@@ -12760,6 +12779,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627836,
       "structure_id": null,
       "support_skills": {
@@ -12938,6 +12958,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627850,
       "structure_id": null,
       "support_skills": {
@@ -13137,6 +13158,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627856,
       "structure_id": null,
       "support_skills": {
@@ -13336,6 +13358,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627860,
       "structure_id": null,
       "support_skills": {
@@ -13550,6 +13573,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627862,
       "structure_id": null,
       "support_skills": {
@@ -13745,6 +13769,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627876,
       "structure_id": null,
       "support_skills": {
@@ -13950,6 +13975,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627882,
       "structure_id": null,
       "support_skills": {
@@ -14164,6 +14190,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627884,
       "structure_id": null,
       "support_skills": {
@@ -14363,6 +14390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627907,
       "structure_id": null,
       "support_skills": {
@@ -14577,6 +14605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627910,
       "structure_id": null,
       "support_skills": {
@@ -14776,6 +14805,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -14989,6 +15019,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -15191,6 +15222,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627950,
       "structure_id": null,
       "support_skills": {
@@ -15390,6 +15422,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627954,
       "structure_id": null,
       "support_skills": {
@@ -15604,6 +15637,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627956,
       "structure_id": null,
       "support_skills": {
@@ -15799,6 +15833,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627982,
       "structure_id": null,
       "support_skills": {
@@ -15998,6 +16033,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627978,
       "structure_id": null,
       "support_skills": {
@@ -16212,6 +16248,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627981,
       "structure_id": null,
       "support_skills": {
@@ -16411,6 +16448,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627986,
       "structure_id": null,
       "support_skills": {
@@ -16610,6 +16648,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628001,
       "structure_id": null,
       "support_skills": {
@@ -16824,6 +16863,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628004,
       "structure_id": null,
       "support_skills": {
@@ -17023,6 +17063,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628024,
       "structure_id": null,
       "support_skills": {
@@ -17237,6 +17278,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628027,
       "structure_id": null,
       "support_skills": {
@@ -17395,6 +17437,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628028,
       "structure_id": null,
       "support_skills": {
@@ -17540,6 +17583,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628032,
       "structure_id": null,
       "support_skills": {
@@ -17739,6 +17783,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628034,
       "structure_id": null,
       "support_skills": {
@@ -17930,6 +17975,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628038,
       "structure_id": null,
       "support_skills": {
@@ -18129,6 +18175,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628071,
       "structure_id": null,
       "support_skills": {
@@ -18343,6 +18390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628073,
       "structure_id": null,
       "support_skills": {
@@ -18542,6 +18590,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628096,
       "structure_id": null,
       "support_skills": {
@@ -18756,6 +18805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628098,
       "structure_id": null,
       "support_skills": {
@@ -18947,6 +18997,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19142,6 +19193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19283,6 +19335,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628113,
       "structure_id": null,
       "support_skills": {
@@ -19478,6 +19531,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628114,
       "structure_id": null,
       "support_skills": {
@@ -19654,6 +19708,7 @@
       "player_id": 42046369,
       "player_name": "Ral farm B",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -19849,6 +19904,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -20023,6 +20079,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20226,6 +20283,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628117,
       "structure_id": null,
       "support_skills": {
@@ -20404,6 +20462,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20603,6 +20662,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628120,
       "structure_id": null,
       "support_skills": {
@@ -20798,6 +20858,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628123,
       "structure_id": null,
       "support_skills": {
@@ -20999,6 +21060,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628130,
       "structure_id": null,
       "support_skills": {
@@ -21204,6 +21266,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628136,
       "structure_id": null,
       "support_skills": {
@@ -21544,6 +21607,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628199,
       "structure_id": null,
       "support_skills": {
@@ -21708,6 +21772,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628168,
       "structure_id": null,
       "support_skills": {
@@ -21903,6 +21968,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628173,
       "structure_id": null,
       "support_skills": {
@@ -22108,6 +22174,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628175,
       "structure_id": null,
       "support_skills": {
@@ -22322,6 +22389,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628178,
       "structure_id": null,
       "support_skills": {
@@ -22521,6 +22589,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628181,
       "structure_id": null,
       "support_skills": {
@@ -22716,6 +22785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628184,
       "structure_id": null,
       "support_skills": {
@@ -22917,6 +22987,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628204,
       "structure_id": null,
       "support_skills": {
@@ -23122,6 +23193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628206,
       "structure_id": null,
       "support_skills": {
@@ -23328,6 +23400,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23531,6 +23604,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23730,6 +23804,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628212,
       "structure_id": null,
       "support_skills": {
@@ -23925,6 +24000,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628215,
       "structure_id": null,
       "support_skills": {
@@ -24122,6 +24198,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628224,
       "structure_id": null,
       "support_skills": {
@@ -24327,6 +24404,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628226,
       "structure_id": null,
       "support_skills": {
@@ -24526,6 +24604,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -24723,6 +24802,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -24918,6 +24998,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628249,
       "structure_id": null,
       "support_skills": {
@@ -25123,6 +25204,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628251,
       "structure_id": null,
       "support_skills": {
@@ -25337,6 +25419,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628254,
       "structure_id": null,
       "support_skills": {
@@ -25536,6 +25619,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628257,
       "structure_id": null,
       "support_skills": {
@@ -25731,6 +25815,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628260,
       "structure_id": null,
       "support_skills": {
@@ -25894,6 +25979,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628270,
       "structure_id": null,
       "support_skills": {
@@ -26089,6 +26175,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628274,
       "structure_id": null,
       "support_skills": {
@@ -26290,6 +26377,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628275,
       "structure_id": null,
       "support_skills": {
@@ -26491,6 +26579,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628276,
       "structure_id": null,
       "support_skills": {
@@ -26697,6 +26786,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628278,
       "structure_id": null,
       "support_skills": {
@@ -26898,6 +26988,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628288,
       "structure_id": null,
       "support_skills": {
@@ -27093,6 +27184,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628312,
       "structure_id": null,
       "support_skills": {
@@ -27298,6 +27390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628315,
       "structure_id": null,
       "support_skills": {
@@ -27512,6 +27605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628318,
       "structure_id": null,
       "support_skills": {
@@ -27711,6 +27805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628321,
       "structure_id": null,
       "support_skills": {
@@ -27906,6 +28001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628324,
       "structure_id": null,
       "support_skills": {
@@ -28107,6 +28203,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628342,
       "structure_id": null,
       "support_skills": {
@@ -28302,6 +28399,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628346,
       "structure_id": null,
       "support_skills": {
@@ -28507,6 +28605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628348,
       "structure_id": null,
       "support_skills": {
@@ -28721,6 +28820,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628351,
       "structure_id": null,
       "support_skills": {
@@ -28920,6 +29020,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628354,
       "structure_id": null,
       "support_skills": {
@@ -29115,6 +29216,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628357,
       "structure_id": null,
       "support_skills": {
@@ -29316,6 +29418,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628393,
       "structure_id": null,
       "support_skills": {
@@ -29521,6 +29624,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628396,
       "structure_id": null,
       "support_skills": {
@@ -29735,6 +29839,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628399,
       "structure_id": null,
       "support_skills": {
@@ -29905,6 +30010,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30104,6 +30210,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30299,6 +30406,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628405,
       "structure_id": null,
       "support_skills": {
@@ -30463,6 +30571,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628406,
       "structure_id": null,
       "support_skills": {
@@ -30641,6 +30750,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628431,
       "structure_id": null,
       "support_skills": {
@@ -30836,6 +30946,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628459,
       "structure_id": null,
       "support_skills": {
@@ -30987,6 +31098,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628461,
       "structure_id": null,
       "support_skills": {
@@ -31186,6 +31298,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628471,
       "structure_id": null,
       "support_skills": {
@@ -31355,6 +31468,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628472,
       "structure_id": null,
       "support_skills": {
@@ -31558,6 +31672,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628473,
       "structure_id": null,
       "support_skills": {
@@ -31757,6 +31872,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628476,
       "structure_id": null,
       "support_skills": {
@@ -31952,6 +32068,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628479,
       "structure_id": null,
       "support_skills": {
@@ -32136,6 +32253,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32327,6 +32445,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32526,6 +32645,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628504,
       "structure_id": null,
       "support_skills": {
@@ -32740,6 +32860,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628507,
       "structure_id": null,
       "support_skills": {
@@ -32939,6 +33060,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628510,
       "structure_id": null,
       "support_skills": {
@@ -33134,6 +33256,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628513,
       "structure_id": null,
       "support_skills": {
@@ -33487,6 +33610,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628560,
       "structure_id": null,
       "support_skills": {
@@ -33697,6 +33821,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628532,
       "structure_id": null,
       "support_skills": {
@@ -33911,6 +34036,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628535,
       "structure_id": null,
       "support_skills": {
@@ -34085,6 +34211,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628536,
       "structure_id": null,
       "support_skills": {
@@ -34284,6 +34411,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628538,
       "structure_id": null,
       "support_skills": {
@@ -34479,6 +34607,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628541,
       "structure_id": null,
       "support_skills": {
@@ -34663,6 +34792,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628581,
       "structure_id": null,
       "support_skills": {
@@ -34862,6 +34992,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628590,
       "structure_id": null,
       "support_skills": {
@@ -35076,6 +35207,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628592,
       "structure_id": null,
       "support_skills": {
@@ -35275,6 +35407,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628595,
       "structure_id": null,
       "support_skills": {
@@ -35470,6 +35603,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628598,
       "structure_id": null,
       "support_skills": {
@@ -35675,6 +35809,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628639,
       "structure_id": null,
       "support_skills": {
@@ -35889,6 +36024,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628641,
       "structure_id": null,
       "support_skills": {
@@ -36042,6 +36178,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628642,
       "structure_id": null,
       "support_skills": {
@@ -36241,6 +36378,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628644,
       "structure_id": null,
       "support_skills": {
@@ -36436,6 +36574,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628647,
       "structure_id": null,
       "support_skills": {
@@ -36633,6 +36772,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628660,
       "structure_id": null,
       "support_skills": {
@@ -36828,6 +36968,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628693,
       "structure_id": null,
       "support_skills": {
@@ -37023,6 +37164,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628694,
       "structure_id": null,
       "support_skills": {
@@ -37228,6 +37370,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628697,
       "structure_id": null,
       "support_skills": {
@@ -37442,6 +37585,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628700,
       "structure_id": null,
       "support_skills": {
@@ -37641,6 +37785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628703,
       "structure_id": null,
       "support_skills": {
@@ -37836,6 +37981,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628706,
       "structure_id": null,
       "support_skills": {
@@ -38000,6 +38146,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628725,
       "structure_id": null,
       "support_skills": {
@@ -38195,6 +38342,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628751,
       "structure_id": null,
       "support_skills": {
@@ -38400,6 +38548,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628753,
       "structure_id": null,
       "support_skills": {
@@ -38599,6 +38748,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628754,
       "structure_id": null,
       "support_skills": {
@@ -38813,6 +38963,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628757,
       "structure_id": null,
       "support_skills": {
@@ -39008,6 +39159,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628759,
       "structure_id": null,
       "support_skills": {
@@ -39207,6 +39359,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628760,
       "structure_id": null,
       "support_skills": {
@@ -39402,6 +39555,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628763,
       "structure_id": null,
       "support_skills": {
@@ -39603,6 +39757,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628776,
       "structure_id": null,
       "support_skills": {
@@ -39808,6 +39963,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628779,
       "structure_id": null,
       "support_skills": {
@@ -40022,6 +40178,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628782,
       "structure_id": null,
       "support_skills": {
@@ -40217,6 +40374,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628785,
       "structure_id": null,
       "support_skills": {
@@ -40401,6 +40559,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628828,
       "structure_id": null,
       "support_skills": {
@@ -40596,6 +40755,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628829,
       "structure_id": null,
       "support_skills": {
@@ -40801,6 +40961,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628831,
       "structure_id": null,
       "support_skills": {
@@ -41003,6 +41164,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628832,
       "structure_id": null,
       "support_skills": {
@@ -41181,6 +41343,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -41384,6 +41547,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -41583,6 +41747,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628837,
       "structure_id": null,
       "support_skills": {
@@ -41744,6 +41909,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628838,
       "structure_id": null,
       "support_skills": {
@@ -41914,6 +42080,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42109,6 +42276,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42314,6 +42482,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628850,
       "structure_id": null,
       "support_skills": {
@@ -42515,6 +42684,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628855,
       "structure_id": null,
       "support_skills": {
@@ -42720,6 +42890,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628857,
       "structure_id": null,
       "support_skills": {
@@ -42934,6 +43105,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628860,
       "structure_id": null,
       "support_skills": {
@@ -43133,6 +43305,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628868,
       "structure_id": null,
       "support_skills": {
@@ -43450,6 +43623,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628908,
       "structure_id": null,
       "support_skills": {
@@ -43660,6 +43834,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628878,
       "structure_id": null,
       "support_skills": {
@@ -43859,6 +44034,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628886,
       "structure_id": null,
       "support_skills": {
@@ -44060,6 +44236,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628897,
       "structure_id": null,
       "support_skills": {
@@ -44265,6 +44442,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628900,
       "structure_id": null,
       "support_skills": {
@@ -44479,6 +44657,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628903,
       "structure_id": null,
       "support_skills": {
@@ -44678,6 +44857,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628906,
       "structure_id": null,
       "support_skills": {
@@ -44873,6 +45053,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628909,
       "structure_id": null,
       "support_skills": {
@@ -45053,6 +45234,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628915,
       "structure_id": null,
       "support_skills": {
@@ -45254,6 +45436,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628922,
       "structure_id": null,
       "support_skills": {
@@ -45449,6 +45632,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628933,
       "structure_id": null,
       "support_skills": {
@@ -45654,6 +45838,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628935,
       "structure_id": null,
       "support_skills": {
@@ -45868,6 +46053,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628938,
       "structure_id": null,
       "support_skills": {
@@ -46067,6 +46253,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628941,
       "structure_id": null,
       "support_skills": {
@@ -46262,6 +46449,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628944,
       "structure_id": null,
       "support_skills": {
@@ -46425,6 +46613,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628969,
       "structure_id": null,
       "support_skills": {
@@ -46616,6 +46805,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628973,
       "structure_id": null,
       "support_skills": {
@@ -46811,6 +47001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628981,
       "structure_id": null,
       "support_skills": {
@@ -47016,6 +47207,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628983,
       "structure_id": null,
       "support_skills": {
@@ -47230,6 +47422,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628986,
       "structure_id": null,
       "support_skills": {
@@ -47429,6 +47622,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628989,
       "structure_id": null,
       "support_skills": {
@@ -47624,6 +47818,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628992,
       "structure_id": null,
       "support_skills": {
@@ -47825,6 +48020,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628993,
       "structure_id": null,
       "support_skills": {
@@ -48016,6 +48212,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629009,
       "structure_id": null,
       "support_skills": {
@@ -48219,6 +48416,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629011,
       "structure_id": null,
       "support_skills": {
@@ -48422,6 +48620,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629035,
       "structure_id": null,
       "support_skills": {
@@ -48628,6 +48827,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629032,
       "structure_id": null,
       "support_skills": {
@@ -48833,6 +49033,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629033,
       "structure_id": null,
       "support_skills": {
@@ -49047,6 +49248,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629037,
       "structure_id": null,
       "support_skills": {
@@ -49246,6 +49448,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629040,
       "structure_id": null,
       "support_skills": {
@@ -49441,6 +49644,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629043,
       "structure_id": null,
       "support_skills": {
@@ -49642,6 +49846,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629053,
       "structure_id": null,
       "support_skills": {
@@ -49851,6 +50056,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629055,
       "structure_id": null,
       "support_skills": {
@@ -50046,6 +50252,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629068,
       "structure_id": null,
       "support_skills": {
@@ -50241,6 +50448,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629072,
       "structure_id": null,
       "support_skills": {
@@ -50442,6 +50650,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629085,
       "structure_id": null,
       "support_skills": {
@@ -50647,6 +50856,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629087,
       "structure_id": null,
       "support_skills": {
@@ -50861,6 +51071,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629090,
       "structure_id": null,
       "support_skills": {
@@ -51060,6 +51271,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629093,
       "structure_id": null,
       "support_skills": {
@@ -51255,6 +51467,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629096,
       "structure_id": null,
       "support_skills": {
@@ -51456,6 +51669,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629108,
       "structure_id": null,
       "support_skills": {
@@ -51661,6 +51875,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629110,
       "structure_id": null,
       "support_skills": {
@@ -51875,6 +52090,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629113,
       "structure_id": null,
       "support_skills": {
@@ -52070,6 +52286,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629116,
       "structure_id": null,
       "support_skills": {
@@ -52238,6 +52455,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -52429,6 +52647,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -52628,6 +52847,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -52825,6 +53045,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -52987,6 +53208,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -53157,6 +53379,7 @@
       "player_id": 42046369,
       "player_name": "Ral farm B",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629142,
       "structure_id": null,
       "support_skills": {
@@ -53348,6 +53571,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629149,
       "structure_id": null,
       "support_skills": {
@@ -53543,6 +53767,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629159,
       "structure_id": null,
       "support_skills": {
@@ -53748,6 +53973,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629162,
       "structure_id": null,
       "support_skills": {
@@ -53962,6 +54188,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629165,
       "structure_id": null,
       "support_skills": {
@@ -54161,6 +54388,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629168,
       "structure_id": null,
       "support_skills": {
@@ -54356,6 +54584,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629170,
       "structure_id": null,
       "support_skills": {
@@ -54767,6 +54996,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 629221,
       "structure_id": null,
       "support_skills": {
@@ -54969,6 +55199,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55160,6 +55391,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55359,6 +55591,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55554,6 +55787,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629188,
       "structure_id": null,
       "support_skills": {
@@ -55749,6 +55983,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629189,
       "structure_id": null,
       "support_skills": {
@@ -55933,6 +56168,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629190,
       "structure_id": null,
       "support_skills": {
@@ -56132,6 +56368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629192,
       "structure_id": null,
       "support_skills": {
@@ -56346,6 +56583,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629194,
       "structure_id": null,
       "support_skills": {
@@ -56545,6 +56783,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629198,
       "structure_id": null,
       "support_skills": {
@@ -56740,6 +56979,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629201,
       "structure_id": null,
       "support_skills": {
@@ -56945,6 +57185,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629211,
       "structure_id": null,
       "support_skills": {
@@ -57144,6 +57385,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629219,
       "structure_id": null,
       "support_skills": {
@@ -57347,6 +57589,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629236,
       "structure_id": null,
       "support_skills": {
@@ -57542,6 +57785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629238,
       "structure_id": null,
       "support_skills": {
@@ -57743,6 +57987,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -57948,6 +58193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629240,
       "structure_id": null,
       "support_skills": {
@@ -58162,6 +58408,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629243,
       "structure_id": null,
       "support_skills": {
@@ -58340,6 +58587,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -58545,6 +58793,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629246,
       "structure_id": null,
       "support_skills": {
@@ -58740,6 +58989,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629249,
       "structure_id": null,
       "support_skills": {
@@ -58941,6 +59191,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629267,
       "structure_id": null,
       "support_skills": {
@@ -59146,6 +59397,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629269,
       "structure_id": null,
       "support_skills": {
@@ -59360,6 +59612,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629272,
       "structure_id": null,
       "support_skills": {
@@ -59559,6 +59812,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629275,
       "structure_id": null,
       "support_skills": {
@@ -59754,6 +60008,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629278,
       "structure_id": null,
       "support_skills": {
@@ -59955,6 +60210,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629287,
       "structure_id": null,
       "support_skills": {
@@ -60150,6 +60406,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629295,
       "structure_id": null,
       "support_skills": {
@@ -60345,6 +60602,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629318,
       "structure_id": null,
       "support_skills": {
@@ -60550,6 +60808,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629321,
       "structure_id": null,
       "support_skills": {
@@ -60764,6 +61023,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629323,
       "structure_id": null,
       "support_skills": {
@@ -60963,6 +61223,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629327,
       "structure_id": null,
       "support_skills": {
@@ -61158,6 +61419,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629330,
       "structure_id": null,
       "support_skills": {
@@ -61342,6 +61604,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629335,
       "structure_id": null,
       "support_skills": {
@@ -61537,6 +61800,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629341,
       "structure_id": null,
       "support_skills": {
@@ -61742,6 +62006,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629343,
       "structure_id": null,
       "support_skills": {
@@ -61956,6 +62221,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -62147,6 +62413,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -62338,6 +62605,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629348,
       "structure_id": null,
       "support_skills": {
@@ -62537,6 +62805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629349,
       "structure_id": null,
       "support_skills": {
@@ -62732,6 +63001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629352,
       "structure_id": null,
       "support_skills": {
@@ -62933,6 +63203,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629358,
       "structure_id": null,
       "support_skills": {
@@ -63103,6 +63374,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629390,
       "structure_id": null,
       "support_skills": {
@@ -63298,6 +63570,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629395,
       "structure_id": null,
       "support_skills": {
@@ -63503,6 +63776,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629398,
       "structure_id": null,
       "support_skills": {
@@ -63709,6 +63983,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -63912,6 +64187,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629401,
       "structure_id": null,
       "support_skills": {
@@ -64111,6 +64387,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -64313,6 +64590,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629402,
       "structure_id": null,
       "support_skills": {
@@ -64512,6 +64790,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629404,
       "structure_id": null,
       "support_skills": {
@@ -64707,6 +64986,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629407,
       "structure_id": null,
       "support_skills": {
@@ -64908,6 +65188,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629423,
       "structure_id": null,
       "support_skills": {
@@ -65113,6 +65394,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629425,
       "structure_id": null,
       "support_skills": {
@@ -65319,6 +65601,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629427,
       "structure_id": null,
       "support_skills": {
@@ -65522,6 +65805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629428,
       "structure_id": null,
       "support_skills": {
@@ -65675,6 +65959,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629430,
       "structure_id": null,
       "support_skills": {
@@ -65874,6 +66159,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629431,
       "structure_id": null,
       "support_skills": {
@@ -66069,6 +66355,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629434,
       "structure_id": null,
       "support_skills": {
@@ -66245,6 +66532,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -66448,6 +66736,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -66621,6 +66910,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -66799,6 +67089,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -66998,6 +67289,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629463,
       "structure_id": null,
       "support_skills": {
@@ -67193,6 +67485,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629480,
       "structure_id": null,
       "support_skills": {
@@ -67398,6 +67691,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629482,
       "structure_id": null,
       "support_skills": {
@@ -67612,6 +67906,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629485,
       "structure_id": null,
       "support_skills": {
@@ -67811,6 +68106,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629488,
       "structure_id": null,
       "support_skills": {
@@ -68006,6 +68302,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629491,
       "structure_id": null,
       "support_skills": {
@@ -68157,6 +68454,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629498,
       "structure_id": null,
       "support_skills": {
@@ -68356,6 +68654,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -68555,6 +68854,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -68754,6 +69054,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629504,
       "structure_id": null,
       "support_skills": {
@@ -68915,6 +69216,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629510,
       "structure_id": null,
       "support_skills": {
@@ -69093,6 +69395,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629529,
       "structure_id": null,
       "support_skills": {
@@ -69288,6 +69591,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629533,
       "structure_id": null,
       "support_skills": {
@@ -69483,6 +69787,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629547,
       "structure_id": null,
       "support_skills": {
@@ -69688,6 +69993,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629549,
       "structure_id": null,
       "support_skills": {
@@ -71202,6 +71508,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 629595,
       "structure_id": null,
       "support_skills": {
@@ -71416,6 +71723,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629552,
       "structure_id": null,
       "support_skills": {
@@ -71615,6 +71923,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629555,
       "structure_id": null,
       "support_skills": {
@@ -71810,6 +72119,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629557,
       "structure_id": null,
       "support_skills": {
@@ -72011,6 +72321,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629571,
       "structure_id": null,
       "support_skills": {
@@ -72216,6 +72527,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629573,
       "structure_id": null,
       "support_skills": {
@@ -72405,6 +72717,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629583,
       "structure_id": null,
       "support_skills": {
@@ -72608,6 +72921,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629576,
       "structure_id": null,
       "support_skills": {
@@ -72807,6 +73121,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629579,
       "structure_id": null,
       "support_skills": {
@@ -73002,6 +73317,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629582,
       "structure_id": null,
       "support_skills": {
@@ -73203,6 +73519,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629605,
       "structure_id": null,
       "support_skills": {
@@ -73413,6 +73730,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629611,
       "structure_id": null,
       "support_skills": {
@@ -73587,6 +73905,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629617,
       "structure_id": null,
       "support_skills": {
@@ -73788,6 +74107,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629619,
       "structure_id": null,
       "support_skills": {
@@ -73994,6 +74314,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629622,
       "structure_id": null,
       "support_skills": {
@@ -74199,6 +74520,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629623,
       "structure_id": null,
       "support_skills": {
@@ -74398,6 +74720,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629624,
       "structure_id": null,
       "support_skills": {
@@ -74608,6 +74931,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -74817,6 +75141,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629627,
       "structure_id": null,
       "support_skills": {
@@ -75016,6 +75341,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -75221,6 +75547,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629630,
       "structure_id": null,
       "support_skills": {
@@ -75416,6 +75743,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629633,
       "structure_id": null,
       "support_skills": {
@@ -75621,6 +75949,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629634,
       "structure_id": null,
       "support_skills": {
@@ -75824,6 +76153,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629636,
       "structure_id": null,
       "support_skills": {
@@ -76023,6 +76353,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629642,
       "structure_id": null,
       "support_skills": {
@@ -76218,6 +76549,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629648,
       "structure_id": null,
       "support_skills": {
@@ -76419,6 +76751,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -76614,6 +76947,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629649,
       "structure_id": null,
       "support_skills": {
@@ -76819,6 +77153,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -77033,6 +77368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629654,
       "structure_id": null,
       "support_skills": {
@@ -77232,6 +77568,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629657,
       "structure_id": null,
       "support_skills": {
@@ -77423,6 +77760,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629658,
       "structure_id": null,
       "support_skills": {
@@ -77618,6 +77956,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629660,
       "structure_id": null,
       "support_skills": {
@@ -77802,6 +78141,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629667,
       "structure_id": null,
       "support_skills": {
@@ -77997,6 +78337,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -78203,6 +78544,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -78381,6 +78723,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78561,6 +78904,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78766,6 +79110,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78961,6 +79306,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629692,
       "structure_id": null,
       "support_skills": {
@@ -79166,6 +79512,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629703,
       "structure_id": null,
       "support_skills": {
@@ -79365,6 +79712,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629707,
       "structure_id": null,
       "support_skills": {
@@ -79564,6 +79912,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629712,
       "structure_id": null,
       "support_skills": {
@@ -79759,6 +80108,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629713,
       "structure_id": null,
       "support_skills": {
@@ -79964,6 +80314,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629715,
       "structure_id": null,
       "support_skills": {
@@ -80178,6 +80529,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629718,
       "structure_id": null,
       "support_skills": {
@@ -80373,6 +80725,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629721,
       "structure_id": null,
       "support_skills": {
@@ -80574,6 +80927,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629729,
       "structure_id": null,
       "support_skills": {
@@ -80773,6 +81127,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -80976,6 +81331,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -81167,6 +81523,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629743,
       "structure_id": null,
       "support_skills": {
@@ -81366,6 +81723,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81557,6 +81915,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81731,6 +82090,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81901,6 +82261,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629755,
       "structure_id": null,
       "support_skills": {
@@ -82092,6 +82453,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82291,6 +82653,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82486,6 +82849,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82696,6 +83060,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629766,
       "structure_id": null,
       "support_skills": {
@@ -82909,6 +83274,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629770,
       "structure_id": null,
       "support_skills": {
@@ -83110,6 +83476,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629772,
       "structure_id": null,
       "support_skills": {
@@ -83305,6 +83672,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629778,
       "structure_id": null,
       "support_skills": {
@@ -83500,6 +83868,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629790,
       "structure_id": null,
       "support_skills": {
@@ -83710,6 +84079,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -83901,6 +84271,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -84102,6 +84473,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629799,
       "structure_id": null,
       "support_skills": {
@@ -84259,6 +84631,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629807,
       "structure_id": null,
       "support_skills": {
@@ -84433,6 +84806,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629811,
       "structure_id": null,
       "support_skills": {
@@ -84638,6 +85012,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -84795,6 +85170,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -84986,6 +85362,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -85185,6 +85562,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629825,
       "structure_id": null,
       "support_skills": {
@@ -85380,6 +85758,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -85579,6 +85958,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -85778,6 +86158,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629857,
       "structure_id": null,
       "support_skills": {
@@ -85973,6 +86354,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629875,
       "structure_id": null,
       "support_skills": {
@@ -86136,6 +86518,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629887,
       "structure_id": null,
       "support_skills": {
@@ -86335,6 +86718,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629889,
       "structure_id": null,
       "support_skills": {
@@ -86530,6 +86914,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -86743,6 +87128,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -86948,6 +87334,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629911,
       "structure_id": null,
       "support_skills": {
@@ -87143,6 +87530,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629913,
       "structure_id": null,
       "support_skills": {
@@ -87338,6 +87726,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -87526,6 +87915,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -87725,6 +88115,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -87930,6 +88321,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -88129,6 +88521,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88307,6 +88700,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88487,6 +88881,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88688,6 +89083,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -88883,6 +89279,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -89082,6 +89479,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -89277,6 +89675,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -89434,6 +89833,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629977,
       "structure_id": null,
       "support_skills": {
@@ -89637,6 +90037,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -89817,6 +90218,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -89998,6 +90400,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -90193,6 +90596,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629987,
       "structure_id": null,
       "support_skills": {
@@ -90399,6 +90803,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629995,
       "structure_id": null,
       "support_skills": {
@@ -90604,6 +91009,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -90807,6 +91213,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -91006,6 +91413,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -91201,6 +91609,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -91408,6 +91817,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -91614,6 +92024,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -91815,6 +92226,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -92014,6 +92426,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -92213,6 +92626,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -92423,6 +92837,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630031,
       "structure_id": null,
       "support_skills": {
@@ -92633,6 +93048,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630033,
       "structure_id": null,
       "support_skills": {
@@ -92836,6 +93252,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630034,
       "structure_id": null,
       "support_skills": {
@@ -93035,6 +93452,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630037,
       "structure_id": null,
       "support_skills": {
@@ -93230,6 +93648,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630040,
       "structure_id": null,
       "support_skills": {
@@ -93431,6 +93850,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630050,
       "structure_id": null,
       "support_skills": {
@@ -93632,6 +94052,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630062,
       "structure_id": null,
       "support_skills": {
@@ -93833,6 +94254,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630080,
       "structure_id": null,
       "support_skills": {
@@ -94011,6 +94433,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630087,
       "structure_id": null,
       "support_skills": {
@@ -94185,6 +94608,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -94369,6 +94793,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -94553,6 +94978,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630103,
       "structure_id": null,
       "support_skills": {
@@ -94752,6 +95178,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630109,
       "structure_id": null,
       "support_skills": {
@@ -94947,6 +95374,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630115,
       "structure_id": null,
       "support_skills": {
@@ -95152,6 +95580,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630123,
       "structure_id": null,
       "support_skills": {
@@ -95351,6 +95780,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630127,
       "structure_id": null,
       "support_skills": {
@@ -95523,6 +95953,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -95726,6 +96157,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -95925,6 +96357,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630132,
       "structure_id": null,
       "support_skills": {
@@ -96124,6 +96557,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630133,
       "structure_id": null,
       "support_skills": {
@@ -96319,6 +96753,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630135,
       "structure_id": null,
       "support_skills": {
@@ -96532,6 +96967,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630146,
       "structure_id": null,
       "support_skills": {
@@ -96742,6 +97178,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -96945,6 +97382,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -97140,6 +97578,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630166,
       "structure_id": null,
       "support_skills": {
@@ -97339,6 +97778,7 @@
       "player_id": 19998976,
       "player_name": "Forgo义Preyla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -97517,6 +97957,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -97716,6 +98157,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630189,
       "structure_id": null,
       "support_skills": {
@@ -97930,6 +98372,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630191,
       "structure_id": null,
       "support_skills": {
@@ -98129,6 +98572,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630194,
       "structure_id": null,
       "support_skills": {
@@ -98324,6 +98768,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630197,
       "structure_id": null,
       "support_skills": {
@@ -98529,6 +98974,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630207,
       "structure_id": null,
       "support_skills": {
@@ -98728,6 +99174,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630232,
       "structure_id": null,
       "support_skills": {
@@ -98927,6 +99374,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630238,
       "structure_id": null,
       "support_skills": {
@@ -99105,6 +99553,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630249,
       "structure_id": null,
       "support_skills": {
@@ -99308,6 +99757,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -99507,6 +99957,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -99706,6 +100157,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630291,
       "structure_id": null,
       "support_skills": {
@@ -99916,6 +100368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630304,
       "structure_id": null,
       "support_skills": {
@@ -100130,6 +100583,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630306,
       "structure_id": null,
       "support_skills": {
@@ -100329,6 +100783,7 @@
       "player_id": 27624147,
       "player_name": "ItsJustDave",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -100474,6 +100929,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -100665,6 +101121,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -100868,6 +101325,7 @@
       "player_id": 110236148,
       "player_name": "ᴸᴸKapten",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -101063,6 +101521,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101233,6 +101692,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101418,6 +101878,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101613,6 +102074,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630333,
       "structure_id": null,
       "support_skills": {
@@ -101814,6 +102276,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -101994,6 +102457,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -102176,6 +102640,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630357,
       "structure_id": null,
       "support_skills": {
@@ -102371,6 +102836,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630383,
       "structure_id": null,
       "support_skills": {
@@ -102572,6 +103038,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630404,
       "structure_id": null,
       "support_skills": {
@@ -102782,6 +103249,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630442,
       "structure_id": null,
       "support_skills": {
@@ -102992,6 +103460,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630448,
       "structure_id": null,
       "support_skills": {
@@ -103202,6 +103671,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630492,
       "structure_id": null,
       "support_skills": {
@@ -103393,6 +103863,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630501,
       "structure_id": null,
       "support_skills": {
@@ -104248,6 +104719,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 630607,
       "structure_id": null,
       "support_skills": {
@@ -104429,6 +104901,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630577,
       "structure_id": null,
       "support_skills": {
@@ -104624,6 +105097,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630591,
       "structure_id": null,
       "support_skills": {
@@ -104829,6 +105303,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630638,
       "structure_id": null,
       "support_skills": {
@@ -105032,6 +105507,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630642,
       "structure_id": null,
       "support_skills": {
@@ -105223,6 +105699,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630654,
       "structure_id": null,
       "support_skills": {
@@ -105376,6 +105853,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630660,
       "structure_id": null,
       "support_skills": {
@@ -105579,6 +106057,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630662,
       "structure_id": null,
       "support_skills": {
@@ -105771,6 +106250,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -105962,6 +106442,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -106161,6 +106642,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -106331,6 +106813,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -106484,6 +106967,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630726,
       "structure_id": null,
       "support_skills": {
@@ -106687,6 +107171,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -106844,6 +107329,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -107020,6 +107506,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -107212,6 +107699,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630732,
       "structure_id": null,
       "support_skills": {
@@ -107419,6 +107907,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630767,
       "structure_id": null,
       "support_skills": {
@@ -107629,6 +108118,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630780,
       "structure_id": null,
       "support_skills": {
@@ -107824,6 +108314,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -107994,6 +108485,7 @@
       "player_id": 51418078,
       "player_name": "Ral Farm C",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -108193,6 +108685,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630807,
       "structure_id": null,
       "support_skills": {
@@ -108392,6 +108885,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630818,
       "structure_id": null,
       "support_skills": {
@@ -108597,6 +109091,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630844,
       "structure_id": null,
       "support_skills": {
@@ -108802,6 +109297,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630850,
       "structure_id": null,
       "support_skills": {
@@ -109003,6 +109499,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630854,
       "structure_id": null,
       "support_skills": {
@@ -109200,6 +109697,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630856,
       "structure_id": null,
       "support_skills": {
@@ -109376,6 +109874,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -109561,6 +110060,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -109760,6 +110260,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630919,
       "structure_id": null,
       "support_skills": {
@@ -109955,6 +110456,7 @@
       "player_id": 49083224,
       "player_name": "Sheir0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630924,
       "structure_id": null,
       "support_skills": {
@@ -110156,6 +110658,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -110355,6 +110858,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -110550,6 +111054,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630930,
       "structure_id": null,
       "support_skills": {
@@ -110755,6 +111260,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630938,
       "structure_id": null,
       "support_skills": {
@@ -110954,6 +111460,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630947,
       "structure_id": null,
       "support_skills": {
@@ -111128,6 +111635,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -111331,6 +111839,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -111526,6 +112035,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -111729,6 +112239,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -111928,6 +112439,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -112133,6 +112645,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -112318,6 +112831,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631018,
       "structure_id": null,
       "support_skills": {
@@ -112513,6 +113027,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -112708,6 +113223,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -112886,6 +113402,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631033,
       "structure_id": null,
       "support_skills": {
@@ -113099,6 +113616,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -113300,6 +113818,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -113493,6 +114012,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631055,
       "structure_id": null,
       "support_skills": {
@@ -113688,6 +114208,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631085,
       "structure_id": null,
       "support_skills": {
@@ -113845,6 +114366,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631063,
       "structure_id": null,
       "support_skills": {
@@ -114044,6 +114566,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -114250,6 +114773,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -114451,6 +114975,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631069,
       "structure_id": null,
       "support_skills": {
@@ -114650,6 +115175,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631073,
       "structure_id": null,
       "support_skills": {
@@ -114855,6 +115381,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -115054,6 +115581,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631097,
       "structure_id": null,
       "support_skills": {
@@ -115249,6 +115777,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631117,
       "structure_id": null,
       "support_skills": {
@@ -115454,6 +115983,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631123,
       "structure_id": null,
       "support_skills": {
@@ -115664,6 +116194,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631163,
       "structure_id": null,
       "support_skills": {
@@ -115825,6 +116356,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631170,
       "structure_id": null,
       "support_skills": {
@@ -116039,6 +116571,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631182,
       "structure_id": null,
       "support_skills": {
@@ -116200,6 +116733,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631195,
       "structure_id": null,
       "support_skills": {
@@ -116410,6 +116944,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631231,
       "structure_id": null,
       "support_skills": {
@@ -116563,6 +117098,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631239,
       "structure_id": null,
       "support_skills": {
@@ -116733,6 +117269,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -116928,6 +117465,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -117127,6 +117665,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -117322,6 +117861,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631259,
       "structure_id": null,
       "support_skills": {
@@ -117500,6 +118040,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631271,
       "structure_id": null,
       "support_skills": {
@@ -117674,6 +118215,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631281,
       "structure_id": null,
       "support_skills": {
@@ -117873,6 +118415,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631288,
       "structure_id": null,
       "support_skills": {
@@ -118083,6 +118626,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631292,
       "structure_id": null,
       "support_skills": {
@@ -127184,6 +127728,7 @@
     "player_id": 41377732,
     "player_name": "ˢJian x Laars",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -12670,6 +12670,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595330,
       "structure_id": 38,
       "support_skills": {
@@ -12865,6 +12866,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13060,6 +13062,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13259,6 +13262,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13450,6 +13454,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13645,6 +13650,7 @@
       "player_id": 5093787,
       "player_name": "Sparkx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595343,
       "structure_id": null,
       "support_skills": {
@@ -13840,6 +13846,7 @@
       "player_id": 2728540,
       "player_name": "刀劍Kir",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -14031,6 +14038,7 @@
       "player_id": 18663801,
       "player_name": "Paw pаw",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595352,
       "structure_id": null,
       "support_skills": {
@@ -14230,6 +14238,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14425,6 +14434,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -14620,6 +14630,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14819,6 +14830,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595335,
       "structure_id": null,
       "support_skills": {
@@ -15014,6 +15026,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15209,6 +15222,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15408,6 +15422,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15607,6 +15622,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15802,6 +15818,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -15997,6 +16014,7 @@
       "player_id": 66126870,
       "player_name": "Kitty Gang",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595360,
       "structure_id": null,
       "support_skills": {
@@ -16192,6 +16210,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -16387,6 +16406,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595353,
       "structure_id": null,
       "support_skills": {
@@ -16578,6 +16598,7 @@
       "player_id": 15964597,
       "player_name": "мᴀXXuм",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595554,
       "structure_id": null,
       "support_skills": {
@@ -16773,6 +16794,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -16968,6 +16990,7 @@
       "player_id": 75908538,
       "player_name": "SuperLuffy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595394,
       "structure_id": null,
       "support_skills": {
@@ -17163,6 +17186,7 @@
       "player_id": 40812700,
       "player_name": "ZombiNuggies13",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595488,
       "structure_id": null,
       "support_skills": {
@@ -17358,6 +17382,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595764,
       "structure_id": null,
       "support_skills": {
@@ -17553,6 +17578,7 @@
       "player_id": 41802504,
       "player_name": "KateRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595350,
       "structure_id": null,
       "support_skills": {
@@ -17748,6 +17774,7 @@
       "player_id": 6108852,
       "player_name": "Rimuru 림",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595904,
       "structure_id": null,
       "support_skills": {
@@ -17943,6 +17970,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18142,6 +18170,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18341,6 +18370,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18536,6 +18566,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -18731,6 +18762,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18930,6 +18962,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -19129,6 +19162,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -19328,6 +19362,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -19523,6 +19558,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -19718,6 +19754,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -19917,6 +19954,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595384,
       "structure_id": null,
       "support_skills": {
@@ -20112,6 +20150,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595356,
       "structure_id": null,
       "support_skills": {
@@ -20307,6 +20346,7 @@
       "player_id": 3987185,
       "player_name": "ʚFujiɞ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -20506,6 +20546,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -20701,6 +20742,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -20896,6 +20938,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595725,
       "structure_id": null,
       "support_skills": {
@@ -21087,6 +21130,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -21282,6 +21326,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -21481,6 +21526,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -21680,6 +21726,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -21875,6 +21922,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -22070,6 +22118,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595349,
       "structure_id": null,
       "support_skills": {
@@ -22265,6 +22314,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -22460,6 +22510,7 @@
       "player_id": 59250548,
       "player_name": "彡tktk彡",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595376,
       "structure_id": null,
       "support_skills": {
@@ -22659,6 +22710,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595776,
       "structure_id": null,
       "support_skills": {
@@ -22854,6 +22906,7 @@
       "player_id": 26795734,
       "player_name": "MGKing Legacy S",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -23049,6 +23102,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23244,6 +23298,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -23443,6 +23498,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23642,6 +23698,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595396,
       "structure_id": null,
       "support_skills": {
@@ -23837,6 +23894,7 @@
       "player_id": 21928143,
       "player_name": "Zoned Out",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596454,
       "structure_id": null,
       "support_skills": {
@@ -24032,6 +24090,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24227,6 +24286,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24422,6 +24482,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -24613,6 +24674,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24808,6 +24870,7 @@
       "player_id": 34851989,
       "player_name": "MALJAHAメWolfy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -25003,6 +25066,7 @@
       "player_id": 40812700,
       "player_name": "ZombiNuggies13",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595485,
       "structure_id": null,
       "support_skills": {
@@ -25202,6 +25266,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595505,
       "structure_id": null,
       "support_skills": {
@@ -25393,6 +25458,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -25592,6 +25658,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595503,
       "structure_id": null,
       "support_skills": {
@@ -25787,6 +25854,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -25978,6 +26046,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26173,6 +26242,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595834,
       "structure_id": null,
       "support_skills": {
@@ -26368,6 +26438,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595704,
       "structure_id": null,
       "support_skills": {
@@ -26563,6 +26634,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26758,6 +26830,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596468,
       "structure_id": null,
       "support_skills": {
@@ -26953,6 +27026,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595520,
       "structure_id": null,
       "support_skills": {
@@ -27148,6 +27222,7 @@
       "player_id": 37360378,
       "player_name": "TânメNguyễn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595897,
       "structure_id": null,
       "support_skills": {
@@ -27347,6 +27422,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595403,
       "structure_id": null,
       "support_skills": {
@@ -27542,6 +27618,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -27737,6 +27814,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -27936,6 +28014,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28135,6 +28214,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28326,6 +28406,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28525,6 +28606,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28716,6 +28798,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595426,
       "structure_id": null,
       "support_skills": {
@@ -29041,6 +29124,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595456,
       "structure_id": null,
       "support_skills": {
@@ -29240,6 +29324,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595657,
       "structure_id": null,
       "support_skills": {
@@ -29435,6 +29520,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595573,
       "structure_id": null,
       "support_skills": {
@@ -29630,6 +29716,7 @@
       "player_id": 31679831,
       "player_name": "BØBA",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595762,
       "structure_id": null,
       "support_skills": {
@@ -29829,6 +29916,7 @@
       "player_id": 70176209,
       "player_name": "SevenZeroOne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595470,
       "structure_id": null,
       "support_skills": {
@@ -30140,6 +30228,7 @@
       "player_id": 41079688,
       "player_name": "Baronita",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595500,
       "structure_id": null,
       "support_skills": {
@@ -30301,6 +30390,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30496,6 +30586,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30670,6 +30761,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30848,6 +30940,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -31043,6 +31136,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31238,6 +31332,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31437,6 +31532,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31636,6 +31732,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31831,6 +31928,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32026,6 +32124,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32225,6 +32324,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32416,6 +32516,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595636,
       "structure_id": null,
       "support_skills": {
@@ -32759,6 +32860,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595600,
       "structure_id": null,
       "support_skills": {
@@ -32958,6 +33060,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595778,
       "structure_id": null,
       "support_skills": {
@@ -33153,6 +33256,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33352,6 +33456,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33655,6 +33760,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595634,
       "structure_id": null,
       "support_skills": {
@@ -33846,6 +33952,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595632,
       "structure_id": null,
       "support_skills": {
@@ -34037,6 +34144,7 @@
       "player_id": 19854296,
       "player_name": "Goofyᴴᴳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596177,
       "structure_id": null,
       "support_skills": {
@@ -34232,6 +34340,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34431,6 +34540,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34626,6 +34736,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34825,6 +34936,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35016,6 +35128,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35215,6 +35328,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35410,6 +35524,7 @@
       "player_id": 3480868,
       "player_name": "PoonSquad",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -35609,6 +35724,7 @@
       "player_id": 3480868,
       "player_name": "PoonSquad",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -35808,6 +35924,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -36003,6 +36120,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595831,
       "structure_id": null,
       "support_skills": {
@@ -36198,6 +36316,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595899,
       "structure_id": null,
       "support_skills": {
@@ -36368,6 +36487,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595975,
       "structure_id": null,
       "support_skills": {
@@ -36563,6 +36683,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -36758,6 +36879,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -36957,6 +37079,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37156,6 +37279,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37355,6 +37479,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37546,6 +37671,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -37745,6 +37871,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -37944,6 +38071,7 @@
       "player_id": 3497995,
       "player_name": "ᴱ ᴸ ᴼM1Lo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596153,
       "structure_id": null,
       "support_skills": {
@@ -38139,6 +38267,7 @@
       "player_id": 10367779,
       "player_name": "Jade StaR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595837,
       "structure_id": null,
       "support_skills": {
@@ -38334,6 +38463,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595907,
       "structure_id": null,
       "support_skills": {
@@ -38533,6 +38663,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -38894,6 +39025,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595750,
       "structure_id": null,
       "support_skills": {
@@ -39085,6 +39217,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595998,
       "structure_id": null,
       "support_skills": {
@@ -39410,6 +39543,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595790,
       "structure_id": null,
       "support_skills": {
@@ -39605,6 +39739,7 @@
       "player_id": 133347325,
       "player_name": "22 Armani",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -39804,6 +39939,7 @@
       "player_id": 11794206,
       "player_name": "Hᴏɴᴄʜᴏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -40165,6 +40301,7 @@
       "player_id": 44183166,
       "player_name": "Bladezメkizzy",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595934,
       "structure_id": null,
       "support_skills": {
@@ -40360,6 +40497,7 @@
       "player_id": 62393946,
       "player_name": "FeilongX Yeager",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596163,
       "structure_id": null,
       "support_skills": {
@@ -40555,6 +40693,7 @@
       "player_id": 5093787,
       "player_name": "Sparkx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596150,
       "structure_id": null,
       "support_skills": {
@@ -40750,6 +40889,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -40949,6 +41089,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596055,
       "structure_id": null,
       "support_skills": {
@@ -41144,6 +41285,7 @@
       "player_id": 155192039,
       "player_name": "白蘭丶亮",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596048,
       "structure_id": null,
       "support_skills": {
@@ -41339,6 +41481,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -41538,6 +41681,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -41917,6 +42061,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595954,
       "structure_id": null,
       "support_skills": {
@@ -42108,6 +42253,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -42303,6 +42449,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42502,6 +42649,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42697,6 +42845,7 @@
       "player_id": 29338219,
       "player_name": "Rayes 77 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596550,
       "structure_id": null,
       "support_skills": {
@@ -42892,6 +43041,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -43087,6 +43237,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -43282,6 +43433,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -43481,6 +43633,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596295,
       "structure_id": null,
       "support_skills": {
@@ -43680,6 +43833,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -43871,6 +44025,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44070,6 +44225,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44269,6 +44425,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44468,6 +44625,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -44659,6 +44817,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44854,6 +45013,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -45053,6 +45213,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596494,
       "structure_id": null,
       "support_skills": {
@@ -45248,6 +45409,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -45443,6 +45605,7 @@
       "player_id": 9766100,
       "player_name": "Tueiut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596085,
       "structure_id": null,
       "support_skills": {
@@ -45642,6 +45805,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -45837,6 +46001,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -46028,6 +46193,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46223,6 +46389,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46422,6 +46589,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -46621,6 +46789,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -46812,6 +46981,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47007,6 +47177,7 @@
       "player_id": 42981395,
       "player_name": "eter乂noob",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596103,
       "structure_id": null,
       "support_skills": {
@@ -47202,6 +47373,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47397,6 +47569,7 @@
       "player_id": 3430258,
       "player_name": "Snoo ᴿᴮ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -47592,6 +47765,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47953,6 +48127,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596093,
       "structure_id": null,
       "support_skills": {
@@ -48148,6 +48323,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -48509,6 +48685,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596128,
       "structure_id": null,
       "support_skills": {
@@ -48704,6 +48881,7 @@
       "player_id": 17563040,
       "player_name": "Pocahontas ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596309,
       "structure_id": null,
       "support_skills": {
@@ -48874,6 +49052,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596591,
       "structure_id": null,
       "support_skills": {
@@ -49073,6 +49252,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596592,
       "structure_id": null,
       "support_skills": {
@@ -49272,6 +49452,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596593,
       "structure_id": null,
       "support_skills": {
@@ -49467,6 +49648,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596301,
       "structure_id": null,
       "support_skills": {
@@ -49662,6 +49844,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -49857,6 +50040,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50056,6 +50240,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50247,6 +50432,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -50446,6 +50632,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50641,6 +50828,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -50832,6 +51020,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -51027,6 +51216,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596571,
       "structure_id": null,
       "support_skills": {
@@ -51222,6 +51412,7 @@
       "player_id": 12654270,
       "player_name": "AbuAntaaar 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -51417,6 +51608,7 @@
       "player_id": 77809884,
       "player_name": "Chofen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596461,
       "structure_id": null,
       "support_skills": {
@@ -51742,6 +51934,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -51937,6 +52130,7 @@
       "player_id": 1201146,
       "player_name": "Ember       s",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596324,
       "structure_id": null,
       "support_skills": {
@@ -52128,6 +52322,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596594,
       "structure_id": null,
       "support_skills": {
@@ -52323,6 +52518,7 @@
       "player_id": 28874635,
       "player_name": "Peak Gacs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596600,
       "structure_id": null,
       "support_skills": {
@@ -52656,6 +52852,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596290,
       "structure_id": null,
       "support_skills": {
@@ -52855,6 +53052,7 @@
       "player_id": 15964597,
       "player_name": "мᴀXXuм",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596667,
       "structure_id": null,
       "support_skills": {
@@ -53050,6 +53248,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -53245,6 +53444,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -53440,6 +53640,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -53635,6 +53836,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596439,
       "structure_id": null,
       "support_skills": {
@@ -53834,6 +54036,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54025,6 +54228,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54224,6 +54428,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54423,6 +54628,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596443,
       "structure_id": null,
       "support_skills": {
@@ -54618,6 +54824,7 @@
       "player_id": 9031871,
       "player_name": "Hallゞ翰",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -54813,6 +55020,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596674,
       "structure_id": null,
       "support_skills": {
@@ -55004,6 +55212,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596433,
       "structure_id": null,
       "support_skills": {
@@ -55195,6 +55404,7 @@
       "player_id": 9031871,
       "player_name": "Hallゞ翰",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596950,
       "structure_id": null,
       "support_skills": {
@@ -55390,6 +55600,7 @@
       "player_id": 37360378,
       "player_name": "TânメNguyễn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596517,
       "structure_id": null,
       "support_skills": {
@@ -55585,6 +55796,7 @@
       "player_id": 62312731,
       "player_name": "火 Truth 火",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -55780,6 +55992,7 @@
       "player_id": 20185357,
       "player_name": "Sleepy fr",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596666,
       "structure_id": null,
       "support_skills": {
@@ -56123,6 +56336,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596432,
       "structure_id": null,
       "support_skills": {
@@ -56318,6 +56532,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -56517,6 +56732,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -56716,6 +56932,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -56911,6 +57128,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57106,6 +57324,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596659,
       "structure_id": null,
       "support_skills": {
@@ -57305,6 +57524,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -57504,6 +57724,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57695,6 +57916,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57894,6 +58116,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596649,
       "structure_id": null,
       "support_skills": {
@@ -58093,6 +58316,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58292,6 +58516,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -58491,6 +58716,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58682,6 +58908,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -59025,6 +59252,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596470,
       "structure_id": null,
       "support_skills": {
@@ -59224,6 +59452,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596663,
       "structure_id": null,
       "support_skills": {
@@ -59415,6 +59644,7 @@
       "player_id": 56024386,
       "player_name": "LORD OF ALL Dk",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -59610,6 +59840,7 @@
       "player_id": 10988067,
       "player_name": "Barça",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -59801,6 +60032,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -59996,6 +60228,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60195,6 +60428,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -60394,6 +60628,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60593,6 +60828,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60788,6 +61024,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60987,6 +61224,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61178,6 +61416,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61373,6 +61612,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -61572,6 +61812,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -61771,6 +62012,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -61962,6 +62204,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -62157,6 +62400,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -62352,6 +62596,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596813,
       "structure_id": null,
       "support_skills": {
@@ -62551,6 +62796,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596662,
       "structure_id": null,
       "support_skills": {
@@ -62746,6 +62992,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -62945,6 +63192,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -63140,6 +63388,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596791,
       "structure_id": null,
       "support_skills": {
@@ -63335,6 +63584,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -63534,6 +63784,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596793,
       "structure_id": null,
       "support_skills": {
@@ -63733,6 +63984,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -64076,6 +64328,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596596,
       "structure_id": null,
       "support_skills": {
@@ -64271,6 +64524,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64470,6 +64724,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64665,6 +64920,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64860,6 +65116,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65055,6 +65312,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65250,6 +65508,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -65449,6 +65708,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -65648,6 +65908,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596812,
       "structure_id": null,
       "support_skills": {
@@ -65843,6 +66104,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596965,
       "structure_id": null,
       "support_skills": {
@@ -66034,6 +66296,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596966,
       "structure_id": null,
       "support_skills": {
@@ -66233,6 +66496,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -66738,6 +67002,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596640,
       "structure_id": null,
       "support_skills": {
@@ -66929,6 +67194,7 @@
       "player_id": 12902531,
       "player_name": "SupEr",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -67124,6 +67390,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -67323,6 +67590,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596988,
       "structure_id": null,
       "support_skills": {
@@ -67522,6 +67790,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -67717,6 +67986,7 @@
       "player_id": 16709775,
       "player_name": "メFACELESSメ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -67912,6 +68182,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -68111,6 +68382,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -68310,6 +68582,7 @@
       "player_id": 83531919,
       "player_name": "MÄD乄SaLva98",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -68501,6 +68774,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -68696,6 +68970,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597020,
       "structure_id": null,
       "support_skills": {
@@ -68891,6 +69166,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69090,6 +69366,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69289,6 +69566,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69488,6 +69766,7 @@
       "player_id": 8888366,
       "player_name": "SAO Pink",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -69683,6 +69962,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69878,6 +70158,7 @@
       "player_id": 25499449,
       "player_name": "Mr Yahya",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596957,
       "structure_id": null,
       "support_skills": {
@@ -70073,6 +70354,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -70264,6 +70546,7 @@
       "player_id": 8888366,
       "player_name": "SAO Pink",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597061,
       "structure_id": null,
       "support_skills": {
@@ -70459,6 +70742,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -70658,6 +70942,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -70857,6 +71142,7 @@
       "player_id": 25499449,
       "player_name": "Mr Yahya",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -71056,6 +71342,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -71247,6 +71534,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596752,
       "structure_id": null,
       "support_skills": {
@@ -71446,6 +71734,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -71637,6 +71926,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -71836,6 +72126,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -72035,6 +72326,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -72234,6 +72526,7 @@
       "player_id": 124677212,
       "player_name": "Pangea",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596976,
       "structure_id": null,
       "support_skills": {
@@ -72429,6 +72722,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -72624,6 +72918,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -72823,6 +73118,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -73018,6 +73314,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -73217,6 +73514,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -73412,6 +73710,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -73611,6 +73910,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -73802,6 +74102,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -73997,6 +74298,7 @@
       "player_id": 13315180,
       "player_name": "niicii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596987,
       "structure_id": null,
       "support_skills": {
@@ -74196,6 +74498,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -74391,6 +74694,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -74752,6 +75056,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596758,
       "structure_id": null,
       "support_skills": {
@@ -74947,6 +75252,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -75142,6 +75448,7 @@
       "player_id": 18850140,
       "player_name": "Ghøstboy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -75337,6 +75644,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -75532,6 +75840,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -75731,6 +76040,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596955,
       "structure_id": null,
       "support_skills": {
@@ -75926,6 +76236,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -76125,6 +76436,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -76324,6 +76636,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -76519,6 +76832,7 @@
       "player_id": 52942505,
       "player_name": "ᶜʰᵉᶠ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596970,
       "structure_id": null,
       "support_skills": {
@@ -76714,6 +77028,7 @@
       "player_id": 4825135,
       "player_name": "1baller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -76913,6 +77228,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596992,
       "structure_id": null,
       "support_skills": {
@@ -77108,6 +77424,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -77299,6 +77616,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -77494,6 +77812,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -77689,6 +78008,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -77888,6 +78208,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -78083,6 +78404,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78278,6 +78600,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -78477,6 +78800,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78676,6 +79000,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78871,6 +79196,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -79066,6 +79392,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -79257,6 +79584,7 @@
       "player_id": 31679831,
       "player_name": "BØBA",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597006,
       "structure_id": null,
       "support_skills": {
@@ -79448,6 +79776,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79647,6 +79976,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79838,6 +80168,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -80037,6 +80368,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -80232,6 +80564,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -80427,6 +80760,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -80622,6 +80956,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -80817,6 +81152,7 @@
       "player_id": 18216035,
       "player_name": "Mayoh",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -81012,6 +81348,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597010,
       "structure_id": null,
       "support_skills": {
@@ -81207,6 +81544,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -81406,6 +81744,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -81597,6 +81936,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -81796,6 +82136,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -81995,6 +82336,7 @@
       "player_id": 11326540,
       "player_name": "BaoBun248",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -82190,6 +82532,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597011,
       "structure_id": null,
       "support_skills": {
@@ -82389,6 +82732,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -82584,6 +82928,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -82783,6 +83128,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597032,
       "structure_id": null,
       "support_skills": {
@@ -82982,6 +83328,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -83181,6 +83528,7 @@
       "player_id": 11326540,
       "player_name": "BaoBun248",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -83376,6 +83724,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -83575,6 +83924,7 @@
       "player_id": 6135053,
       "player_name": "ʚïɞce ⁿʷ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -83766,6 +84116,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -83965,6 +84316,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -84160,6 +84512,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596986,
       "structure_id": null,
       "support_skills": {
@@ -84511,6 +84864,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596851,
       "structure_id": null,
       "support_skills": {
@@ -84706,6 +85060,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -84901,6 +85256,7 @@
       "player_id": 7362219,
       "player_name": "ironvox",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -85100,6 +85456,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85295,6 +85652,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85494,6 +85852,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85689,6 +86048,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85884,6 +86244,7 @@
       "player_id": 76160426,
       "player_name": "sNaXs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -86083,6 +86444,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86278,6 +86640,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -86473,6 +86836,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596968,
       "structure_id": null,
       "support_skills": {
@@ -86668,6 +87032,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -86863,6 +87228,7 @@
       "player_id": 147732473,
       "player_name": "ORIGINALxKILLER",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597012,
       "structure_id": null,
       "support_skills": {
@@ -87058,6 +87424,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -87257,6 +87624,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597029,
       "structure_id": null,
       "support_skills": {
@@ -87448,6 +87816,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -87639,6 +88008,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -87834,6 +88204,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -88033,6 +88404,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -88228,6 +88600,7 @@
       "player_id": 17563040,
       "player_name": "Pocahontas ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -88423,6 +88796,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -88618,6 +88992,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -88813,6 +89188,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89004,6 +89380,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89203,6 +89580,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89398,6 +89776,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89593,6 +89972,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -89792,6 +90172,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89991,6 +90372,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -90186,6 +90568,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90381,6 +90764,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -90580,6 +90964,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90775,6 +91160,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90966,6 +91352,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -91161,6 +91548,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -91356,6 +91744,7 @@
       "player_id": 76602855,
       "player_name": "anothersin",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -91551,6 +91940,7 @@
       "player_id": 7155054,
       "player_name": "Lyonardo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -91750,6 +92140,7 @@
       "player_id": 7155054,
       "player_name": "Lyonardo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -91945,6 +92336,7 @@
       "player_id": 59461309,
       "player_name": "AJ ᴴᴳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -92140,6 +92532,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -92339,6 +92732,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -92534,6 +92928,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -92733,6 +93128,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597014,
       "structure_id": null,
       "support_skills": {
@@ -92928,6 +93324,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -93289,6 +93686,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596949,
       "structure_id": null,
       "support_skills": {
@@ -93488,6 +93886,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -93687,6 +94086,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -93886,6 +94286,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -94081,6 +94482,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -94276,6 +94678,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -94471,6 +94874,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -94670,6 +95074,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -94865,6 +95270,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -95064,6 +95470,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -95263,6 +95670,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -95458,6 +95866,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -95653,6 +96062,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -95848,6 +96258,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -96047,6 +96458,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -96242,6 +96654,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -96437,6 +96850,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -96632,6 +97046,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597058,
       "structure_id": null,
       "support_skills": {
@@ -96827,6 +97242,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597016,
       "structure_id": null,
       "support_skills": {
@@ -97022,6 +97438,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -97217,6 +97634,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -97416,6 +97834,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -97607,6 +98026,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -97806,6 +98226,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -98365,6 +98786,7 @@
       "player_id": 19075788,
       "player_name": "Røñín",
       "rally": true,
+      "server_season": "100",
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -110375,6 +110797,7 @@
     "player_id": 32220019,
     "player_name": "Acanada",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "2225911117695327552",
     "mail_receiver": "player_32523681",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "28700881175578047431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 798757,
       "structure_id": null,
       "support_skills": {
@@ -296,6 +297,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "29048795175579066131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 809011,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "30346123155694137715",
     "mail_receiver": "player_14022209",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -159,6 +159,7 @@
       "player_id": 13451284,
       "player_name": "hasan pilay",
       "rally": null,
+      "server_season": null,
       "start_tick": 421258,
       "structure_id": null,
       "support_skills": {
@@ -270,6 +271,7 @@
     "player_id": 14022209,
     "player_name": "Resir",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "31709368176977161019",
     "mail_receiver": "player_47043938",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 875164,
       "structure_id": null,
       "support_skills": {
@@ -296,6 +297,7 @@
     "player_id": 47043938,
     "player_name": "QuackerOats",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -329,6 +330,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -495,6 +497,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922765,
       "structure_id": null,
       "support_skills": {
@@ -661,6 +664,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922800,
       "structure_id": null,
       "support_skills": {
@@ -807,6 +811,7 @@
     "player_id": 83629727,
     "player_name": "Atomicbunny",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 810,
     "mail_id": "32282022178380122828",
     "mail_receiver": "player_83629727",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -154,6 +154,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 906332,
       "structure_id": null,
       "support_skills": {
@@ -295,6 +296,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 906321,
       "structure_id": null,
       "support_skills": {
@@ -453,6 +455,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "33830971176980291131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "41633096157514072311",
     "mail_receiver": "player_23984527",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -837,6 +837,7 @@
       "player_id": 23872628,
       "player_name": "Eiden2018",
       "rally": null,
+      "server_season": null,
       "start_tick": 474937,
       "structure_id": null,
       "support_skills": {
@@ -1011,6 +1012,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475002,
       "structure_id": null,
       "support_skills": {
@@ -1164,6 +1166,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475013,
       "structure_id": null,
       "support_skills": {
@@ -1338,6 +1341,7 @@
       "player_id": 23259836,
       "player_name": "Nhi   Hí",
       "rally": null,
+      "server_season": null,
       "start_tick": 475104,
       "structure_id": null,
       "support_skills": {
@@ -1491,6 +1495,7 @@
       "player_id": 25899634,
       "player_name": "Simon시몬",
       "rally": null,
+      "server_season": null,
       "start_tick": 475111,
       "structure_id": null,
       "support_skills": {
@@ -1661,6 +1666,7 @@
       "player_id": 23855047,
       "player_name": "Navion69",
       "rally": null,
+      "server_season": null,
       "start_tick": 475200,
       "structure_id": null,
       "support_skills": {
@@ -1831,6 +1837,7 @@
       "player_id": 24237253,
       "player_name": "Gunz88",
       "rally": null,
+      "server_season": null,
       "start_tick": 475232,
       "structure_id": null,
       "support_skills": {
@@ -2001,6 +2008,7 @@
       "player_id": 23432594,
       "player_name": "cruack",
       "rally": null,
+      "server_season": null,
       "start_tick": 475371,
       "structure_id": null,
       "support_skills": {
@@ -2171,6 +2179,7 @@
       "player_id": 23919208,
       "player_name": "EOB 喵腳",
       "rally": null,
+      "server_season": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2341,6 +2350,7 @@
       "player_id": 23432594,
       "player_name": "cruack",
       "rally": null,
+      "server_season": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2515,6 +2525,7 @@
       "player_id": 23855822,
       "player_name": "Wanger94",
       "rally": null,
+      "server_season": null,
       "start_tick": 475440,
       "structure_id": null,
       "support_skills": {
@@ -2685,6 +2696,7 @@
       "player_id": 23881213,
       "player_name": "Sanya007",
       "rally": null,
+      "server_season": null,
       "start_tick": 475461,
       "structure_id": null,
       "support_skills": {
@@ -2863,6 +2875,7 @@
       "player_id": 23866612,
       "player_name": "VirusLoveLy",
       "rally": null,
+      "server_season": null,
       "start_tick": 475547,
       "structure_id": null,
       "support_skills": {
@@ -3033,6 +3046,7 @@
       "player_id": 23881213,
       "player_name": "Sanya007",
       "rally": null,
+      "server_season": null,
       "start_tick": 475568,
       "structure_id": null,
       "support_skills": {
@@ -3211,6 +3225,7 @@
       "player_id": 23866612,
       "player_name": "VirusLoveLy",
       "rally": null,
+      "server_season": null,
       "start_tick": 475603,
       "structure_id": null,
       "support_skills": {
@@ -3364,6 +3379,7 @@
       "player_id": 23639163,
       "player_name": "Phocidea",
       "rally": null,
+      "server_season": null,
       "start_tick": 475640,
       "structure_id": null,
       "support_skills": {
@@ -3538,6 +3554,7 @@
       "player_id": 23872628,
       "player_name": "Eiden2018",
       "rally": null,
+      "server_season": null,
       "start_tick": 475666,
       "structure_id": null,
       "support_skills": {
@@ -3708,6 +3725,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475678,
       "structure_id": null,
       "support_skills": {
@@ -3878,6 +3896,7 @@
       "player_id": 23974117,
       "player_name": "Sorcerer Tim",
       "rally": null,
+      "server_season": null,
       "start_tick": 475682,
       "structure_id": null,
       "support_skills": {
@@ -4052,6 +4071,7 @@
       "player_id": 23881159,
       "player_name": "MemphusX",
       "rally": null,
+      "server_season": null,
       "start_tick": 475825,
       "structure_id": null,
       "support_skills": {
@@ -4693,6 +4713,7 @@
     "player_id": 15068434,
     "player_name": "Ø Heimdall Ø",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 819,
     "mail_id": "47051167177023603224",
     "mail_receiver": "player_12210123",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -196,6 +196,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -391,6 +392,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -586,6 +588,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339450,
       "structure_id": null,
       "support_skills": {
@@ -781,6 +784,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -976,6 +980,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -1171,6 +1176,7 @@
       "player_id": 167694437,
       "player_name": "ᴴᴮMoretti",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339448,
       "structure_id": null,
       "support_skills": {
@@ -1370,6 +1376,7 @@
       "player_id": 167694437,
       "player_name": "ᴴᴮMoretti",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339449,
       "structure_id": null,
       "support_skills": {
@@ -1477,6 +1484,7 @@
     "player_id": 12210123,
     "player_name": "Smallest Madas",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 13857,
       "structure_id": null,
       "support_skills": {
@@ -311,6 +312,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "485440176891031331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "53118177176782122317",
     "mail_receiver": "player_37556801",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -114,6 +114,7 @@
       "player_id": 0,
       "player_name": "",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1314485,
       "structure_id": null,
       "support_skills": {
@@ -233,6 +234,7 @@
     "player_id": 37556801,
     "player_name": "Benbu",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 375269,
       "structure_id": null,
       "support_skills": {
@@ -309,6 +310,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 375279,
       "structure_id": null,
       "support_skills": {
@@ -643,6 +645,7 @@
     "player_id": 151739835,
     "player_name": "Pro100WRyj ツ",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "54530308177357763431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -196,6 +196,7 @@
       "player_id": 29862805,
       "player_name": "Titanobenbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1603621,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 109813467,
     "player_name": "Faystonychus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "58600202175658527723",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -171,6 +171,7 @@
       "player_id": 39115363,
       "player_name": "Old s",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536214,
       "structure_id": null,
       "support_skills": {
@@ -349,6 +350,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536215,
       "structure_id": null,
       "support_skills": {
@@ -523,6 +525,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -697,6 +700,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -871,6 +875,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1049,6 +1054,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536211,
       "structure_id": null,
       "support_skills": {
@@ -1223,6 +1229,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536205,
       "structure_id": null,
       "support_skills": {
@@ -1401,6 +1408,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536206,
       "structure_id": null,
       "support_skills": {
@@ -1579,6 +1587,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1757,6 +1766,7 @@
       "player_id": 34979098,
       "player_name": "Fear of God",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -1931,6 +1941,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536213,
       "structure_id": null,
       "support_skills": {
@@ -2104,6 +2115,7 @@
     "player_id": 7607766,
     "player_name": "wb74",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "60719727166813248216",
     "mail_receiver": "player_12607995",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "67826590176494996531",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -142,6 +142,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 101149,
       "structure_id": null,
       "support_skills": {
@@ -286,6 +287,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -171,6 +171,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -352,6 +353,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470642,
       "structure_id": null,
       "support_skills": {
@@ -533,6 +535,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470649,
       "structure_id": null,
       "support_skills": {
@@ -718,6 +721,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -892,6 +896,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470634,
       "structure_id": null,
       "support_skills": {
@@ -1022,6 +1027,7 @@
     "player_id": 4361125,
     "player_name": "精武丶羅剎",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "69428020161978725321",
     "mail_receiver": "player_4361125",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "7948875176322794831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 208770,
       "structure_id": null,
       "support_skills": {
@@ -224,6 +225,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "80922048176537396031",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -142,6 +142,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 525144,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "G Var",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 205396,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar x Dimi",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407016178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 205395,
       "structure_id": null,
       "support_skills": {
@@ -294,6 +295,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar x Dimi",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407037178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -196,6 +196,7 @@
       "player_id": 126319007,
       "player_name": "ˢˣ火TDouche",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378833,
       "structure_id": null,
       "support_skills": {
@@ -395,6 +396,7 @@
       "player_id": 31532594,
       "player_name": "АLex",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -594,6 +596,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -793,6 +796,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -988,6 +992,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378832,
       "structure_id": null,
       "support_skills": {
@@ -1187,6 +1192,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377880,
       "structure_id": null,
       "support_skills": {
@@ -1365,6 +1371,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377995,
       "structure_id": null,
       "support_skills": {
@@ -1564,6 +1571,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378182,
       "structure_id": null,
       "support_skills": {
@@ -1763,6 +1771,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -1954,6 +1963,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -2145,6 +2155,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -2344,6 +2355,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -2522,6 +2534,7 @@
       "player_id": 4678951,
       "player_name": "Ğrumpy Čhris",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -2721,6 +2734,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -2920,6 +2934,7 @@
       "player_id": 29428027,
       "player_name": "MercilessNoob",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -3119,6 +3134,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378675,
       "structure_id": null,
       "support_skills": {
@@ -3318,6 +3334,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378347,
       "structure_id": null,
       "support_skills": {
@@ -3509,6 +3526,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3708,6 +3726,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3903,6 +3922,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -4102,6 +4122,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -4301,6 +4322,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -4500,6 +4522,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -4699,6 +4722,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -4890,6 +4914,7 @@
       "player_id": 84984958,
       "player_name": "Mystique",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -5089,6 +5114,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -5280,6 +5306,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5479,6 +5506,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5678,6 +5706,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -5877,6 +5906,7 @@
       "player_id": 34488395,
       "player_name": "Zwiebelritter79",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -6076,6 +6106,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -6271,6 +6302,7 @@
       "player_id": 123803055,
       "player_name": "B4ngB4ng",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379179,
       "structure_id": null,
       "support_skills": {
@@ -6470,6 +6502,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6669,6 +6702,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6868,6 +6902,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -7067,6 +7102,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -7266,6 +7302,7 @@
       "player_id": 20118027,
       "player_name": "x Twitty x",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378646,
       "structure_id": null,
       "support_skills": {
@@ -7461,6 +7498,7 @@
       "player_id": 125470745,
       "player_name": "武士道Hercs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378000,
       "structure_id": null,
       "support_skills": {
@@ -7660,6 +7698,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -7859,6 +7898,7 @@
       "player_id": 128123718,
       "player_name": "ˢAuthentiks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -8054,6 +8094,7 @@
       "player_id": 128123718,
       "player_name": "ˢAuthentiks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377761,
       "structure_id": null,
       "support_skills": {
@@ -8245,6 +8286,7 @@
       "player_id": 111776448,
       "player_name": "Thorin lonestar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378636,
       "structure_id": null,
       "support_skills": {
@@ -8444,6 +8486,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -8643,6 +8686,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -8817,6 +8861,7 @@
       "player_id": 111776448,
       "player_name": "Thorin lonestar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -9012,6 +9057,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -9207,6 +9253,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -9406,6 +9453,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -9601,6 +9649,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -9800,6 +9849,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -9995,6 +10045,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -10194,6 +10245,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377400,
       "structure_id": null,
       "support_skills": {
@@ -10393,6 +10445,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377828,
       "structure_id": null,
       "support_skills": {
@@ -10592,6 +10645,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -10791,6 +10845,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377357,
       "structure_id": null,
       "support_skills": {
@@ -10990,6 +11045,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -11189,6 +11245,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377530,
       "structure_id": null,
       "support_skills": {
@@ -11388,6 +11445,7 @@
       "player_id": 126613785,
       "player_name": "霊ˢ Kleines",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -11587,6 +11645,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -11786,6 +11845,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -11985,6 +12045,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -12184,6 +12245,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -12383,6 +12445,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377517,
       "structure_id": null,
       "support_skills": {
@@ -12582,6 +12645,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377346,
       "structure_id": null,
       "support_skills": {
@@ -12781,6 +12845,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -12980,6 +13045,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -13179,6 +13245,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -13374,6 +13441,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -13573,6 +13641,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -13772,6 +13841,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -13971,6 +14041,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -14149,6 +14220,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -14348,6 +14420,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -14543,6 +14616,7 @@
       "player_id": 18916855,
       "player_name": "ツ Governor ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -14742,6 +14816,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377522,
       "structure_id": null,
       "support_skills": {
@@ -14941,6 +15016,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -15140,6 +15216,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -15339,6 +15416,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -15538,6 +15616,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -15729,6 +15808,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -15920,6 +16000,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378318,
       "structure_id": null,
       "support_skills": {
@@ -16119,6 +16200,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -16310,6 +16392,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -16505,6 +16588,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -31370,6 +31454,7 @@
       "player_id": 4678951,
       "player_name": "Ğrumpy Čhris",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377305,
       "structure_id": null,
       "support_skills": {
@@ -32073,6 +32158,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377313,
       "structure_id": null,
       "support_skills": {
@@ -32272,6 +32358,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -32471,6 +32558,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -32670,6 +32758,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -32869,6 +32958,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377584,
       "structure_id": null,
       "support_skills": {
@@ -33064,6 +33154,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -33263,6 +33354,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -33458,6 +33550,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -33653,6 +33746,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -33852,6 +33946,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378533,
       "structure_id": null,
       "support_skills": {
@@ -34043,6 +34138,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378155,
       "structure_id": null,
       "support_skills": {
@@ -34242,6 +34338,7 @@
       "player_id": 20155879,
       "player_name": "뚜뚜 DduDdu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378037,
       "structure_id": null,
       "support_skills": {
@@ -34424,6 +34521,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377453,
       "structure_id": null,
       "support_skills": {
@@ -34627,6 +34725,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377467,
       "structure_id": null,
       "support_skills": {
@@ -34788,6 +34887,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377473,
       "structure_id": null,
       "support_skills": {
@@ -34987,6 +35087,7 @@
       "player_id": 50471265,
       "player_name": "四Ocho 四",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377715,
       "structure_id": null,
       "support_skills": {
@@ -35186,6 +35287,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -35381,6 +35483,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -35580,6 +35683,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -35771,6 +35875,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377551,
       "structure_id": null,
       "support_skills": {
@@ -35970,6 +36075,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -36169,6 +36275,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36368,6 +36475,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36567,6 +36675,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377590,
       "structure_id": null,
       "support_skills": {
@@ -36762,6 +36871,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -36953,6 +37063,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -37148,6 +37259,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377648,
       "structure_id": null,
       "support_skills": {
@@ -37347,6 +37459,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -37538,6 +37651,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -37733,6 +37847,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378012,
       "structure_id": null,
       "support_skills": {
@@ -37936,6 +38051,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377662,
       "structure_id": null,
       "support_skills": {
@@ -38135,6 +38251,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -38326,6 +38443,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -38525,6 +38643,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -38716,6 +38835,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -38890,6 +39010,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -39081,6 +39202,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -39280,6 +39402,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -39479,6 +39602,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -39678,6 +39802,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -39856,6 +39981,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377685,
       "structure_id": null,
       "support_skills": {
@@ -40051,6 +40177,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40246,6 +40373,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40445,6 +40573,7 @@
       "player_id": 129152631,
       "player_name": "Klimson3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377935,
       "structure_id": null,
       "support_skills": {
@@ -40640,6 +40769,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377940,
       "structure_id": null,
       "support_skills": {
@@ -40839,6 +40969,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -41042,6 +41173,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377737,
       "structure_id": null,
       "support_skills": {
@@ -41220,6 +41352,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377743,
       "structure_id": null,
       "support_skills": {
@@ -41419,6 +41552,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378013,
       "structure_id": null,
       "support_skills": {
@@ -41614,6 +41748,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378019,
       "structure_id": null,
       "support_skills": {
@@ -41809,6 +41944,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -42004,6 +42140,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377980,
       "structure_id": null,
       "support_skills": {
@@ -42203,6 +42340,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -42402,6 +42540,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -42601,6 +42740,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -42800,6 +42940,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -42999,6 +43140,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379630,
       "structure_id": null,
       "support_skills": {
@@ -43774,6 +43916,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377835,
       "structure_id": null,
       "support_skills": {
@@ -43973,6 +44116,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377817,
       "structure_id": null,
       "support_skills": {
@@ -44172,6 +44316,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378522,
       "structure_id": null,
       "support_skills": {
@@ -44363,6 +44508,7 @@
       "player_id": 84984958,
       "player_name": "Mystique",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377858,
       "structure_id": null,
       "support_skills": {
@@ -44562,6 +44708,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377865,
       "structure_id": null,
       "support_skills": {
@@ -44761,6 +44908,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -44960,6 +45108,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -45159,6 +45308,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -45350,6 +45500,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378140,
       "structure_id": null,
       "support_skills": {
@@ -45549,6 +45700,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -45744,6 +45896,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -45943,6 +46096,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377894,
       "structure_id": null,
       "support_skills": {
@@ -46134,6 +46288,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -46333,6 +46488,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -46528,6 +46684,7 @@
       "player_id": 124513829,
       "player_name": "メDmitry82メ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -46727,6 +46884,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -46926,6 +47084,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378152,
       "structure_id": null,
       "support_skills": {
@@ -47121,6 +47280,7 @@
       "player_id": 94732875,
       "player_name": "Ada ㋛",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378024,
       "structure_id": null,
       "support_skills": {
@@ -47320,6 +47480,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -47515,6 +47676,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -47714,6 +47876,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -47909,6 +48072,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -48108,6 +48272,7 @@
       "player_id": 123880685,
       "player_name": "運命ˢToxic",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378873,
       "structure_id": null,
       "support_skills": {
@@ -48290,6 +48455,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378051,
       "structure_id": null,
       "support_skills": {
@@ -48485,6 +48651,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378057,
       "structure_id": null,
       "support_skills": {
@@ -48684,6 +48851,7 @@
       "player_id": 941710,
       "player_name": "SAH4RCOREJZ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -48879,6 +49047,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -49070,6 +49239,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378438,
       "structure_id": null,
       "support_skills": {
@@ -49269,6 +49439,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -49468,6 +49639,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -49646,6 +49818,7 @@
       "player_id": 53674767,
       "player_name": "Krawler12000",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -49845,6 +50018,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50023,6 +50197,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378092,
       "structure_id": null,
       "support_skills": {
@@ -50222,6 +50397,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50417,6 +50593,7 @@
       "player_id": 91774997,
       "player_name": "Sir Skyrr Duck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378107,
       "structure_id": null,
       "support_skills": {
@@ -50616,6 +50793,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50815,6 +50993,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -51014,6 +51193,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51209,6 +51389,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51408,6 +51589,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -51607,6 +51789,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -51806,6 +51989,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52005,6 +52189,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52200,6 +52385,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52378,6 +52564,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378133,
       "structure_id": null,
       "support_skills": {
@@ -52573,6 +52760,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52768,6 +52956,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378428,
       "structure_id": null,
       "support_skills": {
@@ -52967,6 +53156,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378432,
       "structure_id": null,
       "support_skills": {
@@ -53166,6 +53356,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -53361,6 +53552,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378168,
       "structure_id": null,
       "support_skills": {
@@ -53560,6 +53752,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -53759,6 +53952,7 @@
       "player_id": 18916855,
       "player_name": "ツ Governor ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378180,
       "structure_id": null,
       "support_skills": {
@@ -53954,6 +54148,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -54153,6 +54348,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -54331,6 +54527,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378194,
       "structure_id": null,
       "support_skills": {
@@ -54522,6 +54719,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378200,
       "structure_id": null,
       "support_skills": {
@@ -54717,6 +54915,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -54916,6 +55115,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -55115,6 +55315,7 @@
       "player_id": 11987186,
       "player_name": "I Dare",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -55314,6 +55515,7 @@
       "player_id": 89959030,
       "player_name": "xxRONxx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -55513,6 +55715,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -55712,6 +55915,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378453,
       "structure_id": null,
       "support_skills": {
@@ -55907,6 +56111,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378247,
       "structure_id": null,
       "support_skills": {
@@ -56106,6 +56311,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -56305,6 +56511,7 @@
       "player_id": 123803055,
       "player_name": "B4ngB4ng",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -56500,6 +56707,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378269,
       "structure_id": null,
       "support_skills": {
@@ -56691,6 +56899,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -56890,6 +57099,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378278,
       "structure_id": null,
       "support_skills": {
@@ -57089,6 +57299,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -57288,6 +57499,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -57479,6 +57691,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378479,
       "structure_id": null,
       "support_skills": {
@@ -57674,6 +57887,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -57873,6 +58087,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -58072,6 +58287,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -58246,6 +58462,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -58445,6 +58662,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -58644,6 +58862,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -58843,6 +59062,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -59017,6 +59237,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378336,
       "structure_id": null,
       "support_skills": {
@@ -59918,6 +60139,7 @@
       "player_id": 7462352,
       "player_name": "駆逐艦ˢBrHe",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2378374,
       "structure_id": null,
       "support_skills": {
@@ -60117,6 +60339,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -60295,6 +60518,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378359,
       "structure_id": null,
       "support_skills": {
@@ -60494,6 +60718,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -60689,6 +60914,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378385,
       "structure_id": null,
       "support_skills": {
@@ -60888,6 +61114,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378391,
       "structure_id": null,
       "support_skills": {
@@ -61083,6 +61310,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -61274,6 +61502,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -61473,6 +61702,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378466,
       "structure_id": null,
       "support_skills": {
@@ -61671,6 +61901,7 @@
       "player_id": 1019269,
       "player_name": "Aachen 7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -61866,6 +62097,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -62061,6 +62293,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -62260,6 +62493,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378415,
       "structure_id": null,
       "support_skills": {
@@ -62451,6 +62685,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -62646,6 +62881,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -62845,6 +63081,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63044,6 +63281,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63239,6 +63477,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -63438,6 +63677,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378459,
       "structure_id": null,
       "support_skills": {
@@ -63637,6 +63877,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -63828,6 +64069,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379859,
       "structure_id": null,
       "support_skills": {
@@ -64023,6 +64265,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -64222,6 +64465,7 @@
       "player_id": 4713658,
       "player_name": "Zuckachu ヅ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -64421,6 +64665,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378645,
       "structure_id": null,
       "support_skills": {
@@ -64620,6 +64865,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -64815,6 +65061,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378499,
       "structure_id": null,
       "support_skills": {
@@ -65014,6 +65261,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378662,
       "structure_id": null,
       "support_skills": {
@@ -65213,6 +65461,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378531,
       "structure_id": null,
       "support_skills": {
@@ -65412,6 +65661,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -65611,6 +65861,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378738,
       "structure_id": null,
       "support_skills": {
@@ -65806,6 +66057,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -66005,6 +66257,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -66204,6 +66457,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378580,
       "structure_id": null,
       "support_skills": {
@@ -66403,6 +66657,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378998,
       "structure_id": null,
       "support_skills": {
@@ -66594,6 +66849,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -66793,6 +67049,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -66984,6 +67241,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -67183,6 +67441,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378587,
       "structure_id": null,
       "support_skills": {
@@ -67382,6 +67641,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378663,
       "structure_id": null,
       "support_skills": {
@@ -67581,6 +67841,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -67780,6 +68041,7 @@
       "player_id": 9618231,
       "player_name": "Fürst Wilhelm",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378790,
       "structure_id": null,
       "support_skills": {
@@ -67979,6 +68241,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379005,
       "structure_id": null,
       "support_skills": {
@@ -68178,6 +68441,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378593,
       "structure_id": null,
       "support_skills": {
@@ -68373,6 +68637,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -68572,6 +68837,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -68767,6 +69033,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -68962,6 +69229,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378812,
       "structure_id": null,
       "support_skills": {
@@ -69161,6 +69429,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378817,
       "structure_id": null,
       "support_skills": {
@@ -69360,6 +69629,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -69559,6 +69829,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -69758,6 +70029,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -69949,6 +70221,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378823,
       "structure_id": null,
       "support_skills": {
@@ -70148,6 +70421,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -70347,6 +70621,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -70546,6 +70821,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -70745,6 +71021,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -70948,6 +71225,7 @@
       "player_id": 125013933,
       "player_name": "sucior420",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379050,
       "structure_id": null,
       "support_skills": {
@@ -71147,6 +71425,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378896,
       "structure_id": null,
       "support_skills": {
@@ -71346,6 +71625,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -71545,6 +71825,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -71744,6 +72025,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -71943,6 +72225,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -72117,6 +72400,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378709,
       "structure_id": null,
       "support_skills": {
@@ -72312,6 +72596,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -72511,6 +72796,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -72710,6 +72996,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378818,
       "structure_id": null,
       "support_skills": {
@@ -72909,6 +73196,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -73104,6 +73392,7 @@
       "player_id": 91774997,
       "player_name": "Sir Skyrr Duck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73303,6 +73592,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73477,6 +73767,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73672,6 +73963,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -73867,6 +74159,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378822,
       "structure_id": null,
       "support_skills": {
@@ -74066,6 +74359,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -74261,6 +74555,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378748,
       "structure_id": null,
       "support_skills": {
@@ -74460,6 +74755,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378962,
       "structure_id": null,
       "support_skills": {
@@ -74655,6 +74951,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378756,
       "structure_id": null,
       "support_skills": {
@@ -74854,6 +75151,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379463,
       "structure_id": null,
       "support_skills": {
@@ -75049,6 +75347,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378762,
       "structure_id": null,
       "support_skills": {
@@ -75248,6 +75547,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -75447,6 +75747,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -75642,6 +75943,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -75833,6 +76135,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -76032,6 +76335,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379318,
       "structure_id": null,
       "support_skills": {
@@ -76231,6 +76535,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -76430,6 +76735,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -76608,6 +76914,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378797,
       "structure_id": null,
       "support_skills": {
@@ -76786,6 +77093,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -77543,6 +77851,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -77732,6 +78041,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -77927,6 +78237,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -78118,6 +78429,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379698,
       "structure_id": null,
       "support_skills": {
@@ -78317,6 +78629,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -78470,6 +78783,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -78652,6 +78966,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -78843,6 +79158,7 @@
       "player_id": 149256003,
       "player_name": "Sir Bambam",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -79042,6 +79358,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -79237,6 +79554,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378869,
       "structure_id": null,
       "support_skills": {
@@ -79436,6 +79754,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378875,
       "structure_id": null,
       "support_skills": {
@@ -79610,6 +79929,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378880,
       "structure_id": null,
       "support_skills": {
@@ -79805,6 +80125,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -79979,6 +80300,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378913,
       "structure_id": null,
       "support_skills": {
@@ -80178,6 +80500,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379134,
       "structure_id": null,
       "support_skills": {
@@ -80377,6 +80700,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378938,
       "structure_id": null,
       "support_skills": {
@@ -80572,6 +80896,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -80771,6 +81096,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379158,
       "structure_id": null,
       "support_skills": {
@@ -80970,6 +81296,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -81148,6 +81475,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379012,
       "structure_id": null,
       "support_skills": {
@@ -81347,6 +81675,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -81538,6 +81867,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -81716,6 +82046,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -81919,6 +82250,7 @@
       "player_id": 129169775,
       "player_name": "Aydinn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -82118,6 +82450,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379459,
       "structure_id": null,
       "support_skills": {
@@ -82317,6 +82650,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -82495,6 +82829,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -82690,6 +83025,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379059,
       "structure_id": null,
       "support_skills": {
@@ -82885,6 +83221,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379167,
       "structure_id": null,
       "support_skills": {
@@ -83067,6 +83404,7 @@
       "player_id": 34488395,
       "player_name": "Zwiebelritter79",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379078,
       "structure_id": null,
       "support_skills": {
@@ -83266,6 +83604,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -83461,6 +83800,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -83660,6 +84000,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -83859,6 +84200,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379112,
       "structure_id": null,
       "support_skills": {
@@ -84050,6 +84392,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379278,
       "structure_id": null,
       "support_skills": {
@@ -84245,6 +84588,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -84444,6 +84788,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -84614,6 +84959,7 @@
       "player_id": 129258203,
       "player_name": "BLK92",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379500,
       "structure_id": null,
       "support_skills": {
@@ -84813,6 +85159,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -85008,6 +85355,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -85207,6 +85555,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -85406,6 +85755,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -85605,6 +85955,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -85804,6 +86155,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -85961,6 +86313,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379190,
       "structure_id": null,
       "support_skills": {
@@ -86135,6 +86488,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -86330,6 +86684,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -86508,6 +86863,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379204,
       "structure_id": null,
       "support_skills": {
@@ -86703,6 +87059,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379211,
       "structure_id": null,
       "support_skills": {
@@ -86902,6 +87259,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379371,
       "structure_id": null,
       "support_skills": {
@@ -87076,6 +87434,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -87254,6 +87613,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -87411,6 +87771,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379224,
       "structure_id": null,
       "support_skills": {
@@ -87585,6 +87946,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379243,
       "structure_id": null,
       "support_skills": {
@@ -87784,6 +88146,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379470,
       "structure_id": null,
       "support_skills": {
@@ -87983,6 +88346,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379255,
       "structure_id": null,
       "support_skills": {
@@ -88178,6 +88542,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379262,
       "structure_id": null,
       "support_skills": {
@@ -88373,6 +88738,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -88568,6 +88934,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -88763,6 +89130,7 @@
       "player_id": 949733,
       "player_name": "Greiserich",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379284,
       "structure_id": null,
       "support_skills": {
@@ -88958,6 +89326,7 @@
       "player_id": 124893142,
       "player_name": "ˢˣ乄Daspim",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379456,
       "structure_id": null,
       "support_skills": {
@@ -89157,6 +89526,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379305,
       "structure_id": null,
       "support_skills": {
@@ -89356,6 +89726,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -89555,6 +89926,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -89754,6 +90126,7 @@
       "player_id": 36152860,
       "player_name": "Aldérik",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379345,
       "structure_id": null,
       "support_skills": {
@@ -89907,6 +90280,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -90106,6 +90480,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -90297,6 +90672,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90475,6 +90851,7 @@
       "player_id": 53674767,
       "player_name": "Krawler12000",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90674,6 +91051,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90873,6 +91251,7 @@
       "player_id": 4713658,
       "player_name": "Zuckachu ヅ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -91072,6 +91451,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -91267,6 +91647,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -91466,6 +91847,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379375,
       "structure_id": null,
       "support_skills": {
@@ -91665,6 +92047,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -91860,6 +92243,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379469,
       "structure_id": null,
       "support_skills": {
@@ -92013,6 +92397,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379382,
       "structure_id": null,
       "support_skills": {
@@ -92191,6 +92576,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379390,
       "structure_id": null,
       "support_skills": {
@@ -92386,6 +92772,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379420,
       "structure_id": null,
       "support_skills": {
@@ -92581,6 +92968,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379427,
       "structure_id": null,
       "support_skills": {
@@ -92780,6 +93168,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -92979,6 +93368,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -93174,6 +93564,7 @@
       "player_id": 952217,
       "player_name": "Stop war ua",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -93373,6 +93764,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379442,
       "structure_id": null,
       "support_skills": {
@@ -93572,6 +93964,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -93767,6 +94160,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -94484,6 +94878,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -94675,6 +95070,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -94849,6 +95245,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -95044,6 +95441,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -95239,6 +95637,7 @@
       "player_id": 922968,
       "player_name": "MaveK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379483,
       "structure_id": null,
       "support_skills": {
@@ -95438,6 +95837,7 @@
       "player_id": 1019269,
       "player_name": "Aachen 7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -95637,6 +96037,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -95828,6 +96229,7 @@
       "player_id": 38611314,
       "player_name": "Shazb0t",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -95981,6 +96383,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -96176,6 +96579,7 @@
       "player_id": 941710,
       "player_name": "SAH4RCOREJZ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -96379,6 +96783,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -96578,6 +96983,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -96777,6 +97183,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -96968,6 +97375,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379513,
       "structure_id": null,
       "support_skills": {
@@ -97167,6 +97575,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -97366,6 +97775,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379507,
       "structure_id": null,
       "support_skills": {
@@ -97561,6 +97971,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379722,
       "structure_id": null,
       "support_skills": {
@@ -97735,6 +98146,7 @@
       "player_id": 29156197,
       "player_name": "Judge Jonzement",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379519,
       "structure_id": null,
       "support_skills": {
@@ -97934,6 +98346,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -98133,6 +98546,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -98328,6 +98742,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -98527,6 +98942,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379548,
       "structure_id": null,
       "support_skills": {
@@ -98726,6 +99142,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379598,
       "structure_id": null,
       "support_skills": {
@@ -98925,6 +99342,7 @@
       "player_id": 10052322,
       "player_name": "Sɪʀ Zucks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -99120,6 +99538,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379637,
       "structure_id": null,
       "support_skills": {
@@ -99298,6 +99717,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379645,
       "structure_id": null,
       "support_skills": {
@@ -99497,6 +99917,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379651,
       "structure_id": null,
       "support_skills": {
@@ -99696,6 +100117,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379658,
       "structure_id": null,
       "support_skills": {
@@ -99891,6 +100313,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379666,
       "structure_id": null,
       "support_skills": {
@@ -100090,6 +100513,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379670,
       "structure_id": null,
       "support_skills": {
@@ -100264,6 +100688,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379678,
       "structure_id": null,
       "support_skills": {
@@ -100442,6 +100867,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -100641,6 +101067,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -100840,6 +101267,7 @@
       "player_id": 11987186,
       "player_name": "I Dare",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379752,
       "structure_id": null,
       "support_skills": {
@@ -101026,6 +101454,7 @@
       "player_id": 86610794,
       "player_name": "ᵛⁿmoneybo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379753,
       "structure_id": null,
       "support_skills": {
@@ -101217,6 +101646,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -101416,6 +101846,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -101615,6 +102046,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -101806,6 +102238,7 @@
       "player_id": 6193256,
       "player_name": "cpt pelle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -101984,6 +102417,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -102183,6 +102617,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379852,
       "structure_id": null,
       "support_skills": {
@@ -102382,6 +102817,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -102581,6 +103017,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -102784,6 +103221,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379785,
       "structure_id": null,
       "support_skills": {
@@ -102979,6 +103417,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379806,
       "structure_id": null,
       "support_skills": {
@@ -103174,6 +103613,7 @@
       "player_id": 936551,
       "player_name": "Nordsee 300",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379820,
       "structure_id": null,
       "support_skills": {
@@ -103373,6 +103813,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379845,
       "structure_id": null,
       "support_skills": {
@@ -115469,6 +115910,7 @@
     "player_id": 37188990,
     "player_name": "망치丶Black",
     "rally": null,
+    "server_season": "100",
     "structure_id": 52,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 412,
     "mail_id": "8421200117137313126",
     "mail_receiver": "player_46387535",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "914085176607419831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -192,6 +192,7 @@
       "player_id": 37556801,
       "player_name": "Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 31439,
       "structure_id": null,
       "support_skills": {
@@ -332,6 +333,7 @@
     "player_id": 71738515,
     "player_name": "G Var",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,


### PR DESCRIPTION
## Summary

- extract `SerSeason` as `server_season` for battle report senders and opponents
- preserve the report string exactly, including empty and sentinel values
- return `null` when the report does not include the field
- regenerate the tracked Battle sample outputs

## Why

The server season provides the player's season bracket at the time of the battle report. Exposing the raw value allows consumers to use that context without guessing a value for older reports where it is unavailable.

## Validation

- `cargo test -p mail-processor-battle`
- `cargo clippy -p mail-processor-battle --all-targets --locked -- -D warnings`
- `cargo fmt --check`
- regenerated all tracked `samples/Battle` outputs with `mail-cli`
- verified every sender and opponent value against its decoded source
