### PR TITLE
feat(battle): extract report schema

### DIFF
--- a/crates/mail/processors/battle/src/metadata.rs
+++ b/crates/mail/processors/battle/src/metadata.rs
@@ -33,12 +33,14 @@ impl Extractor for MetadataExtractor {
         let report_id = require_u64_field(content, "Id")?;
         let mail_role = require_string_field(content, "Role")?;
         let kvk = resolve_kvk(&mail_role, content, metadata.server_id)?;
+        let schema = optional_u64_field(content, "Schema")?;
         let ll_script_schema = optional_u64_field(content, "LLScriptSchema")?;
 
         let mut section = metadata.into_section();
         section.insert("report_id", Value::from(report_id));
         section.insert("mail_role", Value::String(mail_role));
         section.insert("kvk", Value::Bool(kvk));
+        section.insert("schema", schema.map_or(Value::Null, Value::from));
         section.insert("ll_script_schema", ll_script_schema.map_or(Value::Null, Value::from));
         Ok(section)
     }
@@ -260,6 +262,33 @@ mod tests {
     }
 
     #[test]
+    fn metadata_extractor_preserves_schema() {
+        let input = metadata_input_with_schema(Some(json!(10002)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["schema"], json!(10002));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_zero_schema() {
+        let input = metadata_input_with_schema(Some(json!(0)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["schema"], json!(0));
+    }
+
+    #[test]
+    fn metadata_extractor_uses_null_when_schema_is_absent() {
+        let input = metadata_input_with_schema(None);
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["schema"], Value::Null);
+    }
+
+    #[test]
     fn metadata_extractor_preserves_zero_ll_script_schema() {
         let input = metadata_input_with_ll_script_schema(Some(json!(0)));
 
@@ -297,6 +326,16 @@ mod tests {
 
         if let Some(value) = ll_script_schema {
             input["body"]["content"]["LLScriptSchema"] = value;
+        }
+
+        input
+    }
+
+    fn metadata_input_with_schema(schema: Option<Value>) -> Value {
+        let mut input = metadata_input_with_ll_script_schema(None);
+
+        if let Some(value) = schema {
+            input["body"]["content"]["Schema"] = value;
         }
 
         input

--- a/crates/mail/processors/battle/src/metadata.rs
+++ b/crates/mail/processors/battle/src/metadata.rs
@@ -2,7 +2,7 @@
 
 use mail_sdk::{
     ExtractError, Extractor, Section, extract_base_metadata, optional_bool_field,
-    require_string_field, require_u64_field,
+    optional_u64_field, require_string_field, require_u64_field,
 };
 use serde_json::{Map, Value};
 
@@ -33,11 +33,13 @@ impl Extractor for MetadataExtractor {
         let report_id = require_u64_field(content, "Id")?;
         let mail_role = require_string_field(content, "Role")?;
         let kvk = resolve_kvk(&mail_role, content, metadata.server_id)?;
+        let ll_script_schema = optional_u64_field(content, "LLScriptSchema")?;
 
         let mut section = metadata.into_section();
         section.insert("report_id", Value::from(report_id));
         section.insert("mail_role", Value::String(mail_role));
         section.insert("kvk", Value::Bool(kvk));
+        section.insert("ll_script_schema", ll_script_schema.map_or(Value::Null, Value::from));
         Ok(section)
     }
 }
@@ -246,5 +248,57 @@ mod tests {
         let section = extractor.extract(&input).unwrap();
         let fields = section.fields();
         assert_eq!(fields["kvk"], json!(false));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(320)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(320));
+    }
+
+    #[test]
+    fn metadata_extractor_preserves_zero_ll_script_schema() {
+        let input = metadata_input_with_ll_script_schema(Some(json!(0)));
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], json!(0));
+    }
+
+    #[test]
+    fn metadata_extractor_uses_null_when_ll_script_schema_is_absent() {
+        let input = metadata_input_with_ll_script_schema(None);
+
+        let section = MetadataExtractor::new().extract(&input).unwrap();
+
+        assert_eq!(section.fields()["ll_script_schema"], Value::Null);
+    }
+
+    fn metadata_input_with_ll_script_schema(ll_script_schema: Option<Value>) -> Value {
+        let mut input = json!({
+            "id": "mail-1",
+            "time": 1234,
+            "receiver": "player-1",
+            "serverId": 55,
+            "body": {
+                "content": {
+                    "Id": 18930744,
+                    "Role": "gsmp",
+                    "isConquerSeason": true,
+                    "SelfChar": {
+                        "COSId": 10
+                    }
+                }
+            }
+        });
+
+        if let Some(value) = ll_script_schema {
+            input["body"]["content"]["LLScriptSchema"] = value;
+        }
+
+        input
     }
 }

--- a/crates/mail/processors/battle/src/player.rs
+++ b/crates/mail/processors/battle/src/player.rs
@@ -58,6 +58,7 @@ pub(crate) fn extract_player_fields(
     let auxiliary_skills = extract_auxiliary_skills(player)?;
     let (app_id, app_uid) = extract_app_identity(player)?;
     let server_season = optional_string_field(player, "SerSeason")?;
+    let package_identifier = optional_string_field(player, "PkgNameNew")?;
     let (avatar_url, frame_url) = parse_avatar(player)?;
     let supreme_strife = extract_supreme_strife(player)?;
 
@@ -98,6 +99,10 @@ pub(crate) fn extract_player_fields(
     fields.insert(
         "server_season".to_string(),
         server_season.map(Value::String).unwrap_or(Value::Null),
+    );
+    fields.insert(
+        "package_identifier".to_string(),
+        package_identifier.map(Value::String).unwrap_or(Value::Null),
     );
     fields.insert("avatar_url".to_string(), avatar_url);
     fields.insert("frame_url".to_string(), frame_url);
@@ -559,6 +564,33 @@ mod tests {
         let fields = extract_player_fields(&base_player()).unwrap();
 
         assert_eq!(fields["server_season"], Value::Null);
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_package_identifier() {
+        let mut player = base_player();
+        player.insert("PkgNameNew".to_string(), json!("com.lilithgames.rok.pc.int"));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["package_identifier"], json!("com.lilithgames.rok.pc.int"));
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_empty_package_identifier() {
+        let mut player = base_player();
+        player.insert("PkgNameNew".to_string(), json!(""));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["package_identifier"], json!(""));
+    }
+
+    #[test]
+    fn extract_player_fields_uses_null_when_package_identifier_is_absent() {
+        let fields = extract_player_fields(&base_player()).unwrap();
+
+        assert_eq!(fields["package_identifier"], Value::Null);
     }
 
     #[test]

--- a/crates/mail/processors/battle/src/player.rs
+++ b/crates/mail/processors/battle/src/player.rs
@@ -57,6 +57,7 @@ pub(crate) fn extract_player_fields(
     let support_skills = extract_support_skills(player)?;
     let auxiliary_skills = extract_auxiliary_skills(player)?;
     let (app_id, app_uid) = extract_app_identity(player)?;
+    let server_season = optional_string_field(player, "SerSeason")?;
     let (avatar_url, frame_url) = parse_avatar(player)?;
     let supreme_strife = extract_supreme_strife(player)?;
 
@@ -94,6 +95,10 @@ pub(crate) fn extract_player_fields(
     fields.insert("auxiliary_skills".to_string(), auxiliary_skills);
     fields.insert("app_id".to_string(), app_id.map(Value::from).unwrap_or(Value::Null));
     fields.insert("app_uid".to_string(), app_uid.map(Value::from).unwrap_or(Value::Null));
+    fields.insert(
+        "server_season".to_string(),
+        server_season.map(Value::String).unwrap_or(Value::Null),
+    );
     fields.insert("avatar_url".to_string(), avatar_url);
     fields.insert("frame_url".to_string(), frame_url);
     fields.insert("supreme_strife".to_string(), supreme_strife);
@@ -527,6 +532,33 @@ mod tests {
         player.remove("COSId");
         let fields = extract_player_fields(&player).unwrap();
         assert_eq!(fields.get("kingdom_id"), Some(&json!(null)));
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_server_season() {
+        let mut player = base_player();
+        player.insert("SerSeason".to_string(), json!("100"));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["server_season"], json!("100"));
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_empty_server_season() {
+        let mut player = base_player();
+        player.insert("SerSeason".to_string(), json!(""));
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(fields["server_season"], json!(""));
+    }
+
+    #[test]
+    fn extract_player_fields_uses_null_when_server_season_is_absent() {
+        let fields = extract_player_fields(&base_player()).unwrap();
+
+        assert_eq!(fields["server_season"], Value::Null);
     }
 
     #[test]

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -185,6 +185,7 @@
       "player_id": 130014943,
       "player_name": "xAvarice",
       "rally": null,
+      "server_season": "100",
       "start_tick": 312472,
       "structure_id": null,
       "support_skills": {
@@ -325,6 +326,7 @@
     "player_id": 110176153,
     "player_name": "F7yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755294123041275,
     "report_id": 5391170,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -144,6 +144,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -303,6 +304,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1002579517552941234",
     "mail_receiver": "player_110176153",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -192,6 +192,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -402,6 +403,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -608,6 +610,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -818,6 +821,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -1024,6 +1028,7 @@
       "player_id": 92330300,
       "player_name": "Kung Fu Tsar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -1522,6 +1527,7 @@
       "player_id": 80837230,
       "player_name": "西伯利亞狼",
       "rally": true,
+      "server_season": "100",
       "start_tick": 109490,
       "structure_id": null,
       "support_skills": {
@@ -1749,6 +1755,7 @@
     "player_id": 71738515,
     "player_name": "agent G",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -169,6 +169,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -380,6 +381,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -587,6 +589,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -798,6 +801,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -1005,6 +1009,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -1216,6 +1221,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -1660,6 +1666,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_146.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1752345011341072,
     "report_id": 9694158,
+    "schema": 224,
     "server_id": 15538
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "100439187175234501131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 304,
     "mail_id": "10121648172261838131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -196,6 +196,7 @@
       "player_id": 89554760,
       "player_name": "KanomTᵒᵐ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120717,
       "structure_id": null,
       "support_skills": {
@@ -928,6 +929,7 @@
       "player_id": 59351306,
       "player_name": "SOMTAM Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120689,
       "structure_id": null,
       "support_skills": {
@@ -1462,6 +1464,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120793,
       "structure_id": null,
       "support_skills": {
@@ -1668,6 +1671,7 @@
       "player_id": 149352350,
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -1878,6 +1882,7 @@
       "player_id": 149352350,
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2084,6 +2089,7 @@
       "player_id": 23016065,
       "player_name": "Mr Jeep",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120719,
       "structure_id": null,
       "support_skills": {
@@ -2294,6 +2300,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2504,6 +2511,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -2718,6 +2726,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120705,
       "structure_id": null,
       "support_skills": {
@@ -2909,6 +2918,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120704,
       "structure_id": null,
       "support_skills": {
@@ -3119,6 +3129,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -3329,6 +3340,7 @@
       "player_id": 148711145,
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3539,6 +3551,7 @@
       "player_id": 148711145,
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3753,6 +3766,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120712,
       "structure_id": null,
       "support_skills": {
@@ -3959,6 +3973,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120709,
       "structure_id": null,
       "support_skills": {
@@ -4169,6 +4184,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -4379,6 +4395,7 @@
       "player_id": 35381336,
       "player_name": "亗SlamDawg",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120711,
       "structure_id": null,
       "support_skills": {
@@ -4589,6 +4606,7 @@
       "player_id": 5221475,
       "player_name": "Mr nuer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -4799,6 +4817,7 @@
       "player_id": 5221475,
       "player_name": "Mr nuer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120769,
       "structure_id": null,
       "support_skills": {
@@ -5009,6 +5028,7 @@
       "player_id": 76104153,
       "player_name": "OmOshi Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120702,
       "structure_id": null,
       "support_skills": {
@@ -5208,6 +5228,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120783,
       "structure_id": null,
       "support_skills": {
@@ -5418,6 +5439,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120777,
       "structure_id": null,
       "support_skills": {
@@ -5628,6 +5650,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -5830,6 +5853,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6040,6 +6064,7 @@
       "player_id": 10824810,
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6246,6 +6271,7 @@
       "player_id": 10824810,
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -6456,6 +6482,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -6666,6 +6693,7 @@
       "player_id": 2308579,
       "player_name": "Niezy Miller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120779,
       "structure_id": null,
       "support_skills": {
@@ -6872,6 +6900,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7082,6 +7111,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -7292,6 +7322,7 @@
       "player_id": 82768938,
       "player_name": "ﾐ Lemon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7502,6 +7533,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120790,
       "structure_id": null,
       "support_skills": {
@@ -7716,6 +7748,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120787,
       "structure_id": null,
       "support_skills": {
@@ -7926,6 +7959,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120788,
       "structure_id": null,
       "support_skills": {
@@ -8132,6 +8166,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120789,
       "structure_id": null,
       "support_skills": {
@@ -8342,6 +8377,7 @@
       "player_id": 17839483,
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -8817,6 +8853,7 @@
     "player_id": 34961809,
     "player_name": "비아티나",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -384,6 +385,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1117,6 +1119,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1648,6 +1651,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1859,6 +1863,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2066,6 +2071,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2277,6 +2283,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2488,6 +2495,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2703,6 +2711,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2895,6 +2904,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3106,6 +3116,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3317,6 +3328,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3528,6 +3540,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3743,6 +3756,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3950,6 +3964,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4161,6 +4176,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4372,6 +4388,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4583,6 +4600,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4794,6 +4812,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5005,6 +5024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5205,6 +5225,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5416,6 +5437,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5627,6 +5649,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5830,6 +5853,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6041,6 +6065,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6248,6 +6273,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6459,6 +6485,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6670,6 +6697,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6877,6 +6905,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7088,6 +7117,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7299,6 +7329,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7510,6 +7541,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7725,6 +7757,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7936,6 +7969,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8143,6 +8177,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8354,6 +8389,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8506,6 +8542,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_171.png",
     "kingdom_id": 1102,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1722618381913348,
     "report_id": 7865603,
+    "schema": 304,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10163399175529366525",
     "mail_receiver": "player_129397124",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 312015,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 129397124,
     "player_name": "F6yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -120,6 +120,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -254,6 +255,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755293665540670,
     "report_id": 5391066,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -214,6 +214,7 @@
       "player_id": 56779522,
       "player_name": "Raha ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315491,
       "structure_id": null,
       "support_skills": {
@@ -560,6 +561,7 @@
     "player_id": 20075558,
     "player_name": "jën x ƒaräɀ",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -340,6 +341,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1772492621967584,
     "report_id": 6619333,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "10200933177249262113",
     "mail_receiver": "player_53517007",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -192,6 +192,7 @@
       "player_id": 129155556,
       "player_name": "ˢNinoveraptor",
       "rally": null,
+      "server_season": "100",
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -387,6 +388,7 @@
       "player_id": 129155556,
       "player_name": "ˢNinoveraptor",
       "rally": null,
+      "server_season": "100",
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -527,6 +529,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755292554783132,
     "report_id": 5390807,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "10224136175529255431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -169,6 +169,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -365,6 +366,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -506,6 +508,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_104.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgame.roc.gp",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315072,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755296722303273,
     "report_id": 5391297,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -120,6 +120,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -254,6 +255,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036544617552967227",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036588117552967397",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755296739305311,
     "report_id": 5391307,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -120,6 +120,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -254,6 +255,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315089,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -161,6 +161,7 @@
       "player_id": 181252461,
       "player_name": "F4 Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 315091,
       "structure_id": null,
       "support_skills": {
@@ -276,6 +277,7 @@
     "player_id": 141393181,
     "player_name": "F12yst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755296741304367,
     "report_id": 5391309,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "1036600917552967417",
     "mail_receiver": "player_141393181",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -120,6 +120,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -254,6 +255,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -169,6 +169,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -649,6 +650,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -841,6 +843,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1041,6 +1044,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1241,6 +1245,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1433,6 +1438,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1629,6 +1635,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1825,6 +1832,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2021,6 +2029,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2213,6 +2222,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2409,6 +2419,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2613,6 +2624,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2813,6 +2825,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3009,6 +3022,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3205,6 +3219,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3397,6 +3412,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3593,6 +3609,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3738,6 +3755,7 @@
     },
     "frame_url": null,
     "kingdom_id": 2219,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1708105543473384,
     "report_id": 28594462,
+    "schema": 104,
     "server_id": 15790
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -480,6 +480,7 @@
       "player_id": 18285347,
       "player_name": "ミ K H A L I D",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505754,
       "structure_id": null,
       "support_skills": {
@@ -671,6 +672,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -862,6 +864,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1061,6 +1064,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1260,6 +1264,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -1451,6 +1456,7 @@
       "player_id": 154813471,
       "player_name": "Dzin Wielki",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505876,
       "structure_id": null,
       "support_skills": {
@@ -1646,6 +1652,7 @@
       "player_id": 154193427,
       "player_name": "ミ Solgaleo ミ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505790,
       "structure_id": null,
       "support_skills": {
@@ -1841,6 +1848,7 @@
       "player_id": 153947353,
       "player_name": "bedebuh",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505772,
       "structure_id": null,
       "support_skills": {
@@ -2036,6 +2044,7 @@
       "player_id": 156028467,
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -2227,6 +2236,7 @@
       "player_id": 151201578,
       "player_name": "Nicossss",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -2422,6 +2432,7 @@
       "player_id": 156028467,
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505840,
       "structure_id": null,
       "support_skills": {
@@ -2625,6 +2636,7 @@
       "player_id": 153873531,
       "player_name": "Lelouchhシ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505811,
       "structure_id": null,
       "support_skills": {
@@ -2824,6 +2836,7 @@
       "player_id": 142651363,
       "player_name": "香水じゅん",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505799,
       "structure_id": null,
       "support_skills": {
@@ -3019,6 +3032,7 @@
       "player_id": 153434524,
       "player_name": "TANSAA",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -3214,6 +3228,7 @@
       "player_id": 155144299,
       "player_name": "ヅYusekeᵀᴴ",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505835,
       "structure_id": null,
       "support_skills": {
@@ -3405,6 +3420,7 @@
       "player_id": 153434524,
       "player_name": "TANSAA",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505786,
       "structure_id": null,
       "support_skills": {
@@ -3600,6 +3616,7 @@
       "player_id": 154838551,
       "player_name": "ExCalìbur",
       "rally": null,
+      "server_season": "3",
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -4068,6 +4085,7 @@
     "player_id": 71738515,
     "player_name": "ᵀᴼバニー",
     "rally": true,
+    "server_season": "3",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 0,
     "mail_id": "104653012170810554331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1089,6 +1089,7 @@
       "player_id": 21580496,
       "player_name": "Ni丶大佑",
       "rally": null,
+      "server_season": null,
       "start_tick": 962476,
       "structure_id": null,
       "support_skills": {
@@ -1267,6 +1268,7 @@
       "player_id": 20107958,
       "player_name": "Ni 丶毒城",
       "rally": null,
+      "server_season": null,
       "start_tick": 962493,
       "structure_id": null,
       "support_skills": {
@@ -1437,6 +1439,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1615,6 +1618,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1793,6 +1797,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -1950,6 +1955,7 @@
       "player_id": 22795846,
       "player_name": "不放大極靈",
       "rally": null,
+      "server_season": null,
       "start_tick": 962521,
       "structure_id": null,
       "support_skills": {
@@ -2124,6 +2130,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -2294,6 +2301,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962529,
       "structure_id": null,
       "support_skills": {
@@ -2472,6 +2480,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2646,6 +2655,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2824,6 +2834,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -2998,6 +3009,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962574,
       "structure_id": null,
       "support_skills": {
@@ -3168,6 +3180,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962588,
       "structure_id": null,
       "support_skills": {
@@ -3342,6 +3355,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962595,
       "structure_id": null,
       "support_skills": {
@@ -3520,6 +3534,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -3698,6 +3713,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962603,
       "structure_id": null,
       "support_skills": {
@@ -3880,6 +3896,7 @@
       "player_id": 6541069,
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962610,
       "structure_id": null,
       "support_skills": {
@@ -4054,6 +4071,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -4228,6 +4246,7 @@
       "player_id": 66855877,
       "player_name": "慈雲山GAng",
       "rally": null,
+      "server_season": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4406,6 +4425,7 @@
       "player_id": 40988463,
       "player_name": "相思鸟",
       "rally": null,
+      "server_season": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4584,6 +4604,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962652,
       "structure_id": null,
       "support_skills": {
@@ -4754,6 +4775,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962666,
       "structure_id": null,
       "support_skills": {
@@ -4928,6 +4950,7 @@
       "player_id": 19997360,
       "player_name": "300丶mit90109",
       "rally": null,
+      "server_season": null,
       "start_tick": 962680,
       "structure_id": null,
       "support_skills": {
@@ -5098,6 +5121,7 @@
       "player_id": 3781975,
       "player_name": "Ni Ball Master",
       "rally": null,
+      "server_season": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -5272,6 +5296,7 @@
       "player_id": 40988463,
       "player_name": "相思鸟",
       "rally": null,
+      "server_season": null,
       "start_tick": 962694,
       "structure_id": null,
       "support_skills": {
@@ -5450,6 +5475,7 @@
       "player_id": 18345946,
       "player_name": "Ni丶20低調",
       "rally": null,
+      "server_season": null,
       "start_tick": 962701,
       "structure_id": null,
       "support_skills": {
@@ -5624,6 +5650,7 @@
       "player_id": 13467971,
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
+      "server_season": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -6261,6 +6288,7 @@
     "player_id": 32180759,
     "player_name": "GRRRRRRREAT",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -148,6 +148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1245,6 +1246,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1416,6 +1418,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1595,6 +1598,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1774,6 +1778,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1932,6 +1937,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2107,6 +2113,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2278,6 +2285,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2457,6 +2465,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2632,6 +2641,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2811,6 +2821,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2986,6 +2997,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3157,6 +3169,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3332,6 +3345,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3511,6 +3525,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3690,6 +3705,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3873,6 +3889,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4048,6 +4065,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4223,6 +4241,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4402,6 +4421,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4581,6 +4601,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4752,6 +4773,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4927,6 +4949,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5098,6 +5121,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5273,6 +5297,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5452,6 +5477,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5627,6 +5653,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5743,6 +5770,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_67.png",
     "kingdom_id": 860,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "106171761165497242010",
     "mail_receiver": "player_32180759",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1654972420975209,
     "report_id": 74483930,
+    "schema": null,
     "server_id": 15763
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -131,6 +131,7 @@
         ],
         "type": 38
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -263,6 +264,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_69.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1768931423616381,
     "report_id": 6232813,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "1409019176893142331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -154,6 +154,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 35058,
       "structure_id": null,
       "support_skills": {
@@ -285,6 +286,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "152526555167004536031",
     "mail_receiver": "player_71738515",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -148,6 +148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -286,6 +287,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_69.png",
     "kingdom_id": 993,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -189,6 +189,7 @@
       "player_id": 72217206,
       "player_name": "Queen SammyJo",
       "rally": null,
+      "server_season": null,
       "start_tick": 1378409,
       "structure_id": null,
       "support_skills": {
@@ -488,6 +489,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1670045360524087,
     "report_id": 25171293,
+    "schema": null,
     "server_id": 11579
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -196,6 +196,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458684,
       "structure_id": null,
       "support_skills": {
@@ -402,6 +403,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458683,
       "structure_id": null,
       "support_skills": {
@@ -612,6 +614,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458697,
       "structure_id": null,
       "support_skills": {
@@ -822,6 +825,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1028,6 +1032,7 @@
       "player_id": 33171104,
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1183,6 +1188,7 @@
     "player_id": 34961809,
     "player_name": "Viatina乂Fayst",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "16125090175544125330",
     "mail_receiver": "player_34961809",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -380,6 +381,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -591,6 +593,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -802,6 +805,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -1009,6 +1013,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -1165,6 +1170,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_113.png",
     "kingdom_id": 1425,
+    "package_identifier": "com.lilithgames.rok.gpkr",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755441253685821,
     "report_id": 6773952,
+    "schema": 224,
     "server_id": 15597
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "dungeon",
     "mail_time": 1769350084903754,
     "report_id": 16195249,
+    "schema": 10002,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -268,6 +268,7 @@
       "player_id": 116551956,
       "player_name": "TEDDY916",
       "rally": true,
+      "server_season": "-1",
       "start_tick": 444,
       "structure_id": null,
       "support_skills": {
@@ -466,6 +467,7 @@
     "player_id": 129213098,
     "player_name": "ˢ vashido",
     "rally": null,
+    "server_season": "-1",
     "structure_id": 109,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 0,
     "mail_id": "16210617176935008431",
     "mail_receiver": "player_71738515",
     "mail_role": "dungeon",

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -390,6 +391,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_3.png",
     "kingdom_id": 113,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -9240,6 +9241,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -9450,6 +9452,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -9658,6 +9661,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -9848,6 +9852,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -10048,6 +10053,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -10248,6 +10254,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -10448,6 +10455,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -10610,6 +10618,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -10818,6 +10827,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -10992,6 +11002,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -11155,6 +11166,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -11355,6 +11367,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -11562,6 +11575,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -11764,6 +11778,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -11960,6 +11975,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -12158,6 +12174,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -12354,6 +12371,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -12560,6 +12578,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -12756,6 +12775,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -12935,6 +12955,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13135,6 +13156,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13335,6 +13357,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13550,6 +13573,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13746,6 +13770,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -13952,6 +13977,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -14167,6 +14193,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -14367,6 +14394,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -14582,6 +14610,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -14782,6 +14811,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -14996,6 +15026,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -15199,6 +15230,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -15399,6 +15431,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -15614,6 +15647,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -15810,6 +15844,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -16010,6 +16045,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -16225,6 +16261,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -16425,6 +16462,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -16625,6 +16663,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -16840,6 +16879,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17040,6 +17080,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17255,6 +17296,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17414,6 +17456,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17560,6 +17603,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17760,6 +17804,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -17952,6 +17997,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -18152,6 +18198,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -18367,6 +18414,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -18567,6 +18615,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -18782,6 +18831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -18974,6 +19024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -19170,6 +19221,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -19312,6 +19364,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -19508,6 +19561,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -19685,6 +19739,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.gpkr",
       "participants": [
         {
           "alliance": {
@@ -19881,6 +19936,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -20056,6 +20112,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -20260,6 +20317,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -20439,6 +20497,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -20639,6 +20698,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -20835,6 +20895,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -21037,6 +21098,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -21243,6 +21305,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -21458,6 +21521,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -21749,6 +21813,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -21945,6 +22010,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -22151,6 +22217,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -22366,6 +22433,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -22566,6 +22634,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -22762,6 +22831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -22964,6 +23034,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -23170,6 +23241,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -23377,6 +23449,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -23581,6 +23654,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -23781,6 +23855,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -23977,6 +24052,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24175,6 +24251,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -24381,6 +24458,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24581,6 +24659,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -24779,6 +24858,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -24975,6 +25055,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -25181,6 +25262,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -25396,6 +25478,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -25596,6 +25679,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -25792,6 +25876,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -25956,6 +26041,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -26152,6 +26238,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -26354,6 +26441,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -26556,6 +26644,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -26763,6 +26852,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -26965,6 +27055,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27161,6 +27252,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27367,6 +27459,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27582,6 +27675,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27782,6 +27876,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27978,6 +28073,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -28180,6 +28276,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -28376,6 +28473,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -28582,6 +28680,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -28797,6 +28896,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -28997,6 +29097,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -29193,6 +29294,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -29395,6 +29497,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -29601,6 +29704,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -29816,6 +29920,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -29987,6 +30092,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30187,6 +30293,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30383,6 +30490,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30548,6 +30656,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30727,6 +30836,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -30923,6 +31033,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31075,6 +31186,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31275,6 +31387,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31445,6 +31558,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31649,6 +31763,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31849,6 +31964,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -32045,6 +32161,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -32230,6 +32347,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -32422,6 +32540,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -32622,6 +32741,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -32837,6 +32957,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -33037,6 +33158,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -33233,6 +33355,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -33443,6 +33566,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -33798,6 +33922,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34013,6 +34138,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34188,6 +34314,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34388,6 +34515,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34584,6 +34712,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34769,6 +34898,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -34969,6 +35099,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -35184,6 +35315,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -35384,6 +35516,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -35580,6 +35713,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -35786,6 +35920,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -36001,6 +36136,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -36155,6 +36291,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36355,6 +36492,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -36551,6 +36689,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -36749,6 +36888,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -36945,6 +37085,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -37141,6 +37282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -37347,6 +37489,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -37562,6 +37705,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -37762,6 +37906,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -37958,6 +38103,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38123,6 +38269,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38319,6 +38466,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38525,6 +38673,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -38725,6 +38874,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38940,6 +39090,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39136,6 +39287,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39336,6 +39488,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39532,6 +39685,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39734,6 +39888,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39940,6 +40095,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40155,6 +40311,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40351,6 +40508,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40536,6 +40694,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40732,6 +40891,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40938,6 +41098,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -41141,6 +41302,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -41320,6 +41482,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -41524,6 +41687,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -41724,6 +41888,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -41886,6 +42051,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -42057,6 +42223,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -42253,6 +42420,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -42459,6 +42627,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -42661,6 +42830,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -42867,6 +43037,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43082,6 +43253,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43282,6 +43454,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43492,6 +43665,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43811,6 +43985,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44011,6 +44186,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -44213,6 +44389,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44419,6 +44596,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44634,6 +44812,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44834,6 +45013,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -45030,6 +45210,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -45211,6 +45392,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -45413,6 +45595,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -45609,6 +45792,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -45815,6 +45999,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -46030,6 +46215,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -46230,6 +46416,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -46426,6 +46613,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -46590,6 +46778,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -46782,6 +46971,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -46978,6 +47168,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -47184,6 +47375,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -47399,6 +47591,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -47599,6 +47792,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -47795,6 +47989,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -47997,6 +48192,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -48189,6 +48385,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -48393,6 +48590,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -48597,6 +48795,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -48804,6 +49003,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49010,6 +49210,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49225,6 +49426,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49425,6 +49627,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49621,6 +49824,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49823,6 +50027,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -50033,6 +50238,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -50229,6 +50435,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -50425,6 +50632,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -50627,6 +50835,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -50833,6 +51042,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -51048,6 +51258,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -51248,6 +51459,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -51444,6 +51656,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -51646,6 +51859,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -51852,6 +52066,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -52067,6 +52282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -52263,6 +52479,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -52432,6 +52649,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -52624,6 +52842,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -52824,6 +53043,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -53022,6 +53242,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53185,6 +53406,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -53356,6 +53578,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.gpkr",
       "participants": [
         {
           "alliance": {
@@ -53548,6 +53771,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -53744,6 +53968,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -53950,6 +54175,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -54165,6 +54391,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -54365,6 +54592,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -54561,6 +54789,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -54775,6 +55004,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -55176,6 +55406,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -55368,6 +55599,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -55568,6 +55800,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -55764,6 +55997,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -55960,6 +56194,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56145,6 +56380,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56345,6 +56581,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56560,6 +56797,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56760,6 +56998,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56956,6 +57195,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57162,6 +57402,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57362,6 +57603,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57566,6 +57808,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57762,6 +58005,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57964,6 +58208,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -58170,6 +58415,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58385,6 +58631,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58564,6 +58811,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -58770,6 +59018,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58966,6 +59215,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -59168,6 +59418,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -59374,6 +59625,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -59589,6 +59841,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -59789,6 +60042,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -59985,6 +60239,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -60187,6 +60442,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -60383,6 +60639,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -60579,6 +60836,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -60785,6 +61043,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -61000,6 +61259,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -61200,6 +61460,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -61396,6 +61657,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -61581,6 +61843,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -61777,6 +62040,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -61983,6 +62247,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -62198,6 +62463,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -62390,6 +62656,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -62582,6 +62849,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -62782,6 +63050,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -62978,6 +63247,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63180,6 +63450,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63351,6 +63622,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63547,6 +63819,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63753,6 +64026,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63960,6 +64234,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -64164,6 +64439,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -64364,6 +64640,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -64567,6 +64844,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -64767,6 +65045,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -64963,6 +65242,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -65165,6 +65445,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -65371,6 +65652,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -65578,6 +65860,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -65782,6 +66065,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -65936,6 +66220,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -66136,6 +66421,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -66332,6 +66618,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -66509,6 +66796,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -66713,6 +67001,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -66887,6 +67176,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67066,6 +67356,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67266,6 +67557,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67462,6 +67754,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67668,6 +67961,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67883,6 +68177,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -68083,6 +68378,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -68279,6 +68575,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -68431,6 +68728,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -68631,6 +68929,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -68831,6 +69130,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -69031,6 +69331,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -69193,6 +69494,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -69372,6 +69674,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -69568,6 +69871,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -69764,6 +70068,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -69970,6 +70275,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -70189,6 +70495,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -71700,6 +72007,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -71900,6 +72208,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72096,6 +72405,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72298,6 +72608,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72504,6 +72815,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72694,6 +73006,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -72898,6 +73211,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73098,6 +73412,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73294,6 +73609,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73496,6 +73812,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -73707,6 +74024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -73882,6 +74200,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -74084,6 +74403,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -74291,6 +74611,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74497,6 +74818,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74697,6 +75019,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74908,6 +75231,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -75118,6 +75442,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -75318,6 +75643,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -75524,6 +75850,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -75720,6 +76047,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -75926,6 +76254,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -76130,6 +76459,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -76330,6 +76660,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -76526,6 +76857,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -76728,6 +77060,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -76924,6 +77257,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77130,6 +77464,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77345,6 +77680,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77545,6 +77881,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77737,6 +78074,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77933,6 +78271,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -78118,6 +78457,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -78314,6 +78654,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -78521,6 +78862,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -78700,6 +79042,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -78881,6 +79224,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -79087,6 +79431,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -79283,6 +79628,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -79489,6 +79835,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -79689,6 +80036,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -79889,6 +80237,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80085,6 +80434,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80291,6 +80641,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80506,6 +80857,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80702,6 +81054,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80904,6 +81257,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -81104,6 +81458,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -81308,6 +81663,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -81500,6 +81856,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -81700,6 +82057,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -81892,6 +82250,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -82067,6 +82426,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -82238,6 +82598,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -82430,6 +82791,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -82630,6 +82992,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -82826,6 +83189,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -83037,6 +83401,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -83251,6 +83616,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -83453,6 +83819,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -83649,6 +84016,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -83845,6 +84213,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -84056,6 +84425,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -84248,6 +84618,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -84450,6 +84821,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -84608,6 +84980,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -84783,6 +85156,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -84989,6 +85363,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85147,6 +85522,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -85339,6 +85715,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -85539,6 +85916,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -85735,6 +86113,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -85935,6 +86314,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -86135,6 +86515,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -86331,6 +86712,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -86495,6 +86877,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -86695,6 +87078,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -86891,6 +87275,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -87105,6 +87490,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -87311,6 +87697,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87507,6 +87894,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87703,6 +88091,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -87892,6 +88281,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -88092,6 +88482,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -88298,6 +88689,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -88498,6 +88890,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -88677,6 +89070,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -88858,6 +89252,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -89060,6 +89455,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -89256,6 +89652,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -89456,6 +89853,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -89652,6 +90050,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -89810,6 +90209,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -90014,6 +90414,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -90195,6 +90596,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -90377,6 +90779,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -90573,6 +90976,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -90780,6 +91184,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -90986,6 +91391,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91190,6 +91596,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91390,6 +91797,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -91586,6 +91994,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -91794,6 +92203,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -92001,6 +92411,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -92203,6 +92614,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92403,6 +92815,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -92603,6 +93016,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -92814,6 +93228,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -93025,6 +93440,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -93229,6 +93645,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -93429,6 +93846,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -93625,6 +94043,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -93827,6 +94246,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -94029,6 +94449,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -94231,6 +94652,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -94410,6 +94832,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -94585,6 +95008,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94770,6 +95194,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94955,6 +95380,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -95155,6 +95581,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -95351,6 +95778,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -95557,6 +95985,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -95757,6 +96186,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -95930,6 +96360,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -96134,6 +96565,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -96334,6 +96766,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -96534,6 +96967,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -96730,6 +97164,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -96944,6 +97379,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -97155,6 +97591,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -97359,6 +97796,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -97555,6 +97993,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -97755,6 +98194,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -97934,6 +98374,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98134,6 +98575,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98349,6 +98791,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98549,6 +98992,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98745,6 +99189,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98951,6 +99396,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -99151,6 +99597,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -99351,6 +99798,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -99530,6 +99978,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -99734,6 +100183,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -99934,6 +100384,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -100134,6 +100585,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -100345,6 +100797,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -100560,6 +101013,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -100760,6 +101214,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -100906,6 +101361,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -101098,6 +101554,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -101302,6 +101759,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -101498,6 +101956,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -101669,6 +102128,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -101855,6 +102315,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -102051,6 +102512,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -102253,6 +102715,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -102434,6 +102897,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -102617,6 +103081,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -102813,6 +103278,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -103015,6 +103481,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -103226,6 +103693,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -103437,6 +103905,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -103648,6 +104117,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -103840,6 +104310,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -104048,6 +104519,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -104878,6 +105350,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -105074,6 +105547,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -105280,6 +105754,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -105484,6 +105959,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -105676,6 +106152,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -105830,6 +106307,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -106034,6 +106512,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -106227,6 +106706,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -106419,6 +106899,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -106619,6 +107100,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -106790,6 +107272,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -106944,6 +107427,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -107148,6 +107632,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -107306,6 +107791,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -107483,6 +107969,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -107676,6 +108163,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -107884,6 +108372,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -108095,6 +108584,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -108291,6 +108781,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -108462,6 +108953,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.gpkr",
       "participants": [
         {
           "alliance": {
@@ -108662,6 +109154,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -108862,6 +109355,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -109068,6 +109562,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -109274,6 +109769,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -109476,6 +109972,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -109674,6 +110171,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -109851,6 +110349,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -110037,6 +110536,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -110237,6 +110737,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -110433,6 +110934,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -110635,6 +111137,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -110835,6 +111338,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -111031,6 +111535,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -111237,6 +111742,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -111437,6 +111943,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -111612,6 +112119,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -111816,6 +112324,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -112012,6 +112521,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -112216,6 +112726,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -112416,6 +112927,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -112622,6 +113134,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -112808,6 +113321,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -113004,6 +113518,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -113200,6 +113715,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -113379,6 +113895,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -113593,6 +114110,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -113795,6 +114313,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -113989,6 +114508,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -114185,6 +114705,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -114343,6 +114864,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -114543,6 +115065,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -114750,6 +115273,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -114952,6 +115476,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -115152,6 +115677,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -115358,6 +115884,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -115558,6 +116085,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -115754,6 +116282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -115960,6 +116489,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -116171,6 +116701,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -116333,6 +116864,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -116548,6 +117080,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.rok.ios.vn",
       "participants": [
         {
           "alliance": {
@@ -116710,6 +117243,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -116921,6 +117455,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -117075,6 +117610,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -117246,6 +117782,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -117442,6 +117979,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -117642,6 +118180,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -117838,6 +118377,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -118017,6 +118557,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -118192,6 +118733,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -118392,6 +118934,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -118603,6 +119146,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -118759,6 +119303,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 224,
     "mail_id": "18895907175034307923",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -9052,6 +9052,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627430,
       "structure_id": null,
       "support_skills": {
@@ -9262,6 +9263,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627539,
       "structure_id": null,
       "support_skills": {
@@ -9471,6 +9473,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627514,
       "structure_id": null,
       "support_skills": {
@@ -9678,6 +9681,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627557,
       "structure_id": null,
       "support_skills": {
@@ -9867,6 +9871,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627614,
       "structure_id": null,
       "support_skills": {
@@ -10066,6 +10071,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10265,6 +10271,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627653,
       "structure_id": null,
       "support_skills": {
@@ -10464,6 +10471,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10625,6 +10633,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -10832,6 +10841,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -11005,6 +11015,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627730,
       "structure_id": null,
       "support_skills": {
@@ -11167,6 +11178,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627732,
       "structure_id": null,
       "support_skills": {
@@ -11366,6 +11378,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627738,
       "structure_id": null,
       "support_skills": {
@@ -11572,6 +11585,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627769,
       "structure_id": null,
       "support_skills": {
@@ -11773,6 +11787,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627772,
       "structure_id": null,
       "support_skills": {
@@ -11968,6 +11983,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627789,
       "structure_id": null,
       "support_skills": {
@@ -12165,6 +12181,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627827,
       "structure_id": null,
       "support_skills": {
@@ -12360,6 +12377,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627830,
       "structure_id": null,
       "support_skills": {
@@ -12565,6 +12583,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627831,
       "structure_id": null,
       "support_skills": {
@@ -12760,6 +12779,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627836,
       "structure_id": null,
       "support_skills": {
@@ -12938,6 +12958,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627850,
       "structure_id": null,
       "support_skills": {
@@ -13137,6 +13158,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627856,
       "structure_id": null,
       "support_skills": {
@@ -13336,6 +13358,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627860,
       "structure_id": null,
       "support_skills": {
@@ -13550,6 +13573,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627862,
       "structure_id": null,
       "support_skills": {
@@ -13745,6 +13769,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627876,
       "structure_id": null,
       "support_skills": {
@@ -13950,6 +13975,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627882,
       "structure_id": null,
       "support_skills": {
@@ -14164,6 +14190,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627884,
       "structure_id": null,
       "support_skills": {
@@ -14363,6 +14390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627907,
       "structure_id": null,
       "support_skills": {
@@ -14577,6 +14605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627910,
       "structure_id": null,
       "support_skills": {
@@ -14776,6 +14805,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -14989,6 +15019,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -15191,6 +15222,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627950,
       "structure_id": null,
       "support_skills": {
@@ -15390,6 +15422,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627954,
       "structure_id": null,
       "support_skills": {
@@ -15604,6 +15637,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627956,
       "structure_id": null,
       "support_skills": {
@@ -15799,6 +15833,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627982,
       "structure_id": null,
       "support_skills": {
@@ -15998,6 +16033,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627978,
       "structure_id": null,
       "support_skills": {
@@ -16212,6 +16248,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627981,
       "structure_id": null,
       "support_skills": {
@@ -16411,6 +16448,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 627986,
       "structure_id": null,
       "support_skills": {
@@ -16610,6 +16648,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628001,
       "structure_id": null,
       "support_skills": {
@@ -16824,6 +16863,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628004,
       "structure_id": null,
       "support_skills": {
@@ -17023,6 +17063,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628024,
       "structure_id": null,
       "support_skills": {
@@ -17237,6 +17278,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628027,
       "structure_id": null,
       "support_skills": {
@@ -17395,6 +17437,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628028,
       "structure_id": null,
       "support_skills": {
@@ -17540,6 +17583,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628032,
       "structure_id": null,
       "support_skills": {
@@ -17739,6 +17783,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628034,
       "structure_id": null,
       "support_skills": {
@@ -17930,6 +17975,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628038,
       "structure_id": null,
       "support_skills": {
@@ -18129,6 +18175,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628071,
       "structure_id": null,
       "support_skills": {
@@ -18343,6 +18390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628073,
       "structure_id": null,
       "support_skills": {
@@ -18542,6 +18590,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628096,
       "structure_id": null,
       "support_skills": {
@@ -18756,6 +18805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628098,
       "structure_id": null,
       "support_skills": {
@@ -18947,6 +18997,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19142,6 +19193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19283,6 +19335,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628113,
       "structure_id": null,
       "support_skills": {
@@ -19478,6 +19531,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628114,
       "structure_id": null,
       "support_skills": {
@@ -19654,6 +19708,7 @@
       "player_id": 42046369,
       "player_name": "Ral farm B",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -19849,6 +19904,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -20023,6 +20079,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20226,6 +20283,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628117,
       "structure_id": null,
       "support_skills": {
@@ -20404,6 +20462,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20603,6 +20662,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628120,
       "structure_id": null,
       "support_skills": {
@@ -20798,6 +20858,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628123,
       "structure_id": null,
       "support_skills": {
@@ -20999,6 +21060,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628130,
       "structure_id": null,
       "support_skills": {
@@ -21204,6 +21266,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628136,
       "structure_id": null,
       "support_skills": {
@@ -21544,6 +21607,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628199,
       "structure_id": null,
       "support_skills": {
@@ -21708,6 +21772,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628168,
       "structure_id": null,
       "support_skills": {
@@ -21903,6 +21968,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628173,
       "structure_id": null,
       "support_skills": {
@@ -22108,6 +22174,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628175,
       "structure_id": null,
       "support_skills": {
@@ -22322,6 +22389,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628178,
       "structure_id": null,
       "support_skills": {
@@ -22521,6 +22589,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628181,
       "structure_id": null,
       "support_skills": {
@@ -22716,6 +22785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628184,
       "structure_id": null,
       "support_skills": {
@@ -22917,6 +22987,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628204,
       "structure_id": null,
       "support_skills": {
@@ -23122,6 +23193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628206,
       "structure_id": null,
       "support_skills": {
@@ -23328,6 +23400,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23531,6 +23604,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23730,6 +23804,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628212,
       "structure_id": null,
       "support_skills": {
@@ -23925,6 +24000,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628215,
       "structure_id": null,
       "support_skills": {
@@ -24122,6 +24198,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628224,
       "structure_id": null,
       "support_skills": {
@@ -24327,6 +24404,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628226,
       "structure_id": null,
       "support_skills": {
@@ -24526,6 +24604,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -24723,6 +24802,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -24918,6 +24998,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628249,
       "structure_id": null,
       "support_skills": {
@@ -25123,6 +25204,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628251,
       "structure_id": null,
       "support_skills": {
@@ -25337,6 +25419,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628254,
       "structure_id": null,
       "support_skills": {
@@ -25536,6 +25619,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628257,
       "structure_id": null,
       "support_skills": {
@@ -25731,6 +25815,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628260,
       "structure_id": null,
       "support_skills": {
@@ -25894,6 +25979,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628270,
       "structure_id": null,
       "support_skills": {
@@ -26089,6 +26175,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628274,
       "structure_id": null,
       "support_skills": {
@@ -26290,6 +26377,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628275,
       "structure_id": null,
       "support_skills": {
@@ -26491,6 +26579,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628276,
       "structure_id": null,
       "support_skills": {
@@ -26697,6 +26786,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628278,
       "structure_id": null,
       "support_skills": {
@@ -26898,6 +26988,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628288,
       "structure_id": null,
       "support_skills": {
@@ -27093,6 +27184,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628312,
       "structure_id": null,
       "support_skills": {
@@ -27298,6 +27390,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628315,
       "structure_id": null,
       "support_skills": {
@@ -27512,6 +27605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628318,
       "structure_id": null,
       "support_skills": {
@@ -27711,6 +27805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628321,
       "structure_id": null,
       "support_skills": {
@@ -27906,6 +28001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628324,
       "structure_id": null,
       "support_skills": {
@@ -28107,6 +28203,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628342,
       "structure_id": null,
       "support_skills": {
@@ -28302,6 +28399,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628346,
       "structure_id": null,
       "support_skills": {
@@ -28507,6 +28605,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628348,
       "structure_id": null,
       "support_skills": {
@@ -28721,6 +28820,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628351,
       "structure_id": null,
       "support_skills": {
@@ -28920,6 +29020,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628354,
       "structure_id": null,
       "support_skills": {
@@ -29115,6 +29216,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628357,
       "structure_id": null,
       "support_skills": {
@@ -29316,6 +29418,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628393,
       "structure_id": null,
       "support_skills": {
@@ -29521,6 +29624,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628396,
       "structure_id": null,
       "support_skills": {
@@ -29735,6 +29839,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628399,
       "structure_id": null,
       "support_skills": {
@@ -29905,6 +30010,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30104,6 +30210,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30299,6 +30406,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628405,
       "structure_id": null,
       "support_skills": {
@@ -30463,6 +30571,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628406,
       "structure_id": null,
       "support_skills": {
@@ -30641,6 +30750,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628431,
       "structure_id": null,
       "support_skills": {
@@ -30836,6 +30946,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628459,
       "structure_id": null,
       "support_skills": {
@@ -30987,6 +31098,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628461,
       "structure_id": null,
       "support_skills": {
@@ -31186,6 +31298,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628471,
       "structure_id": null,
       "support_skills": {
@@ -31355,6 +31468,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628472,
       "structure_id": null,
       "support_skills": {
@@ -31558,6 +31672,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628473,
       "structure_id": null,
       "support_skills": {
@@ -31757,6 +31872,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628476,
       "structure_id": null,
       "support_skills": {
@@ -31952,6 +32068,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628479,
       "structure_id": null,
       "support_skills": {
@@ -32136,6 +32253,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32327,6 +32445,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32526,6 +32645,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628504,
       "structure_id": null,
       "support_skills": {
@@ -32740,6 +32860,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628507,
       "structure_id": null,
       "support_skills": {
@@ -32939,6 +33060,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628510,
       "structure_id": null,
       "support_skills": {
@@ -33134,6 +33256,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628513,
       "structure_id": null,
       "support_skills": {
@@ -33487,6 +33610,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628560,
       "structure_id": null,
       "support_skills": {
@@ -33697,6 +33821,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628532,
       "structure_id": null,
       "support_skills": {
@@ -33911,6 +34036,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628535,
       "structure_id": null,
       "support_skills": {
@@ -34085,6 +34211,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628536,
       "structure_id": null,
       "support_skills": {
@@ -34284,6 +34411,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628538,
       "structure_id": null,
       "support_skills": {
@@ -34479,6 +34607,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628541,
       "structure_id": null,
       "support_skills": {
@@ -34663,6 +34792,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628581,
       "structure_id": null,
       "support_skills": {
@@ -34862,6 +34992,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628590,
       "structure_id": null,
       "support_skills": {
@@ -35076,6 +35207,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628592,
       "structure_id": null,
       "support_skills": {
@@ -35275,6 +35407,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628595,
       "structure_id": null,
       "support_skills": {
@@ -35470,6 +35603,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628598,
       "structure_id": null,
       "support_skills": {
@@ -35675,6 +35809,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628639,
       "structure_id": null,
       "support_skills": {
@@ -35889,6 +36024,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628641,
       "structure_id": null,
       "support_skills": {
@@ -36042,6 +36178,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628642,
       "structure_id": null,
       "support_skills": {
@@ -36241,6 +36378,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628644,
       "structure_id": null,
       "support_skills": {
@@ -36436,6 +36574,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628647,
       "structure_id": null,
       "support_skills": {
@@ -36633,6 +36772,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628660,
       "structure_id": null,
       "support_skills": {
@@ -36828,6 +36968,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628693,
       "structure_id": null,
       "support_skills": {
@@ -37023,6 +37164,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628694,
       "structure_id": null,
       "support_skills": {
@@ -37228,6 +37370,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628697,
       "structure_id": null,
       "support_skills": {
@@ -37442,6 +37585,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628700,
       "structure_id": null,
       "support_skills": {
@@ -37641,6 +37785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628703,
       "structure_id": null,
       "support_skills": {
@@ -37836,6 +37981,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628706,
       "structure_id": null,
       "support_skills": {
@@ -38000,6 +38146,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628725,
       "structure_id": null,
       "support_skills": {
@@ -38195,6 +38342,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628751,
       "structure_id": null,
       "support_skills": {
@@ -38400,6 +38548,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628753,
       "structure_id": null,
       "support_skills": {
@@ -38599,6 +38748,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628754,
       "structure_id": null,
       "support_skills": {
@@ -38813,6 +38963,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628757,
       "structure_id": null,
       "support_skills": {
@@ -39008,6 +39159,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628759,
       "structure_id": null,
       "support_skills": {
@@ -39207,6 +39359,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628760,
       "structure_id": null,
       "support_skills": {
@@ -39402,6 +39555,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628763,
       "structure_id": null,
       "support_skills": {
@@ -39603,6 +39757,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628776,
       "structure_id": null,
       "support_skills": {
@@ -39808,6 +39963,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628779,
       "structure_id": null,
       "support_skills": {
@@ -40022,6 +40178,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628782,
       "structure_id": null,
       "support_skills": {
@@ -40217,6 +40374,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628785,
       "structure_id": null,
       "support_skills": {
@@ -40401,6 +40559,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628828,
       "structure_id": null,
       "support_skills": {
@@ -40596,6 +40755,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628829,
       "structure_id": null,
       "support_skills": {
@@ -40801,6 +40961,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628831,
       "structure_id": null,
       "support_skills": {
@@ -41003,6 +41164,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628832,
       "structure_id": null,
       "support_skills": {
@@ -41181,6 +41343,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -41384,6 +41547,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -41583,6 +41747,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628837,
       "structure_id": null,
       "support_skills": {
@@ -41744,6 +41909,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628838,
       "structure_id": null,
       "support_skills": {
@@ -41914,6 +42080,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42109,6 +42276,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42314,6 +42482,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628850,
       "structure_id": null,
       "support_skills": {
@@ -42515,6 +42684,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628855,
       "structure_id": null,
       "support_skills": {
@@ -42720,6 +42890,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628857,
       "structure_id": null,
       "support_skills": {
@@ -42934,6 +43105,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628860,
       "structure_id": null,
       "support_skills": {
@@ -43133,6 +43305,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628868,
       "structure_id": null,
       "support_skills": {
@@ -43450,6 +43623,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": true,
+      "server_season": "100",
       "start_tick": 628908,
       "structure_id": null,
       "support_skills": {
@@ -43660,6 +43834,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628878,
       "structure_id": null,
       "support_skills": {
@@ -43859,6 +44034,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628886,
       "structure_id": null,
       "support_skills": {
@@ -44060,6 +44236,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628897,
       "structure_id": null,
       "support_skills": {
@@ -44265,6 +44442,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628900,
       "structure_id": null,
       "support_skills": {
@@ -44479,6 +44657,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628903,
       "structure_id": null,
       "support_skills": {
@@ -44678,6 +44857,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628906,
       "structure_id": null,
       "support_skills": {
@@ -44873,6 +45053,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628909,
       "structure_id": null,
       "support_skills": {
@@ -45053,6 +45234,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628915,
       "structure_id": null,
       "support_skills": {
@@ -45254,6 +45436,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628922,
       "structure_id": null,
       "support_skills": {
@@ -45449,6 +45632,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628933,
       "structure_id": null,
       "support_skills": {
@@ -45654,6 +45838,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628935,
       "structure_id": null,
       "support_skills": {
@@ -45868,6 +46053,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628938,
       "structure_id": null,
       "support_skills": {
@@ -46067,6 +46253,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628941,
       "structure_id": null,
       "support_skills": {
@@ -46262,6 +46449,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628944,
       "structure_id": null,
       "support_skills": {
@@ -46425,6 +46613,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628969,
       "structure_id": null,
       "support_skills": {
@@ -46616,6 +46805,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628973,
       "structure_id": null,
       "support_skills": {
@@ -46811,6 +47001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628981,
       "structure_id": null,
       "support_skills": {
@@ -47016,6 +47207,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628983,
       "structure_id": null,
       "support_skills": {
@@ -47230,6 +47422,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628986,
       "structure_id": null,
       "support_skills": {
@@ -47429,6 +47622,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628989,
       "structure_id": null,
       "support_skills": {
@@ -47624,6 +47818,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628992,
       "structure_id": null,
       "support_skills": {
@@ -47825,6 +48020,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 628993,
       "structure_id": null,
       "support_skills": {
@@ -48016,6 +48212,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629009,
       "structure_id": null,
       "support_skills": {
@@ -48219,6 +48416,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629011,
       "structure_id": null,
       "support_skills": {
@@ -48422,6 +48620,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629035,
       "structure_id": null,
       "support_skills": {
@@ -48628,6 +48827,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629032,
       "structure_id": null,
       "support_skills": {
@@ -48833,6 +49033,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629033,
       "structure_id": null,
       "support_skills": {
@@ -49047,6 +49248,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629037,
       "structure_id": null,
       "support_skills": {
@@ -49246,6 +49448,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629040,
       "structure_id": null,
       "support_skills": {
@@ -49441,6 +49644,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629043,
       "structure_id": null,
       "support_skills": {
@@ -49642,6 +49846,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629053,
       "structure_id": null,
       "support_skills": {
@@ -49851,6 +50056,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629055,
       "structure_id": null,
       "support_skills": {
@@ -50046,6 +50252,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629068,
       "structure_id": null,
       "support_skills": {
@@ -50241,6 +50448,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629072,
       "structure_id": null,
       "support_skills": {
@@ -50442,6 +50650,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629085,
       "structure_id": null,
       "support_skills": {
@@ -50647,6 +50856,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629087,
       "structure_id": null,
       "support_skills": {
@@ -50861,6 +51071,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629090,
       "structure_id": null,
       "support_skills": {
@@ -51060,6 +51271,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629093,
       "structure_id": null,
       "support_skills": {
@@ -51255,6 +51467,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629096,
       "structure_id": null,
       "support_skills": {
@@ -51456,6 +51669,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629108,
       "structure_id": null,
       "support_skills": {
@@ -51661,6 +51875,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629110,
       "structure_id": null,
       "support_skills": {
@@ -51875,6 +52090,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629113,
       "structure_id": null,
       "support_skills": {
@@ -52070,6 +52286,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629116,
       "structure_id": null,
       "support_skills": {
@@ -52238,6 +52455,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -52429,6 +52647,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -52628,6 +52847,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -52825,6 +53045,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -52987,6 +53208,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -53157,6 +53379,7 @@
       "player_id": 42046369,
       "player_name": "Ral farm B",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629142,
       "structure_id": null,
       "support_skills": {
@@ -53348,6 +53571,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629149,
       "structure_id": null,
       "support_skills": {
@@ -53543,6 +53767,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629159,
       "structure_id": null,
       "support_skills": {
@@ -53748,6 +53973,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629162,
       "structure_id": null,
       "support_skills": {
@@ -53962,6 +54188,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629165,
       "structure_id": null,
       "support_skills": {
@@ -54161,6 +54388,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629168,
       "structure_id": null,
       "support_skills": {
@@ -54356,6 +54584,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629170,
       "structure_id": null,
       "support_skills": {
@@ -54767,6 +54996,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 629221,
       "structure_id": null,
       "support_skills": {
@@ -54969,6 +55199,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55160,6 +55391,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55359,6 +55591,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55554,6 +55787,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629188,
       "structure_id": null,
       "support_skills": {
@@ -55749,6 +55983,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629189,
       "structure_id": null,
       "support_skills": {
@@ -55933,6 +56168,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629190,
       "structure_id": null,
       "support_skills": {
@@ -56132,6 +56368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629192,
       "structure_id": null,
       "support_skills": {
@@ -56346,6 +56583,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629194,
       "structure_id": null,
       "support_skills": {
@@ -56545,6 +56783,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629198,
       "structure_id": null,
       "support_skills": {
@@ -56740,6 +56979,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629201,
       "structure_id": null,
       "support_skills": {
@@ -56945,6 +57185,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629211,
       "structure_id": null,
       "support_skills": {
@@ -57144,6 +57385,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629219,
       "structure_id": null,
       "support_skills": {
@@ -57347,6 +57589,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629236,
       "structure_id": null,
       "support_skills": {
@@ -57542,6 +57785,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629238,
       "structure_id": null,
       "support_skills": {
@@ -57743,6 +57987,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -57948,6 +58193,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629240,
       "structure_id": null,
       "support_skills": {
@@ -58162,6 +58408,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629243,
       "structure_id": null,
       "support_skills": {
@@ -58340,6 +58587,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -58545,6 +58793,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629246,
       "structure_id": null,
       "support_skills": {
@@ -58740,6 +58989,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629249,
       "structure_id": null,
       "support_skills": {
@@ -58941,6 +59191,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629267,
       "structure_id": null,
       "support_skills": {
@@ -59146,6 +59397,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629269,
       "structure_id": null,
       "support_skills": {
@@ -59360,6 +59612,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629272,
       "structure_id": null,
       "support_skills": {
@@ -59559,6 +59812,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629275,
       "structure_id": null,
       "support_skills": {
@@ -59754,6 +60008,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629278,
       "structure_id": null,
       "support_skills": {
@@ -59955,6 +60210,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629287,
       "structure_id": null,
       "support_skills": {
@@ -60150,6 +60406,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629295,
       "structure_id": null,
       "support_skills": {
@@ -60345,6 +60602,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629318,
       "structure_id": null,
       "support_skills": {
@@ -60550,6 +60808,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629321,
       "structure_id": null,
       "support_skills": {
@@ -60764,6 +61023,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629323,
       "structure_id": null,
       "support_skills": {
@@ -60963,6 +61223,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629327,
       "structure_id": null,
       "support_skills": {
@@ -61158,6 +61419,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629330,
       "structure_id": null,
       "support_skills": {
@@ -61342,6 +61604,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629335,
       "structure_id": null,
       "support_skills": {
@@ -61537,6 +61800,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629341,
       "structure_id": null,
       "support_skills": {
@@ -61742,6 +62006,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629343,
       "structure_id": null,
       "support_skills": {
@@ -61956,6 +62221,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -62147,6 +62413,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -62338,6 +62605,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629348,
       "structure_id": null,
       "support_skills": {
@@ -62537,6 +62805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629349,
       "structure_id": null,
       "support_skills": {
@@ -62732,6 +63001,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629352,
       "structure_id": null,
       "support_skills": {
@@ -62933,6 +63203,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629358,
       "structure_id": null,
       "support_skills": {
@@ -63103,6 +63374,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629390,
       "structure_id": null,
       "support_skills": {
@@ -63298,6 +63570,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629395,
       "structure_id": null,
       "support_skills": {
@@ -63503,6 +63776,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629398,
       "structure_id": null,
       "support_skills": {
@@ -63709,6 +63983,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -63912,6 +64187,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629401,
       "structure_id": null,
       "support_skills": {
@@ -64111,6 +64387,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -64313,6 +64590,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629402,
       "structure_id": null,
       "support_skills": {
@@ -64512,6 +64790,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629404,
       "structure_id": null,
       "support_skills": {
@@ -64707,6 +64986,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629407,
       "structure_id": null,
       "support_skills": {
@@ -64908,6 +65188,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629423,
       "structure_id": null,
       "support_skills": {
@@ -65113,6 +65394,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629425,
       "structure_id": null,
       "support_skills": {
@@ -65319,6 +65601,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629427,
       "structure_id": null,
       "support_skills": {
@@ -65522,6 +65805,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629428,
       "structure_id": null,
       "support_skills": {
@@ -65675,6 +65959,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629430,
       "structure_id": null,
       "support_skills": {
@@ -65874,6 +66159,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629431,
       "structure_id": null,
       "support_skills": {
@@ -66069,6 +66355,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629434,
       "structure_id": null,
       "support_skills": {
@@ -66245,6 +66532,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -66448,6 +66736,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -66621,6 +66910,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -66799,6 +67089,7 @@
       "player_id": 156121848,
       "player_name": "EidensDonkey",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -66998,6 +67289,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629463,
       "structure_id": null,
       "support_skills": {
@@ -67193,6 +67485,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629480,
       "structure_id": null,
       "support_skills": {
@@ -67398,6 +67691,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629482,
       "structure_id": null,
       "support_skills": {
@@ -67612,6 +67906,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629485,
       "structure_id": null,
       "support_skills": {
@@ -67811,6 +68106,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629488,
       "structure_id": null,
       "support_skills": {
@@ -68006,6 +68302,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629491,
       "structure_id": null,
       "support_skills": {
@@ -68157,6 +68454,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629498,
       "structure_id": null,
       "support_skills": {
@@ -68356,6 +68654,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -68555,6 +68854,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -68754,6 +69054,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629504,
       "structure_id": null,
       "support_skills": {
@@ -68915,6 +69216,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629510,
       "structure_id": null,
       "support_skills": {
@@ -69093,6 +69395,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629529,
       "structure_id": null,
       "support_skills": {
@@ -69288,6 +69591,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629533,
       "structure_id": null,
       "support_skills": {
@@ -69483,6 +69787,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629547,
       "structure_id": null,
       "support_skills": {
@@ -69688,6 +69993,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629549,
       "structure_id": null,
       "support_skills": {
@@ -71202,6 +71508,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 629595,
       "structure_id": null,
       "support_skills": {
@@ -71416,6 +71723,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629552,
       "structure_id": null,
       "support_skills": {
@@ -71615,6 +71923,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629555,
       "structure_id": null,
       "support_skills": {
@@ -71810,6 +72119,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629557,
       "structure_id": null,
       "support_skills": {
@@ -72011,6 +72321,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629571,
       "structure_id": null,
       "support_skills": {
@@ -72216,6 +72527,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629573,
       "structure_id": null,
       "support_skills": {
@@ -72405,6 +72717,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629583,
       "structure_id": null,
       "support_skills": {
@@ -72608,6 +72921,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629576,
       "structure_id": null,
       "support_skills": {
@@ -72807,6 +73121,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629579,
       "structure_id": null,
       "support_skills": {
@@ -73002,6 +73317,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629582,
       "structure_id": null,
       "support_skills": {
@@ -73203,6 +73519,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629605,
       "structure_id": null,
       "support_skills": {
@@ -73413,6 +73730,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629611,
       "structure_id": null,
       "support_skills": {
@@ -73587,6 +73905,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629617,
       "structure_id": null,
       "support_skills": {
@@ -73788,6 +74107,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629619,
       "structure_id": null,
       "support_skills": {
@@ -73994,6 +74314,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629622,
       "structure_id": null,
       "support_skills": {
@@ -74199,6 +74520,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629623,
       "structure_id": null,
       "support_skills": {
@@ -74398,6 +74720,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629624,
       "structure_id": null,
       "support_skills": {
@@ -74608,6 +74931,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -74817,6 +75141,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629627,
       "structure_id": null,
       "support_skills": {
@@ -75016,6 +75341,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -75221,6 +75547,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629630,
       "structure_id": null,
       "support_skills": {
@@ -75416,6 +75743,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629633,
       "structure_id": null,
       "support_skills": {
@@ -75621,6 +75949,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629634,
       "structure_id": null,
       "support_skills": {
@@ -75824,6 +76153,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629636,
       "structure_id": null,
       "support_skills": {
@@ -76023,6 +76353,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629642,
       "structure_id": null,
       "support_skills": {
@@ -76218,6 +76549,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629648,
       "structure_id": null,
       "support_skills": {
@@ -76419,6 +76751,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -76614,6 +76947,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629649,
       "structure_id": null,
       "support_skills": {
@@ -76819,6 +77153,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -77033,6 +77368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629654,
       "structure_id": null,
       "support_skills": {
@@ -77232,6 +77568,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629657,
       "structure_id": null,
       "support_skills": {
@@ -77423,6 +77760,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629658,
       "structure_id": null,
       "support_skills": {
@@ -77618,6 +77956,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629660,
       "structure_id": null,
       "support_skills": {
@@ -77802,6 +78141,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629667,
       "structure_id": null,
       "support_skills": {
@@ -77997,6 +78337,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -78203,6 +78544,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -78381,6 +78723,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78561,6 +78904,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78766,6 +79110,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -78961,6 +79306,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629692,
       "structure_id": null,
       "support_skills": {
@@ -79166,6 +79512,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629703,
       "structure_id": null,
       "support_skills": {
@@ -79365,6 +79712,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629707,
       "structure_id": null,
       "support_skills": {
@@ -79564,6 +79912,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629712,
       "structure_id": null,
       "support_skills": {
@@ -79759,6 +80108,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629713,
       "structure_id": null,
       "support_skills": {
@@ -79964,6 +80314,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629715,
       "structure_id": null,
       "support_skills": {
@@ -80178,6 +80529,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629718,
       "structure_id": null,
       "support_skills": {
@@ -80373,6 +80725,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629721,
       "structure_id": null,
       "support_skills": {
@@ -80574,6 +80927,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629729,
       "structure_id": null,
       "support_skills": {
@@ -80773,6 +81127,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -80976,6 +81331,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -81167,6 +81523,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629743,
       "structure_id": null,
       "support_skills": {
@@ -81366,6 +81723,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81557,6 +81915,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81731,6 +82090,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -81901,6 +82261,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629755,
       "structure_id": null,
       "support_skills": {
@@ -82092,6 +82453,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82291,6 +82653,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82486,6 +82849,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -82696,6 +83060,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629766,
       "structure_id": null,
       "support_skills": {
@@ -82909,6 +83274,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629770,
       "structure_id": null,
       "support_skills": {
@@ -83110,6 +83476,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629772,
       "structure_id": null,
       "support_skills": {
@@ -83305,6 +83672,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629778,
       "structure_id": null,
       "support_skills": {
@@ -83500,6 +83868,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629790,
       "structure_id": null,
       "support_skills": {
@@ -83710,6 +84079,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -83901,6 +84271,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -84102,6 +84473,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629799,
       "structure_id": null,
       "support_skills": {
@@ -84259,6 +84631,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629807,
       "structure_id": null,
       "support_skills": {
@@ -84433,6 +84806,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629811,
       "structure_id": null,
       "support_skills": {
@@ -84638,6 +85012,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -84795,6 +85170,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -84986,6 +85362,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -85185,6 +85562,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629825,
       "structure_id": null,
       "support_skills": {
@@ -85380,6 +85758,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -85579,6 +85958,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -85778,6 +86158,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629857,
       "structure_id": null,
       "support_skills": {
@@ -85973,6 +86354,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629875,
       "structure_id": null,
       "support_skills": {
@@ -86136,6 +86518,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629887,
       "structure_id": null,
       "support_skills": {
@@ -86335,6 +86718,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629889,
       "structure_id": null,
       "support_skills": {
@@ -86530,6 +86914,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -86743,6 +87128,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -86948,6 +87334,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629911,
       "structure_id": null,
       "support_skills": {
@@ -87143,6 +87530,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629913,
       "structure_id": null,
       "support_skills": {
@@ -87338,6 +87726,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -87526,6 +87915,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -87725,6 +88115,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -87930,6 +88321,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -88129,6 +88521,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88307,6 +88700,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88487,6 +88881,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -88688,6 +89083,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -88883,6 +89279,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -89082,6 +89479,7 @@
       "player_id": 16267563,
       "player_name": "EidenR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -89277,6 +89675,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -89434,6 +89833,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629977,
       "structure_id": null,
       "support_skills": {
@@ -89637,6 +90037,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -89817,6 +90218,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -89998,6 +90400,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -90193,6 +90596,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629987,
       "structure_id": null,
       "support_skills": {
@@ -90399,6 +90803,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 629995,
       "structure_id": null,
       "support_skills": {
@@ -90604,6 +91009,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -90807,6 +91213,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -91006,6 +91413,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -91201,6 +91609,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -91408,6 +91817,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -91614,6 +92024,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -91815,6 +92226,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -92014,6 +92426,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -92213,6 +92626,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -92423,6 +92837,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630031,
       "structure_id": null,
       "support_skills": {
@@ -92633,6 +93048,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630033,
       "structure_id": null,
       "support_skills": {
@@ -92836,6 +93252,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630034,
       "structure_id": null,
       "support_skills": {
@@ -93035,6 +93452,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630037,
       "structure_id": null,
       "support_skills": {
@@ -93230,6 +93648,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630040,
       "structure_id": null,
       "support_skills": {
@@ -93431,6 +93850,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630050,
       "structure_id": null,
       "support_skills": {
@@ -93632,6 +94052,7 @@
       "player_id": 128959879,
       "player_name": "SleepyシEmre",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630062,
       "structure_id": null,
       "support_skills": {
@@ -93833,6 +94254,7 @@
       "player_id": 66805488,
       "player_name": "Grymne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630080,
       "structure_id": null,
       "support_skills": {
@@ -94011,6 +94433,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630087,
       "structure_id": null,
       "support_skills": {
@@ -94185,6 +94608,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -94369,6 +94793,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -94553,6 +94978,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630103,
       "structure_id": null,
       "support_skills": {
@@ -94752,6 +95178,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630109,
       "structure_id": null,
       "support_skills": {
@@ -94947,6 +95374,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630115,
       "structure_id": null,
       "support_skills": {
@@ -95152,6 +95580,7 @@
       "player_id": 95218418,
       "player_name": "ᴸᴸ Handy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630123,
       "structure_id": null,
       "support_skills": {
@@ -95351,6 +95780,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630127,
       "structure_id": null,
       "support_skills": {
@@ -95523,6 +95953,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -95726,6 +96157,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -95925,6 +96357,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630132,
       "structure_id": null,
       "support_skills": {
@@ -96124,6 +96557,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630133,
       "structure_id": null,
       "support_skills": {
@@ -96319,6 +96753,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630135,
       "structure_id": null,
       "support_skills": {
@@ -96532,6 +96967,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630146,
       "structure_id": null,
       "support_skills": {
@@ -96742,6 +97178,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -96945,6 +97382,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -97140,6 +97578,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630166,
       "structure_id": null,
       "support_skills": {
@@ -97339,6 +97778,7 @@
       "player_id": 19998976,
       "player_name": "Forgo义Preyla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -97517,6 +97957,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -97716,6 +98157,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630189,
       "structure_id": null,
       "support_skills": {
@@ -97930,6 +98372,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630191,
       "structure_id": null,
       "support_skills": {
@@ -98129,6 +98572,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630194,
       "structure_id": null,
       "support_skills": {
@@ -98324,6 +98768,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630197,
       "structure_id": null,
       "support_skills": {
@@ -98529,6 +98974,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630207,
       "structure_id": null,
       "support_skills": {
@@ -98728,6 +99174,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630232,
       "structure_id": null,
       "support_skills": {
@@ -98927,6 +99374,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630238,
       "structure_id": null,
       "support_skills": {
@@ -99105,6 +99553,7 @@
       "player_id": 73744396,
       "player_name": "booty squad 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630249,
       "structure_id": null,
       "support_skills": {
@@ -99308,6 +99757,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -99507,6 +99957,7 @@
       "player_id": 55523312,
       "player_name": "Wongington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -99706,6 +100157,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630291,
       "structure_id": null,
       "support_skills": {
@@ -99916,6 +100368,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630304,
       "structure_id": null,
       "support_skills": {
@@ -100130,6 +100583,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630306,
       "structure_id": null,
       "support_skills": {
@@ -100329,6 +100783,7 @@
       "player_id": 27624147,
       "player_name": "ItsJustDave",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -100474,6 +100929,7 @@
       "player_id": 17472810,
       "player_name": "EidensMule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -100665,6 +101121,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -100868,6 +101325,7 @@
       "player_id": 110236148,
       "player_name": "ᴸᴸKapten",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -101063,6 +101521,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101233,6 +101692,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101418,6 +101878,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -101613,6 +102074,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630333,
       "structure_id": null,
       "support_skills": {
@@ -101814,6 +102276,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -101994,6 +102457,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -102176,6 +102640,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630357,
       "structure_id": null,
       "support_skills": {
@@ -102371,6 +102836,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630383,
       "structure_id": null,
       "support_skills": {
@@ -102572,6 +103038,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630404,
       "structure_id": null,
       "support_skills": {
@@ -102782,6 +103249,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630442,
       "structure_id": null,
       "support_skills": {
@@ -102992,6 +103460,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630448,
       "structure_id": null,
       "support_skills": {
@@ -103202,6 +103671,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630492,
       "structure_id": null,
       "support_skills": {
@@ -103393,6 +103863,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630501,
       "structure_id": null,
       "support_skills": {
@@ -104248,6 +104719,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": true,
+      "server_season": "100",
       "start_tick": 630607,
       "structure_id": null,
       "support_skills": {
@@ -104429,6 +104901,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630577,
       "structure_id": null,
       "support_skills": {
@@ -104624,6 +105097,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630591,
       "structure_id": null,
       "support_skills": {
@@ -104829,6 +105303,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630638,
       "structure_id": null,
       "support_skills": {
@@ -105032,6 +105507,7 @@
       "player_id": 67302352,
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630642,
       "structure_id": null,
       "support_skills": {
@@ -105223,6 +105699,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630654,
       "structure_id": null,
       "support_skills": {
@@ -105376,6 +105853,7 @@
       "player_id": 10335606,
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630660,
       "structure_id": null,
       "support_skills": {
@@ -105579,6 +106057,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630662,
       "structure_id": null,
       "support_skills": {
@@ -105771,6 +106250,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -105962,6 +106442,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -106161,6 +106642,7 @@
       "player_id": 7531115,
       "player_name": "ʳᵉˣHihu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -106331,6 +106813,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -106484,6 +106967,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630726,
       "structure_id": null,
       "support_skills": {
@@ -106687,6 +107171,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -106844,6 +107329,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -107020,6 +107506,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -107212,6 +107699,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630732,
       "structure_id": null,
       "support_skills": {
@@ -107419,6 +107907,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630767,
       "structure_id": null,
       "support_skills": {
@@ -107629,6 +108118,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630780,
       "structure_id": null,
       "support_skills": {
@@ -107824,6 +108314,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -107994,6 +108485,7 @@
       "player_id": 51418078,
       "player_name": "Ral Farm C",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -108193,6 +108685,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630807,
       "structure_id": null,
       "support_skills": {
@@ -108392,6 +108885,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630818,
       "structure_id": null,
       "support_skills": {
@@ -108597,6 +109091,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630844,
       "structure_id": null,
       "support_skills": {
@@ -108802,6 +109297,7 @@
       "player_id": 39133794,
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630850,
       "structure_id": null,
       "support_skills": {
@@ -109003,6 +109499,7 @@
       "player_id": 140188501,
       "player_name": "Paulo 災",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630854,
       "structure_id": null,
       "support_skills": {
@@ -109200,6 +109697,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630856,
       "structure_id": null,
       "support_skills": {
@@ -109376,6 +109874,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -109561,6 +110060,7 @@
       "player_id": 61063415,
       "player_name": "FakeFarm01",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -109760,6 +110260,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630919,
       "structure_id": null,
       "support_skills": {
@@ -109955,6 +110456,7 @@
       "player_id": 49083224,
       "player_name": "Sheir0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630924,
       "structure_id": null,
       "support_skills": {
@@ -110156,6 +110658,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -110355,6 +110858,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -110550,6 +111054,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630930,
       "structure_id": null,
       "support_skills": {
@@ -110755,6 +111260,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630938,
       "structure_id": null,
       "support_skills": {
@@ -110954,6 +111460,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630947,
       "structure_id": null,
       "support_skills": {
@@ -111128,6 +111635,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -111331,6 +111839,7 @@
       "player_id": 26479759,
       "player_name": "wzz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -111526,6 +112035,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -111729,6 +112239,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -111928,6 +112439,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -112133,6 +112645,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -112318,6 +112831,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631018,
       "structure_id": null,
       "support_skills": {
@@ -112513,6 +113027,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -112708,6 +113223,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -112886,6 +113402,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631033,
       "structure_id": null,
       "support_skills": {
@@ -113099,6 +113616,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -113300,6 +113818,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -113493,6 +114012,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631055,
       "structure_id": null,
       "support_skills": {
@@ -113688,6 +114208,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631085,
       "structure_id": null,
       "support_skills": {
@@ -113845,6 +114366,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631063,
       "structure_id": null,
       "support_skills": {
@@ -114044,6 +114566,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -114250,6 +114773,7 @@
       "player_id": 80818579,
       "player_name": "Zinaaje",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -114451,6 +114975,7 @@
       "player_id": 61339741,
       "player_name": "DaveSleepwalker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631069,
       "structure_id": null,
       "support_skills": {
@@ -114650,6 +115175,7 @@
       "player_id": 108043561,
       "player_name": "Dixierect",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631073,
       "structure_id": null,
       "support_skills": {
@@ -114855,6 +115381,7 @@
       "player_id": 58373248,
       "player_name": "ヤFakeRules 乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -115054,6 +115581,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631097,
       "structure_id": null,
       "support_skills": {
@@ -115249,6 +115777,7 @@
       "player_id": 28837172,
       "player_name": "Toxic㋡Bunny",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631117,
       "structure_id": null,
       "support_skills": {
@@ -115454,6 +115983,7 @@
       "player_id": 6914079,
       "player_name": "MrLimeton",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631123,
       "structure_id": null,
       "support_skills": {
@@ -115664,6 +116194,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631163,
       "structure_id": null,
       "support_skills": {
@@ -115825,6 +116356,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631170,
       "structure_id": null,
       "support_skills": {
@@ -116039,6 +116571,7 @@
       "player_id": 166860094,
       "player_name": "Aragorn VI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631182,
       "structure_id": null,
       "support_skills": {
@@ -116200,6 +116733,7 @@
       "player_id": 33042332,
       "player_name": "Ralbro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631195,
       "structure_id": null,
       "support_skills": {
@@ -116410,6 +116944,7 @@
       "player_id": 78603395,
       "player_name": "WarArrow",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631231,
       "structure_id": null,
       "support_skills": {
@@ -116563,6 +117098,7 @@
       "player_id": 76872532,
       "player_name": "booty squad 22",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631239,
       "structure_id": null,
       "support_skills": {
@@ -116733,6 +117269,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -116928,6 +117465,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -117127,6 +117665,7 @@
       "player_id": 65214078,
       "player_name": "Prime Kxan",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -117322,6 +117861,7 @@
       "player_id": 30552095,
       "player_name": "FuhrerBiscotte",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631259,
       "structure_id": null,
       "support_skills": {
@@ -117500,6 +118040,7 @@
       "player_id": 61110146,
       "player_name": "Roach Biz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631271,
       "structure_id": null,
       "support_skills": {
@@ -117674,6 +118215,7 @@
       "player_id": 87138012,
       "player_name": "booty squad c1",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631281,
       "structure_id": null,
       "support_skills": {
@@ -117873,6 +118415,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631288,
       "structure_id": null,
       "support_skills": {
@@ -118083,6 +118626,7 @@
       "player_id": 23872628,
       "player_name": "거지 Eiden",
       "rally": null,
+      "server_season": "100",
       "start_tick": 631292,
       "structure_id": null,
       "support_skills": {
@@ -127184,6 +127728,7 @@
     "player_id": 41377732,
     "player_name": "ˢJian x Laars",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1750343079717997,
     "report_id": 2851403,
+    "schema": 224,
     "server_id": 15660
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -12670,6 +12670,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595330,
       "structure_id": 38,
       "support_skills": {
@@ -12865,6 +12866,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13060,6 +13062,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13259,6 +13262,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13450,6 +13454,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13645,6 +13650,7 @@
       "player_id": 5093787,
       "player_name": "Sparkx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595343,
       "structure_id": null,
       "support_skills": {
@@ -13840,6 +13846,7 @@
       "player_id": 2728540,
       "player_name": "刀劍Kir",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -14031,6 +14038,7 @@
       "player_id": 18663801,
       "player_name": "Paw pаw",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595352,
       "structure_id": null,
       "support_skills": {
@@ -14230,6 +14238,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14425,6 +14434,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -14620,6 +14630,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14819,6 +14830,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595335,
       "structure_id": null,
       "support_skills": {
@@ -15014,6 +15026,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15209,6 +15222,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15408,6 +15422,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15607,6 +15622,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15802,6 +15818,7 @@
       "player_id": 121797186,
       "player_name": "7sKi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -15997,6 +16014,7 @@
       "player_id": 66126870,
       "player_name": "Kitty Gang",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595360,
       "structure_id": null,
       "support_skills": {
@@ -16192,6 +16210,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -16387,6 +16406,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595353,
       "structure_id": null,
       "support_skills": {
@@ -16578,6 +16598,7 @@
       "player_id": 15964597,
       "player_name": "мᴀXXuм",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595554,
       "structure_id": null,
       "support_skills": {
@@ -16773,6 +16794,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -16968,6 +16990,7 @@
       "player_id": 75908538,
       "player_name": "SuperLuffy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595394,
       "structure_id": null,
       "support_skills": {
@@ -17163,6 +17186,7 @@
       "player_id": 40812700,
       "player_name": "ZombiNuggies13",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595488,
       "structure_id": null,
       "support_skills": {
@@ -17358,6 +17382,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595764,
       "structure_id": null,
       "support_skills": {
@@ -17553,6 +17578,7 @@
       "player_id": 41802504,
       "player_name": "KateRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595350,
       "structure_id": null,
       "support_skills": {
@@ -17748,6 +17774,7 @@
       "player_id": 6108852,
       "player_name": "Rimuru 림",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595904,
       "structure_id": null,
       "support_skills": {
@@ -17943,6 +17970,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18142,6 +18170,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18341,6 +18370,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18536,6 +18566,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -18731,6 +18762,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18930,6 +18962,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -19129,6 +19162,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -19328,6 +19362,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -19523,6 +19558,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -19718,6 +19754,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -19917,6 +19954,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595384,
       "structure_id": null,
       "support_skills": {
@@ -20112,6 +20150,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595356,
       "structure_id": null,
       "support_skills": {
@@ -20307,6 +20346,7 @@
       "player_id": 3987185,
       "player_name": "ʚFujiɞ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -20506,6 +20546,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -20701,6 +20742,7 @@
       "player_id": 6722214,
       "player_name": "乄7 Itachi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -20896,6 +20938,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595725,
       "structure_id": null,
       "support_skills": {
@@ -21087,6 +21130,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -21282,6 +21326,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -21481,6 +21526,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -21680,6 +21726,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -21875,6 +21922,7 @@
       "player_id": 31669826,
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -22070,6 +22118,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595349,
       "structure_id": null,
       "support_skills": {
@@ -22265,6 +22314,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -22460,6 +22510,7 @@
       "player_id": 59250548,
       "player_name": "彡tktk彡",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595376,
       "structure_id": null,
       "support_skills": {
@@ -22659,6 +22710,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595776,
       "structure_id": null,
       "support_skills": {
@@ -22854,6 +22906,7 @@
       "player_id": 26795734,
       "player_name": "MGKing Legacy S",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -23049,6 +23102,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23244,6 +23298,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -23443,6 +23498,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23642,6 +23698,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595396,
       "structure_id": null,
       "support_skills": {
@@ -23837,6 +23894,7 @@
       "player_id": 21928143,
       "player_name": "Zoned Out",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596454,
       "structure_id": null,
       "support_skills": {
@@ -24032,6 +24090,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24227,6 +24286,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24422,6 +24482,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -24613,6 +24674,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24808,6 +24870,7 @@
       "player_id": 34851989,
       "player_name": "MALJAHAメWolfy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -25003,6 +25066,7 @@
       "player_id": 40812700,
       "player_name": "ZombiNuggies13",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595485,
       "structure_id": null,
       "support_skills": {
@@ -25202,6 +25266,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595505,
       "structure_id": null,
       "support_skills": {
@@ -25393,6 +25458,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -25592,6 +25658,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595503,
       "structure_id": null,
       "support_skills": {
@@ -25787,6 +25854,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -25978,6 +26046,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26173,6 +26242,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595834,
       "structure_id": null,
       "support_skills": {
@@ -26368,6 +26438,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595704,
       "structure_id": null,
       "support_skills": {
@@ -26563,6 +26634,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26758,6 +26830,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596468,
       "structure_id": null,
       "support_skills": {
@@ -26953,6 +27026,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595520,
       "structure_id": null,
       "support_skills": {
@@ -27148,6 +27222,7 @@
       "player_id": 37360378,
       "player_name": "TânメNguyễn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595897,
       "structure_id": null,
       "support_skills": {
@@ -27347,6 +27422,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595403,
       "structure_id": null,
       "support_skills": {
@@ -27542,6 +27618,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -27737,6 +27814,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -27936,6 +28014,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28135,6 +28214,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28326,6 +28406,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28525,6 +28606,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28716,6 +28798,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595426,
       "structure_id": null,
       "support_skills": {
@@ -29041,6 +29124,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595456,
       "structure_id": null,
       "support_skills": {
@@ -29240,6 +29324,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595657,
       "structure_id": null,
       "support_skills": {
@@ -29435,6 +29520,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595573,
       "structure_id": null,
       "support_skills": {
@@ -29630,6 +29716,7 @@
       "player_id": 31679831,
       "player_name": "BØBA",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595762,
       "structure_id": null,
       "support_skills": {
@@ -29829,6 +29916,7 @@
       "player_id": 70176209,
       "player_name": "SevenZeroOne",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595470,
       "structure_id": null,
       "support_skills": {
@@ -30140,6 +30228,7 @@
       "player_id": 41079688,
       "player_name": "Baronita",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595500,
       "structure_id": null,
       "support_skills": {
@@ -30301,6 +30390,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30496,6 +30586,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30670,6 +30761,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30848,6 +30940,7 @@
       "player_id": 43067150,
       "player_name": "MrNayef p7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -31043,6 +31136,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31238,6 +31332,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31437,6 +31532,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31636,6 +31732,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31831,6 +31928,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32026,6 +32124,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32225,6 +32324,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32416,6 +32516,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595636,
       "structure_id": null,
       "support_skills": {
@@ -32759,6 +32860,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595600,
       "structure_id": null,
       "support_skills": {
@@ -32958,6 +33060,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595778,
       "structure_id": null,
       "support_skills": {
@@ -33153,6 +33256,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33352,6 +33456,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33655,6 +33760,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595634,
       "structure_id": null,
       "support_skills": {
@@ -33846,6 +33952,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595632,
       "structure_id": null,
       "support_skills": {
@@ -34037,6 +34144,7 @@
       "player_id": 19854296,
       "player_name": "Goofyᴴᴳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596177,
       "structure_id": null,
       "support_skills": {
@@ -34232,6 +34340,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34431,6 +34540,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34626,6 +34736,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34825,6 +34936,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35016,6 +35128,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35215,6 +35328,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35410,6 +35524,7 @@
       "player_id": 3480868,
       "player_name": "PoonSquad",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -35609,6 +35724,7 @@
       "player_id": 3480868,
       "player_name": "PoonSquad",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -35808,6 +35924,7 @@
       "player_id": 71564219,
       "player_name": "Đouglas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -36003,6 +36120,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595831,
       "structure_id": null,
       "support_skills": {
@@ -36198,6 +36316,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595899,
       "structure_id": null,
       "support_skills": {
@@ -36368,6 +36487,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595975,
       "structure_id": null,
       "support_skills": {
@@ -36563,6 +36683,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -36758,6 +36879,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -36957,6 +37079,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37156,6 +37279,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37355,6 +37479,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37546,6 +37671,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -37745,6 +37871,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -37944,6 +38071,7 @@
       "player_id": 3497995,
       "player_name": "ᴱ ᴸ ᴼM1Lo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596153,
       "structure_id": null,
       "support_skills": {
@@ -38139,6 +38267,7 @@
       "player_id": 10367779,
       "player_name": "Jade StaR",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595837,
       "structure_id": null,
       "support_skills": {
@@ -38334,6 +38463,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595907,
       "structure_id": null,
       "support_skills": {
@@ -38533,6 +38663,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -38894,6 +39025,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595750,
       "structure_id": null,
       "support_skills": {
@@ -39085,6 +39217,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595998,
       "structure_id": null,
       "support_skills": {
@@ -39410,6 +39543,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595790,
       "structure_id": null,
       "support_skills": {
@@ -39605,6 +39739,7 @@
       "player_id": 133347325,
       "player_name": "22 Armani",
       "rally": null,
+      "server_season": "100",
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -39804,6 +39939,7 @@
       "player_id": 11794206,
       "player_name": "Hᴏɴᴄʜᴏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -40165,6 +40301,7 @@
       "player_id": 44183166,
       "player_name": "Bladezメkizzy",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595934,
       "structure_id": null,
       "support_skills": {
@@ -40360,6 +40497,7 @@
       "player_id": 62393946,
       "player_name": "FeilongX Yeager",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596163,
       "structure_id": null,
       "support_skills": {
@@ -40555,6 +40693,7 @@
       "player_id": 5093787,
       "player_name": "Sparkx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596150,
       "structure_id": null,
       "support_skills": {
@@ -40750,6 +40889,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -40949,6 +41089,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596055,
       "structure_id": null,
       "support_skills": {
@@ -41144,6 +41285,7 @@
       "player_id": 155192039,
       "player_name": "白蘭丶亮",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596048,
       "structure_id": null,
       "support_skills": {
@@ -41339,6 +41481,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -41538,6 +41681,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -41917,6 +42061,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 595954,
       "structure_id": null,
       "support_skills": {
@@ -42108,6 +42253,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -42303,6 +42449,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42502,6 +42649,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42697,6 +42845,7 @@
       "player_id": 29338219,
       "player_name": "Rayes 77 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596550,
       "structure_id": null,
       "support_skills": {
@@ -42892,6 +43041,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -43087,6 +43237,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -43282,6 +43433,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -43481,6 +43633,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596295,
       "structure_id": null,
       "support_skills": {
@@ -43680,6 +43833,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -43871,6 +44025,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44070,6 +44225,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44269,6 +44425,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44468,6 +44625,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -44659,6 +44817,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44854,6 +45013,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -45053,6 +45213,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596494,
       "structure_id": null,
       "support_skills": {
@@ -45248,6 +45409,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -45443,6 +45605,7 @@
       "player_id": 9766100,
       "player_name": "Tueiut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596085,
       "structure_id": null,
       "support_skills": {
@@ -45642,6 +45805,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -45837,6 +46001,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -46028,6 +46193,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46223,6 +46389,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46422,6 +46589,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -46621,6 +46789,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -46812,6 +46981,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47007,6 +47177,7 @@
       "player_id": 42981395,
       "player_name": "eter乂noob",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596103,
       "structure_id": null,
       "support_skills": {
@@ -47202,6 +47373,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47397,6 +47569,7 @@
       "player_id": 3430258,
       "player_name": "Snoo ᴿᴮ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -47592,6 +47765,7 @@
       "player_id": 5415107,
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47953,6 +48127,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596093,
       "structure_id": null,
       "support_skills": {
@@ -48148,6 +48323,7 @@
       "player_id": 10087457,
       "player_name": "WarDaddyBradSki",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -48509,6 +48685,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596128,
       "structure_id": null,
       "support_skills": {
@@ -48704,6 +48881,7 @@
       "player_id": 17563040,
       "player_name": "Pocahontas ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596309,
       "structure_id": null,
       "support_skills": {
@@ -48874,6 +49052,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596591,
       "structure_id": null,
       "support_skills": {
@@ -49073,6 +49252,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596592,
       "structure_id": null,
       "support_skills": {
@@ -49272,6 +49452,7 @@
       "player_id": 40916960,
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596593,
       "structure_id": null,
       "support_skills": {
@@ -49467,6 +49648,7 @@
       "player_id": 74546111,
       "player_name": "Nycko乂CactusJ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596301,
       "structure_id": null,
       "support_skills": {
@@ -49662,6 +49844,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -49857,6 +50040,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50056,6 +50240,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50247,6 +50432,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -50446,6 +50632,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50641,6 +50828,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -50832,6 +51020,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -51027,6 +51216,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596571,
       "structure_id": null,
       "support_skills": {
@@ -51222,6 +51412,7 @@
       "player_id": 12654270,
       "player_name": "AbuAntaaar 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -51417,6 +51608,7 @@
       "player_id": 77809884,
       "player_name": "Chofen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596461,
       "structure_id": null,
       "support_skills": {
@@ -51742,6 +51934,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -51937,6 +52130,7 @@
       "player_id": 1201146,
       "player_name": "Ember       s",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596324,
       "structure_id": null,
       "support_skills": {
@@ -52128,6 +52322,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596594,
       "structure_id": null,
       "support_skills": {
@@ -52323,6 +52518,7 @@
       "player_id": 28874635,
       "player_name": "Peak Gacs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596600,
       "structure_id": null,
       "support_skills": {
@@ -52656,6 +52852,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596290,
       "structure_id": null,
       "support_skills": {
@@ -52855,6 +53052,7 @@
       "player_id": 15964597,
       "player_name": "мᴀXXuм",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596667,
       "structure_id": null,
       "support_skills": {
@@ -53050,6 +53248,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -53245,6 +53444,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -53440,6 +53640,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -53635,6 +53836,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596439,
       "structure_id": null,
       "support_skills": {
@@ -53834,6 +54036,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54025,6 +54228,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54224,6 +54428,7 @@
       "player_id": 18103662,
       "player_name": "Calò 乂 dòll",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54423,6 +54628,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596443,
       "structure_id": null,
       "support_skills": {
@@ -54618,6 +54824,7 @@
       "player_id": 9031871,
       "player_name": "Hallゞ翰",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -54813,6 +55020,7 @@
       "player_id": 93140290,
       "player_name": "兵士Spida",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596674,
       "structure_id": null,
       "support_skills": {
@@ -55004,6 +55212,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596433,
       "structure_id": null,
       "support_skills": {
@@ -55195,6 +55404,7 @@
       "player_id": 9031871,
       "player_name": "Hallゞ翰",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596950,
       "structure_id": null,
       "support_skills": {
@@ -55390,6 +55600,7 @@
       "player_id": 37360378,
       "player_name": "TânメNguyễn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596517,
       "structure_id": null,
       "support_skills": {
@@ -55585,6 +55796,7 @@
       "player_id": 62312731,
       "player_name": "火 Truth 火",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -55780,6 +55992,7 @@
       "player_id": 20185357,
       "player_name": "Sleepy fr",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596666,
       "structure_id": null,
       "support_skills": {
@@ -56123,6 +56336,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596432,
       "structure_id": null,
       "support_skills": {
@@ -56318,6 +56532,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -56517,6 +56732,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -56716,6 +56932,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -56911,6 +57128,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57106,6 +57324,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596659,
       "structure_id": null,
       "support_skills": {
@@ -57305,6 +57524,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -57504,6 +57724,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57695,6 +57916,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57894,6 +58116,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596649,
       "structure_id": null,
       "support_skills": {
@@ -58093,6 +58316,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58292,6 +58516,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -58491,6 +58716,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58682,6 +58908,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -59025,6 +59252,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596470,
       "structure_id": null,
       "support_skills": {
@@ -59224,6 +59452,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596663,
       "structure_id": null,
       "support_skills": {
@@ -59415,6 +59644,7 @@
       "player_id": 56024386,
       "player_name": "LORD OF ALL Dk",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -59610,6 +59840,7 @@
       "player_id": 10988067,
       "player_name": "Barça",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -59801,6 +60032,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -59996,6 +60228,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60195,6 +60428,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -60394,6 +60628,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60593,6 +60828,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60788,6 +61024,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60987,6 +61224,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61178,6 +61416,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61373,6 +61612,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -61572,6 +61812,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -61771,6 +62012,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -61962,6 +62204,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -62157,6 +62400,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -62352,6 +62596,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596813,
       "structure_id": null,
       "support_skills": {
@@ -62551,6 +62796,7 @@
       "player_id": 6104319,
       "player_name": "Sinỳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596662,
       "structure_id": null,
       "support_skills": {
@@ -62746,6 +62992,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -62945,6 +63192,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -63140,6 +63388,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596791,
       "structure_id": null,
       "support_skills": {
@@ -63335,6 +63584,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -63534,6 +63784,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596793,
       "structure_id": null,
       "support_skills": {
@@ -63733,6 +63984,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -64076,6 +64328,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596596,
       "structure_id": null,
       "support_skills": {
@@ -64271,6 +64524,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64470,6 +64724,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64665,6 +64920,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -64860,6 +65116,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65055,6 +65312,7 @@
       "player_id": 37218623,
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65250,6 +65508,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -65449,6 +65708,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -65648,6 +65908,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596812,
       "structure_id": null,
       "support_skills": {
@@ -65843,6 +66104,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596965,
       "structure_id": null,
       "support_skills": {
@@ -66034,6 +66296,7 @@
       "player_id": 31492292,
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596966,
       "structure_id": null,
       "support_skills": {
@@ -66233,6 +66496,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -66738,6 +67002,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596640,
       "structure_id": null,
       "support_skills": {
@@ -66929,6 +67194,7 @@
       "player_id": 12902531,
       "player_name": "SupEr",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -67124,6 +67390,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -67323,6 +67590,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596988,
       "structure_id": null,
       "support_skills": {
@@ -67522,6 +67790,7 @@
       "player_id": 3015053,
       "player_name": "Chisgule",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -67717,6 +67986,7 @@
       "player_id": 16709775,
       "player_name": "メFACELESSメ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -67912,6 +68182,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -68111,6 +68382,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -68310,6 +68582,7 @@
       "player_id": 83531919,
       "player_name": "MÄD乄SaLva98",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -68501,6 +68774,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -68696,6 +68970,7 @@
       "player_id": 9802541,
       "player_name": "Fahad Sensei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597020,
       "structure_id": null,
       "support_skills": {
@@ -68891,6 +69166,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69090,6 +69366,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69289,6 +69566,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69488,6 +69766,7 @@
       "player_id": 8888366,
       "player_name": "SAO Pink",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -69683,6 +69962,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69878,6 +70158,7 @@
       "player_id": 25499449,
       "player_name": "Mr Yahya",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596957,
       "structure_id": null,
       "support_skills": {
@@ -70073,6 +70354,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -70264,6 +70546,7 @@
       "player_id": 8888366,
       "player_name": "SAO Pink",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597061,
       "structure_id": null,
       "support_skills": {
@@ -70459,6 +70742,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -70658,6 +70942,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -70857,6 +71142,7 @@
       "player_id": 25499449,
       "player_name": "Mr Yahya",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -71056,6 +71342,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -71247,6 +71534,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596752,
       "structure_id": null,
       "support_skills": {
@@ -71446,6 +71734,7 @@
       "player_id": 58526952,
       "player_name": "GhostRider99",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -71637,6 +71926,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -71836,6 +72126,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -72035,6 +72326,7 @@
       "player_id": 58882150,
       "player_name": "义 N E X T 义",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -72234,6 +72526,7 @@
       "player_id": 124677212,
       "player_name": "Pangea",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596976,
       "structure_id": null,
       "support_skills": {
@@ -72429,6 +72722,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -72624,6 +72918,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -72823,6 +73118,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -73018,6 +73314,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -73217,6 +73514,7 @@
       "player_id": 30216510,
       "player_name": "Fox 444",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -73412,6 +73710,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -73611,6 +73910,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -73802,6 +74102,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -73997,6 +74298,7 @@
       "player_id": 13315180,
       "player_name": "niicii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596987,
       "structure_id": null,
       "support_skills": {
@@ -74196,6 +74498,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -74391,6 +74694,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -74752,6 +75056,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596758,
       "structure_id": null,
       "support_skills": {
@@ -74947,6 +75252,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -75142,6 +75448,7 @@
       "player_id": 18850140,
       "player_name": "Ghøstboy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -75337,6 +75644,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -75532,6 +75840,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -75731,6 +76040,7 @@
       "player_id": 38659743,
       "player_name": "少東East",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596955,
       "structure_id": null,
       "support_skills": {
@@ -75926,6 +76236,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -76125,6 +76436,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -76324,6 +76636,7 @@
       "player_id": 12695972,
       "player_name": "Guardian019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -76519,6 +76832,7 @@
       "player_id": 52942505,
       "player_name": "ᶜʰᵉᶠ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596970,
       "structure_id": null,
       "support_skills": {
@@ -76714,6 +77028,7 @@
       "player_id": 4825135,
       "player_name": "1baller",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -76913,6 +77228,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596992,
       "structure_id": null,
       "support_skills": {
@@ -77108,6 +77424,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -77299,6 +77616,7 @@
       "player_id": 54138530,
       "player_name": "SpicySquid",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -77494,6 +77812,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -77689,6 +78008,7 @@
       "player_id": 4759359,
       "player_name": "父 TY ЯR 父",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -77888,6 +78208,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -78083,6 +78404,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78278,6 +78600,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -78477,6 +78800,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78676,6 +79000,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -78871,6 +79196,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -79066,6 +79392,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -79257,6 +79584,7 @@
       "player_id": 31679831,
       "player_name": "BØBA",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597006,
       "structure_id": null,
       "support_skills": {
@@ -79448,6 +79776,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79647,6 +79976,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79838,6 +80168,7 @@
       "player_id": 21313143,
       "player_name": "스닉간식 BȺE",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -80037,6 +80368,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -80232,6 +80564,7 @@
       "player_id": 63903435,
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -80427,6 +80760,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -80622,6 +80956,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -80817,6 +81152,7 @@
       "player_id": 18216035,
       "player_name": "Mayoh",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -81012,6 +81348,7 @@
       "player_id": 135030064,
       "player_name": "۞T۞ Infinite",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597010,
       "structure_id": null,
       "support_skills": {
@@ -81207,6 +81544,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -81406,6 +81744,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -81597,6 +81936,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -81796,6 +82136,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -81995,6 +82336,7 @@
       "player_id": 11326540,
       "player_name": "BaoBun248",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -82190,6 +82532,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597011,
       "structure_id": null,
       "support_skills": {
@@ -82389,6 +82732,7 @@
       "player_id": 14979652,
       "player_name": "MAD S3S3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -82584,6 +82928,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -82783,6 +83128,7 @@
       "player_id": 45351682,
       "player_name": "Tsuzilla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597032,
       "structure_id": null,
       "support_skills": {
@@ -82982,6 +83328,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -83181,6 +83528,7 @@
       "player_id": 11326540,
       "player_name": "BaoBun248",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -83376,6 +83724,7 @@
       "player_id": 5102061,
       "player_name": "乄Bin乄",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -83575,6 +83924,7 @@
       "player_id": 6135053,
       "player_name": "ʚïɞce ⁿʷ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -83766,6 +84116,7 @@
       "player_id": 13346444,
       "player_name": "忠GhostMiracle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -83965,6 +84316,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -84160,6 +84512,7 @@
       "player_id": 138022497,
       "player_name": "Skʏ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596986,
       "structure_id": null,
       "support_skills": {
@@ -84511,6 +84864,7 @@
       "player_id": 13537865,
       "player_name": "M  P",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596851,
       "structure_id": null,
       "support_skills": {
@@ -84706,6 +85060,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -84901,6 +85256,7 @@
       "player_id": 7362219,
       "player_name": "ironvox",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -85100,6 +85456,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85295,6 +85652,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85494,6 +85852,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85689,6 +86048,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85884,6 +86244,7 @@
       "player_id": 76160426,
       "player_name": "sNaXs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -86083,6 +86444,7 @@
       "player_id": 168302739,
       "player_name": "Colonel J",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86278,6 +86640,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -86473,6 +86836,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596968,
       "structure_id": null,
       "support_skills": {
@@ -86668,6 +87032,7 @@
       "player_id": 94184266,
       "player_name": "DarthBelugaツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -86863,6 +87228,7 @@
       "player_id": 147732473,
       "player_name": "ORIGINALxKILLER",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597012,
       "structure_id": null,
       "support_skills": {
@@ -87058,6 +87424,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -87257,6 +87624,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597029,
       "structure_id": null,
       "support_skills": {
@@ -87448,6 +87816,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -87639,6 +88008,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -87834,6 +88204,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -88033,6 +88404,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -88228,6 +88600,7 @@
       "player_id": 17563040,
       "player_name": "Pocahontas ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -88423,6 +88796,7 @@
       "player_id": 5440338,
       "player_name": "Goliathᴰᴴ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -88618,6 +88992,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -88813,6 +89188,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89004,6 +89380,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89203,6 +89580,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89398,6 +89776,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89593,6 +89972,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -89792,6 +90172,7 @@
       "player_id": 85248742,
       "player_name": "김릴리Lily",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89991,6 +90372,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -90186,6 +90568,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90381,6 +90764,7 @@
       "player_id": 8738170,
       "player_name": "xCosma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -90580,6 +90964,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90775,6 +91160,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90966,6 +91352,7 @@
       "player_id": 75596147,
       "player_name": "Tad Phrayncke",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -91161,6 +91548,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -91356,6 +91744,7 @@
       "player_id": 76602855,
       "player_name": "anothersin",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -91551,6 +91940,7 @@
       "player_id": 7155054,
       "player_name": "Lyonardo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -91750,6 +92140,7 @@
       "player_id": 7155054,
       "player_name": "Lyonardo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -91945,6 +92336,7 @@
       "player_id": 59461309,
       "player_name": "AJ ᴴᴳ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -92140,6 +92532,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -92339,6 +92732,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -92534,6 +92928,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -92733,6 +93128,7 @@
       "player_id": 11308151,
       "player_name": "Liberlitas",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597014,
       "structure_id": null,
       "support_skills": {
@@ -92928,6 +93324,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -93289,6 +93686,7 @@
       "player_id": 63511986,
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
+      "server_season": "100",
       "start_tick": 596949,
       "structure_id": null,
       "support_skills": {
@@ -93488,6 +93886,7 @@
       "player_id": 157904379,
       "player_name": "Arch3llen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -93687,6 +94086,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -93886,6 +94286,7 @@
       "player_id": 1618540,
       "player_name": "LuboBG",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -94081,6 +94482,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -94276,6 +94678,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -94471,6 +94874,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -94670,6 +95074,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -94865,6 +95270,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -95064,6 +95470,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -95263,6 +95670,7 @@
       "player_id": 26304903,
       "player_name": "JzB",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -95458,6 +95866,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -95653,6 +96062,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -95848,6 +96258,7 @@
       "player_id": 1299501,
       "player_name": "vanjie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -96047,6 +96458,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -96242,6 +96654,7 @@
       "player_id": 62776758,
       "player_name": "JAV Marlboro",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -96437,6 +96850,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -96632,6 +97046,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597058,
       "structure_id": null,
       "support_skills": {
@@ -96827,6 +97242,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597016,
       "structure_id": null,
       "support_skills": {
@@ -97022,6 +97438,7 @@
       "player_id": 56221107,
       "player_name": "skol",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -97217,6 +97634,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -97416,6 +97834,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -97607,6 +98026,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -97806,6 +98226,7 @@
       "player_id": 9077173,
       "player_name": "MAD Mocote5",
       "rally": null,
+      "server_season": "100",
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -98365,6 +98786,7 @@
       "player_id": 19075788,
       "player_name": "Røñín",
       "rally": true,
+      "server_season": "100",
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -110375,6 +110797,7 @@
     "player_id": 32220019,
     "player_name": "Acanada",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -12843,6 +12844,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13039,6 +13041,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13239,6 +13242,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13431,6 +13435,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -13627,6 +13632,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -13823,6 +13829,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -14015,6 +14022,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -14215,6 +14223,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -14411,6 +14420,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -14607,6 +14617,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -14807,6 +14818,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15003,6 +15015,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15199,6 +15212,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15399,6 +15413,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15599,6 +15614,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15795,6 +15811,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -15991,6 +16008,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -16187,6 +16205,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -16383,6 +16402,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -16575,6 +16595,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -16771,6 +16792,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -16967,6 +16989,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -17163,6 +17186,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -17359,6 +17383,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -17555,6 +17580,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -17751,6 +17777,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -17947,6 +17974,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -18147,6 +18175,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -18347,6 +18376,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -18543,6 +18573,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -18739,6 +18770,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -18939,6 +18971,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -19139,6 +19172,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -19339,6 +19373,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -19535,6 +19570,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -19731,6 +19767,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -19931,6 +19968,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -20127,6 +20165,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -20323,6 +20362,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -20523,6 +20563,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -20719,6 +20760,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -20915,6 +20957,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -21107,6 +21150,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -21303,6 +21347,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -21503,6 +21548,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -21703,6 +21749,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -21899,6 +21946,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -22095,6 +22143,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -22291,6 +22340,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -22487,6 +22537,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -22687,6 +22738,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -22883,6 +22935,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -23079,6 +23132,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -23275,6 +23329,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -23475,6 +23530,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -23675,6 +23731,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -23871,6 +23928,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -24067,6 +24125,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24263,6 +24322,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24459,6 +24519,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24651,6 +24712,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -24847,6 +24909,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.kr",
       "participants": [
         {
           "alliance": {
@@ -25043,6 +25106,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -25243,6 +25307,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -25435,6 +25500,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -25635,6 +25701,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -25831,6 +25898,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -26023,6 +26091,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -26219,6 +26288,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -26415,6 +26485,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -26611,6 +26682,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -26807,6 +26879,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -27003,6 +27076,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -27199,6 +27273,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -27399,6 +27474,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -27595,6 +27671,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -27791,6 +27868,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -27991,6 +28069,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -28191,6 +28270,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -28383,6 +28463,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -28583,6 +28664,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -28775,6 +28857,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -28975,6 +29058,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -29301,6 +29385,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -29497,6 +29582,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -29693,6 +29779,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -29893,6 +29980,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -30097,6 +30185,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -30367,6 +30456,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30563,6 +30653,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30738,6 +30829,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -30917,6 +31009,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -31113,6 +31206,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -31309,6 +31403,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -31509,6 +31604,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -31709,6 +31805,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -31905,6 +32002,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -32101,6 +32199,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -32301,6 +32400,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -32493,6 +32593,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -32693,6 +32794,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -33037,6 +33139,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -33233,6 +33336,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -33433,6 +33537,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -33629,6 +33734,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -33929,6 +34035,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -34121,6 +34228,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -34317,6 +34425,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -34517,6 +34626,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -34713,6 +34823,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -34913,6 +35024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -35105,6 +35217,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -35305,6 +35418,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -35501,6 +35615,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -35701,6 +35816,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -35901,6 +36017,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36097,6 +36214,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36293,6 +36411,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36464,6 +36583,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36660,6 +36780,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -36856,6 +36977,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -37056,6 +37178,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -37256,6 +37379,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -37456,6 +37580,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -37648,6 +37773,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -37848,6 +37974,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38048,6 +38175,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -38244,6 +38372,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -38440,6 +38569,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38640,6 +38770,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -38840,6 +38971,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -39194,6 +39326,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -39394,6 +39527,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -39716,6 +39850,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -39916,6 +40051,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -40116,6 +40252,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -40474,6 +40611,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -40670,6 +40808,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -40866,6 +41005,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -41066,6 +41206,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -41262,6 +41403,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -41458,6 +41600,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -41658,6 +41801,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -41858,6 +42002,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -42230,6 +42375,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -42426,6 +42572,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -42626,6 +42773,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -42822,6 +42970,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -43018,6 +43167,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43214,6 +43364,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43410,6 +43561,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43610,6 +43762,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -43810,6 +43963,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44002,6 +44156,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44202,6 +44357,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44402,6 +44558,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44602,6 +44759,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44794,6 +44952,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -44990,6 +45149,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -45190,6 +45350,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -45386,6 +45547,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -45582,6 +45744,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -45782,6 +45945,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -45978,6 +46142,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -46170,6 +46335,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -46366,6 +46532,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -46566,6 +46733,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -46766,6 +46934,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -46958,6 +47127,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -47154,6 +47324,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -47350,6 +47521,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -47546,6 +47718,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -47742,6 +47915,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -47942,6 +48116,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -48300,6 +48475,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -48500,6 +48676,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -48858,6 +49035,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -49029,6 +49207,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49229,6 +49408,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49429,6 +49609,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -49625,6 +49806,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -49821,6 +50003,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50017,6 +50200,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50217,6 +50401,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50409,6 +50594,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50609,6 +50795,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50805,6 +50992,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -50997,6 +51185,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -51193,6 +51382,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -51389,6 +51579,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -51585,6 +51776,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -51785,6 +51977,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -52107,6 +52300,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -52299,6 +52493,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -52495,6 +52690,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -52703,6 +52899,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53029,6 +53226,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53225,6 +53423,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53421,6 +53620,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53617,6 +53817,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -53813,6 +54014,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54013,6 +54215,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54205,6 +54408,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54405,6 +54609,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54605,6 +54810,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54801,6 +55007,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -54997,6 +55204,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -55189,6 +55397,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -55381,6 +55590,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -55577,6 +55787,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -55773,6 +55984,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -55969,6 +56181,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -56169,6 +56382,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -56509,6 +56723,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -56709,6 +56924,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -56909,6 +57125,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -57105,6 +57322,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57301,6 +57519,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57501,6 +57720,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -57701,6 +57921,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -57893,6 +58114,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58093,6 +58315,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -58293,6 +58516,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58493,6 +58717,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -58693,6 +58918,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -58885,6 +59111,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -59085,6 +59312,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -59429,6 +59657,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -59621,6 +59850,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -59817,6 +60047,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -60009,6 +60240,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -60205,6 +60437,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -60405,6 +60638,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -60605,6 +60839,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -60805,6 +61040,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -61001,6 +61237,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -61201,6 +61438,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -61393,6 +61631,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -61589,6 +61828,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -61789,6 +62029,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -61989,6 +62230,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -62181,6 +62423,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -62377,6 +62620,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -62573,6 +62817,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -62773,6 +63018,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -62969,6 +63215,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -63169,6 +63416,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -63365,6 +63613,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63561,6 +63810,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63761,6 +64011,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -63961,6 +64212,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -64161,6 +64413,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -64501,6 +64754,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -64701,6 +64955,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -64897,6 +65152,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -65093,6 +65349,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -65289,6 +65546,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -65485,6 +65743,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -65685,6 +65944,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -65885,6 +66145,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -66081,6 +66342,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -66273,6 +66535,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -66473,6 +66736,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -66673,6 +66937,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -67171,6 +67436,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -67367,6 +67633,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67567,6 +67834,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67767,6 +68035,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -67963,6 +68232,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -68159,6 +68429,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -68359,6 +68630,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -68559,6 +68831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -68751,6 +69024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -68947,6 +69221,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -69143,6 +69418,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -69343,6 +69619,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -69543,6 +69820,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -69743,6 +70021,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -69939,6 +70218,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -70135,6 +70415,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -70331,6 +70612,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -70523,6 +70805,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -70719,6 +71002,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -70919,6 +71203,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -71119,6 +71404,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -71319,6 +71605,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -71511,6 +71798,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -71711,6 +71999,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -71903,6 +72192,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72103,6 +72393,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72303,6 +72594,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -72503,6 +72795,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -72699,6 +72992,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -72895,6 +73189,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73095,6 +73390,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -73291,6 +73587,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73491,6 +73788,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73687,6 +73985,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -73887,6 +74186,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74079,6 +74379,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74275,6 +74576,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -74475,6 +74777,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74671,6 +74974,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -74871,6 +75175,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -75229,6 +75534,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -75425,6 +75731,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -75621,6 +75928,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -75817,6 +76125,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -76017,6 +76326,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios.tw",
       "participants": [
         {
           "alliance": {
@@ -76213,6 +76523,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -76413,6 +76724,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -76613,6 +76925,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -76809,6 +77122,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -77005,6 +77319,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -77205,6 +77520,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -77401,6 +77717,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -77593,6 +77910,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -77789,6 +78107,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -77985,6 +78304,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -78185,6 +78505,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -78381,6 +78702,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -78577,6 +78899,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -78777,6 +79100,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -78977,6 +79301,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -79173,6 +79498,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -79369,6 +79695,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -79561,6 +79888,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -79753,6 +80081,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -79953,6 +80282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80145,6 +80475,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -80345,6 +80676,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -80541,6 +80873,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -80737,6 +81070,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -80933,6 +81267,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -81129,6 +81464,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -81325,6 +81661,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -81521,6 +81858,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -81721,6 +82059,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -81913,6 +82252,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -82113,6 +82453,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -82313,6 +82654,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -82509,6 +82851,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -82709,6 +83052,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -82905,6 +83249,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -83105,6 +83450,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -83305,6 +83651,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -83505,6 +83852,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -83701,6 +84049,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -83901,6 +84250,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -84093,6 +84443,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.vn",
       "participants": [
         {
           "alliance": {
@@ -84293,6 +84644,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -84489,6 +84841,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -84697,6 +85050,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85037,6 +85391,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85233,6 +85588,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85433,6 +85789,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85629,6 +85986,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -85829,6 +86187,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -86025,6 +86384,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -86221,6 +86581,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -86421,6 +86782,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -86617,6 +86979,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -86813,6 +87176,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87009,6 +87373,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -87205,6 +87570,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -87401,6 +87767,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87601,6 +87968,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87793,6 +88161,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -87985,6 +88354,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -88181,6 +88551,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -88381,6 +88752,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -88577,6 +88949,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -88773,6 +89146,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -88969,6 +89343,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -89165,6 +89540,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -89357,6 +89733,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -89557,6 +89934,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -89753,6 +90131,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -89949,6 +90328,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -90149,6 +90529,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.ioskr",
       "participants": [
         {
           "alliance": {
@@ -90349,6 +90730,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -90545,6 +90927,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -90741,6 +91124,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -90941,6 +91325,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91137,6 +91522,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91329,6 +91715,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91525,6 +91912,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -91721,6 +92109,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -91917,6 +92306,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92117,6 +92507,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92313,6 +92704,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92509,6 +92901,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92709,6 +93102,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -92905,6 +93299,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -93105,6 +93500,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -93301,6 +93697,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -93501,6 +93898,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -93863,6 +94261,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94063,6 +94462,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94263,6 +94663,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94459,6 +94860,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94655,6 +95057,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -94851,6 +95254,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -95051,6 +95455,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -95247,6 +95652,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -95447,6 +95853,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -95647,6 +96054,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -95843,6 +96251,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -96039,6 +96448,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -96235,6 +96645,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -96435,6 +96846,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -96631,6 +97043,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -96827,6 +97240,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -97023,6 +97437,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -97219,6 +97634,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -97415,6 +97831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -97611,6 +98028,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -97811,6 +98229,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98003,6 +98422,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98203,6 +98623,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.ios",
       "participants": [
         {
           "alliance": {
@@ -98403,6 +98824,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -98912,6 +99334,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_225.png",
     "kingdom_id": 1489,
+    "package_identifier": "com.lilithgames.rok.pc.kr",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1769532755190023,
     "report_id": 31530372,
+    "schema": 814,
     "server_id": 15803
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "2225911117695327552",
     "mail_receiver": "player_32523681",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755780474538040,
     "report_id": 5465549,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "28700881175578047431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 798757,
       "structure_id": null,
       "support_skills": {
@@ -296,6 +297,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -115,6 +115,7 @@
         "loot": null,
         "type": 107
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -256,6 +257,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_104.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 224,
     "mail_id": "29048795175579066131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -115,6 +115,7 @@
         "loot": null,
         "type": 37
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -260,6 +261,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_104.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1755790661543179,
     "report_id": 5466610,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 809011,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "Griggasaurus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "30346123155694137715",
     "mail_receiver": "player_14022209",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1556941377294066,
     "report_id": 11255691,
+    "schema": null,
     "server_id": 166
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -159,6 +159,7 @@
       "player_id": 13451284,
       "player_name": "hasan pilay",
       "rally": null,
+      "server_season": null,
       "start_tick": 421258,
       "structure_id": null,
       "support_skills": {
@@ -270,6 +271,7 @@
     "player_id": 14022209,
     "player_name": "Resir",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -136,6 +136,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -248,6 +249,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_6.png",
     "kingdom_id": null,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -115,6 +115,7 @@
         "loot": null,
         "type": 110
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -256,6 +257,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_217.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgame.roc.gp",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "31709368176977161019",
     "mail_receiver": "player_47043938",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 875164,
       "structure_id": null,
       "support_skills": {
@@ -296,6 +297,7 @@
     "player_id": 47043938,
     "player_name": "QuackerOats",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1769771610619469,
     "report_id": 6297322,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -329,6 +330,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -495,6 +497,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922765,
       "structure_id": null,
       "support_skills": {
@@ -661,6 +664,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 922800,
       "structure_id": null,
       "support_skills": {
@@ -807,6 +811,7 @@
     "player_id": 83629727,
     "player_name": "Atomicbunny",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -140,6 +140,7 @@
         ],
         "type": 150013
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -307,6 +308,7 @@
         ],
         "type": 150013
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -474,6 +476,7 @@
         ],
         "type": 150011
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -641,6 +644,7 @@
         ],
         "type": 150012
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -788,6 +792,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_221.png",
     "kingdom_id": 1217,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 810,
     "mail_id": "32282022178380122828",
     "mail_receiver": "player_83629727",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1783801228150556,
     "report_id": 6372230,
+    "schema": 810,
     "server_id": 16030
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -154,6 +154,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 906332,
       "structure_id": null,
       "support_skills": {
@@ -295,6 +296,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 906321,
       "structure_id": null,
       "support_skills": {
@@ -453,6 +455,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "33830971176980291131",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -131,6 +131,7 @@
         ],
         "type": 34
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -273,6 +274,7 @@
         "loot": null,
         "type": 110
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -414,6 +416,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_189.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1769802911843205,
     "report_id": 6301574,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": null,
     "mail_id": "41633096157514072311",
     "mail_receiver": "player_23984527",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -148,6 +148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -989,6 +990,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1143,6 +1145,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1318,6 +1321,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1472,6 +1476,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1643,6 +1648,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1814,6 +1820,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1985,6 +1992,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2156,6 +2164,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2327,6 +2336,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2502,6 +2512,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2673,6 +2684,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2852,6 +2864,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3023,6 +3036,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3202,6 +3216,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3356,6 +3371,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3531,6 +3547,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3702,6 +3719,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3873,6 +3891,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4048,6 +4067,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4168,6 +4188,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_20.png",
     "kingdom_id": null,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -837,6 +837,7 @@
       "player_id": 23872628,
       "player_name": "Eiden2018",
       "rally": null,
+      "server_season": null,
       "start_tick": 474937,
       "structure_id": null,
       "support_skills": {
@@ -1011,6 +1012,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475002,
       "structure_id": null,
       "support_skills": {
@@ -1164,6 +1166,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475013,
       "structure_id": null,
       "support_skills": {
@@ -1338,6 +1341,7 @@
       "player_id": 23259836,
       "player_name": "Nhi   Hí",
       "rally": null,
+      "server_season": null,
       "start_tick": 475104,
       "structure_id": null,
       "support_skills": {
@@ -1491,6 +1495,7 @@
       "player_id": 25899634,
       "player_name": "Simon시몬",
       "rally": null,
+      "server_season": null,
       "start_tick": 475111,
       "structure_id": null,
       "support_skills": {
@@ -1661,6 +1666,7 @@
       "player_id": 23855047,
       "player_name": "Navion69",
       "rally": null,
+      "server_season": null,
       "start_tick": 475200,
       "structure_id": null,
       "support_skills": {
@@ -1831,6 +1837,7 @@
       "player_id": 24237253,
       "player_name": "Gunz88",
       "rally": null,
+      "server_season": null,
       "start_tick": 475232,
       "structure_id": null,
       "support_skills": {
@@ -2001,6 +2008,7 @@
       "player_id": 23432594,
       "player_name": "cruack",
       "rally": null,
+      "server_season": null,
       "start_tick": 475371,
       "structure_id": null,
       "support_skills": {
@@ -2171,6 +2179,7 @@
       "player_id": 23919208,
       "player_name": "EOB 喵腳",
       "rally": null,
+      "server_season": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2341,6 +2350,7 @@
       "player_id": 23432594,
       "player_name": "cruack",
       "rally": null,
+      "server_season": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2515,6 +2525,7 @@
       "player_id": 23855822,
       "player_name": "Wanger94",
       "rally": null,
+      "server_season": null,
       "start_tick": 475440,
       "structure_id": null,
       "support_skills": {
@@ -2685,6 +2696,7 @@
       "player_id": 23881213,
       "player_name": "Sanya007",
       "rally": null,
+      "server_season": null,
       "start_tick": 475461,
       "structure_id": null,
       "support_skills": {
@@ -2863,6 +2875,7 @@
       "player_id": 23866612,
       "player_name": "VirusLoveLy",
       "rally": null,
+      "server_season": null,
       "start_tick": 475547,
       "structure_id": null,
       "support_skills": {
@@ -3033,6 +3046,7 @@
       "player_id": 23881213,
       "player_name": "Sanya007",
       "rally": null,
+      "server_season": null,
       "start_tick": 475568,
       "structure_id": null,
       "support_skills": {
@@ -3211,6 +3225,7 @@
       "player_id": 23866612,
       "player_name": "VirusLoveLy",
       "rally": null,
+      "server_season": null,
       "start_tick": 475603,
       "structure_id": null,
       "support_skills": {
@@ -3364,6 +3379,7 @@
       "player_id": 23639163,
       "player_name": "Phocidea",
       "rally": null,
+      "server_season": null,
       "start_tick": 475640,
       "structure_id": null,
       "support_skills": {
@@ -3538,6 +3554,7 @@
       "player_id": 23872628,
       "player_name": "Eiden2018",
       "rally": null,
+      "server_season": null,
       "start_tick": 475666,
       "structure_id": null,
       "support_skills": {
@@ -3708,6 +3725,7 @@
       "player_id": 23516745,
       "player_name": "dabrus",
       "rally": null,
+      "server_season": null,
       "start_tick": 475678,
       "structure_id": null,
       "support_skills": {
@@ -3878,6 +3896,7 @@
       "player_id": 23974117,
       "player_name": "Sorcerer Tim",
       "rally": null,
+      "server_season": null,
       "start_tick": 475682,
       "structure_id": null,
       "support_skills": {
@@ -4052,6 +4071,7 @@
       "player_id": 23881159,
       "player_name": "MemphusX",
       "rally": null,
+      "server_season": null,
       "start_tick": 475825,
       "structure_id": null,
       "support_skills": {
@@ -4693,6 +4713,7 @@
     "player_id": 15068434,
     "player_name": "Ø Heimdall Ø",
     "rally": true,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1575140723042084,
     "report_id": 13076019,
+    "schema": null,
     "server_id": 11533
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 819,
     "mail_id": "47051167177023603224",
     "mail_receiver": "player_12210123",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1770236032894339,
     "report_id": 8526263,
+    "schema": 819,
     "server_id": 2249
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -196,6 +196,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -391,6 +392,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -586,6 +588,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339450,
       "structure_id": null,
       "support_skills": {
@@ -781,6 +784,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -976,6 +980,7 @@
       "player_id": 145503693,
       "player_name": "Corsaire",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -1171,6 +1176,7 @@
       "player_id": 167694437,
       "player_name": "ᴴᴮMoretti",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339448,
       "structure_id": null,
       "support_skills": {
@@ -1370,6 +1376,7 @@
       "player_id": 167694437,
       "player_name": "ᴴᴮMoretti",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1339449,
       "structure_id": null,
       "support_skills": {
@@ -1477,6 +1484,7 @@
     "player_id": 12210123,
     "player_name": "Smallest Madas",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -369,6 +370,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -565,6 +567,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -761,6 +764,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -957,6 +961,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -1153,6 +1158,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -1353,6 +1359,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -1461,6 +1468,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_140.png",
     "kingdom_id": 2249,
+    "package_identifier": "com.lilithgame.roc.ios",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 13857,
       "structure_id": null,
       "support_skills": {
@@ -311,6 +312,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -140,6 +140,7 @@
         ],
         "type": 405
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -289,6 +290,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_69.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "485440176891031331",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1768910313632272,
     "report_id": 18930744,
+    "schema": 320,
     "server_id": 15790
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -110,6 +110,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [],
       "player_id": 0,
       "player_name": "",
@@ -211,6 +212,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_ProfileBg220x220_a.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 320,
     "mail_id": "53118177176782122317",
     "mail_receiver": "player_37556801",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -114,6 +114,7 @@
       "player_id": 0,
       "player_name": "",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1314485,
       "structure_id": null,
       "support_skills": {
@@ -233,6 +234,7 @@
     "player_id": 37556801,
     "player_name": "Benbu",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1767821223319047,
     "report_id": 14644855,
+    "schema": 320,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -115,6 +115,7 @@
         "loot": null,
         "type": 200
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -287,6 +288,7 @@
         ],
         "type": 403
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -424,6 +426,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_26.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgame.roc.ios",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 375269,
       "structure_id": null,
       "support_skills": {
@@ -309,6 +310,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 375279,
       "structure_id": null,
       "support_skills": {
@@ -643,6 +645,7 @@
     "player_id": 151739835,
     "player_name": "Pro100WRyj ツ",
     "rally": true,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1773577634548774,
     "report_id": 2156764,
+    "schema": 814,
     "server_id": 15908
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 814,
     "mail_id": "54530308177357763431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgame.roc.gp",
       "participants": [
         {
           "alliance": {
@@ -260,6 +261,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_27.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1756585277535072,
     "report_id": 5624208,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -196,6 +196,7 @@
       "player_id": 29862805,
       "player_name": "Titanobenbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 1603621,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 109813467,
     "player_name": "Faystonychus",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "58600202175658527723",
     "mail_receiver": "player_109813467",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -171,6 +171,7 @@
       "player_id": 39115363,
       "player_name": "Old s",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536214,
       "structure_id": null,
       "support_skills": {
@@ -349,6 +350,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536215,
       "structure_id": null,
       "support_skills": {
@@ -523,6 +525,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -697,6 +700,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -871,6 +875,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1049,6 +1054,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536211,
       "structure_id": null,
       "support_skills": {
@@ -1223,6 +1229,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536205,
       "structure_id": null,
       "support_skills": {
@@ -1401,6 +1408,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536206,
       "structure_id": null,
       "support_skills": {
@@ -1579,6 +1587,7 @@
       "player_id": 64596713,
       "player_name": "VIP맹인",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1757,6 +1766,7 @@
       "player_id": 34979098,
       "player_name": "Fear of God",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -1931,6 +1941,7 @@
       "player_id": 39771228,
       "player_name": "Саrnagе",
       "rally": null,
+      "server_season": null,
       "start_tick": 1536213,
       "structure_id": null,
       "support_skills": {
@@ -2104,6 +2115,7 @@
     "player_id": 7607766,
     "player_name": "wb74",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1668132482738933,
     "report_id": 17943445,
+    "schema": null,
     "server_id": 960
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "60719727166813248216",
     "mail_receiver": "player_12607995",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -148,6 +148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -327,6 +328,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -502,6 +504,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -677,6 +680,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -852,6 +856,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1031,6 +1036,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1206,6 +1212,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1385,6 +1392,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1564,6 +1572,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1743,6 +1752,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1918,6 +1928,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2038,6 +2049,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 561,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "67826590176494996531",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1764949965563136,
     "report_id": 465694,
+    "schema": 320,
     "server_id": 15790
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -119,6 +119,7 @@
         "loot": null,
         "type": 405
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -264,6 +265,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_189.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -142,6 +142,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 101149,
       "structure_id": null,
       "support_skills": {
@@ -286,6 +287,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -171,6 +171,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -352,6 +353,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470642,
       "structure_id": null,
       "support_skills": {
@@ -533,6 +535,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470649,
       "structure_id": null,
       "support_skills": {
@@ -718,6 +721,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -892,6 +896,7 @@
       "player_id": 2987686,
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
+      "server_season": null,
       "start_tick": 1470634,
       "structure_id": null,
       "support_skills": {
@@ -1022,6 +1027,7 @@
     "player_id": 4361125,
     "player_name": "精武丶羅剎",
     "rally": null,
+    "server_season": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": null,
     "mail_id": "69428020161978725321",
     "mail_receiver": "player_4361125",
     "mail_role": "gs",

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gs",
     "mail_time": 1619787253187050,
     "report_id": 20490591,
+    "schema": null,
     "server_id": 15373
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -148,6 +148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -330,6 +331,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -512,6 +514,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -698,6 +701,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -873,6 +877,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1004,6 +1009,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_5.png",
     "kingdom_id": null,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": false,
+    "ll_script_schema": 919,
     "mail_id": "7948875176322794831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1763227948281037,
     "report_id": 5992572,
+    "schema": 10,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -138,6 +138,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 208770,
       "structure_id": null,
       "support_skills": {
@@ -224,6 +225,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -115,6 +115,7 @@
         "loot": null,
         "type": 33
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -202,6 +203,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_189.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1765373960307792,
     "report_id": 2512259,
+    "schema": 320,
     "server_id": 15790
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "80922048176537396031",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -119,6 +119,7 @@
         "loot": null,
         "type": 401
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -260,6 +261,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -142,6 +142,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 525144,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "G Var",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 205396,
       "structure_id": null,
       "support_skills": {
@@ -282,6 +283,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar x Dimi",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -140,6 +140,7 @@
         ],
         "type": 402
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -260,6 +261,7 @@
     },
     "frame_url": null,
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407016178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1783084314155749,
     "report_id": 853449,
+    "schema": 234,
     "server_id": 16012
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1783084314902039,
     "report_id": 853408,
+    "schema": 234,
     "server_id": 16012
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -163,6 +163,7 @@
       "player_id": -2,
       "player_name": "",
       "rally": null,
+      "server_season": "",
       "start_tick": 205395,
       "structure_id": null,
       "support_skills": {
@@ -294,6 +295,7 @@
     "player_id": 71738515,
     "player_name": "Grigvar x Dimi",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -140,6 +140,7 @@
         ],
         "type": 402
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -272,6 +273,7 @@
     },
     "frame_url": null,
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 234,
     "mail_id": "8407037178308431431",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -196,6 +196,7 @@
       "player_id": 126319007,
       "player_name": "ˢˣ火TDouche",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378833,
       "structure_id": null,
       "support_skills": {
@@ -395,6 +396,7 @@
       "player_id": 31532594,
       "player_name": "АLex",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -594,6 +596,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -793,6 +796,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -988,6 +992,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378832,
       "structure_id": null,
       "support_skills": {
@@ -1187,6 +1192,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377880,
       "structure_id": null,
       "support_skills": {
@@ -1365,6 +1371,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377995,
       "structure_id": null,
       "support_skills": {
@@ -1564,6 +1571,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378182,
       "structure_id": null,
       "support_skills": {
@@ -1763,6 +1771,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -1954,6 +1963,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -2145,6 +2155,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -2344,6 +2355,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -2522,6 +2534,7 @@
       "player_id": 4678951,
       "player_name": "Ğrumpy Čhris",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -2721,6 +2734,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -2920,6 +2934,7 @@
       "player_id": 29428027,
       "player_name": "MercilessNoob",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -3119,6 +3134,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378675,
       "structure_id": null,
       "support_skills": {
@@ -3318,6 +3334,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378347,
       "structure_id": null,
       "support_skills": {
@@ -3509,6 +3526,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3708,6 +3726,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3903,6 +3922,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -4102,6 +4122,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -4301,6 +4322,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -4500,6 +4522,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -4699,6 +4722,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -4890,6 +4914,7 @@
       "player_id": 84984958,
       "player_name": "Mystique",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -5089,6 +5114,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -5280,6 +5306,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5479,6 +5506,7 @@
       "player_id": 6078409,
       "player_name": "anfis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5678,6 +5706,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -5877,6 +5906,7 @@
       "player_id": 34488395,
       "player_name": "Zwiebelritter79",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -6076,6 +6106,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -6271,6 +6302,7 @@
       "player_id": 123803055,
       "player_name": "B4ngB4ng",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379179,
       "structure_id": null,
       "support_skills": {
@@ -6470,6 +6502,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6669,6 +6702,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6868,6 +6902,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -7067,6 +7102,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -7266,6 +7302,7 @@
       "player_id": 20118027,
       "player_name": "x Twitty x",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378646,
       "structure_id": null,
       "support_skills": {
@@ -7461,6 +7498,7 @@
       "player_id": 125470745,
       "player_name": "武士道Hercs",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378000,
       "structure_id": null,
       "support_skills": {
@@ -7660,6 +7698,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -7859,6 +7898,7 @@
       "player_id": 128123718,
       "player_name": "ˢAuthentiks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -8054,6 +8094,7 @@
       "player_id": 128123718,
       "player_name": "ˢAuthentiks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377761,
       "structure_id": null,
       "support_skills": {
@@ -8245,6 +8286,7 @@
       "player_id": 111776448,
       "player_name": "Thorin lonestar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378636,
       "structure_id": null,
       "support_skills": {
@@ -8444,6 +8486,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -8643,6 +8686,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -8817,6 +8861,7 @@
       "player_id": 111776448,
       "player_name": "Thorin lonestar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -9012,6 +9057,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -9207,6 +9253,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -9406,6 +9453,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -9601,6 +9649,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -9800,6 +9849,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -9995,6 +10045,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -10194,6 +10245,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377400,
       "structure_id": null,
       "support_skills": {
@@ -10393,6 +10445,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377828,
       "structure_id": null,
       "support_skills": {
@@ -10592,6 +10645,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -10791,6 +10845,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377357,
       "structure_id": null,
       "support_skills": {
@@ -10990,6 +11045,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -11189,6 +11245,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377530,
       "structure_id": null,
       "support_skills": {
@@ -11388,6 +11445,7 @@
       "player_id": 126613785,
       "player_name": "霊ˢ Kleines",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -11587,6 +11645,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -11786,6 +11845,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -11985,6 +12045,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -12184,6 +12245,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -12383,6 +12445,7 @@
       "player_id": 90173172,
       "player_name": "BABA YAGA 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377517,
       "structure_id": null,
       "support_skills": {
@@ -12582,6 +12645,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377346,
       "structure_id": null,
       "support_skills": {
@@ -12781,6 +12845,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -12980,6 +13045,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -13179,6 +13245,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -13374,6 +13441,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -13573,6 +13641,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -13772,6 +13841,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -13971,6 +14041,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -14149,6 +14220,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -14348,6 +14420,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -14543,6 +14616,7 @@
       "player_id": 18916855,
       "player_name": "ツ Governor ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -14742,6 +14816,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377522,
       "structure_id": null,
       "support_skills": {
@@ -14941,6 +15016,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -15140,6 +15216,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -15339,6 +15416,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -15538,6 +15616,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -15729,6 +15808,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -15920,6 +16000,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378318,
       "structure_id": null,
       "support_skills": {
@@ -16119,6 +16200,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -16310,6 +16392,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -16505,6 +16588,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -31370,6 +31454,7 @@
       "player_id": 4678951,
       "player_name": "Ğrumpy Čhris",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377305,
       "structure_id": null,
       "support_skills": {
@@ -32073,6 +32158,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377313,
       "structure_id": null,
       "support_skills": {
@@ -32272,6 +32358,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -32471,6 +32558,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -32670,6 +32758,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -32869,6 +32958,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377584,
       "structure_id": null,
       "support_skills": {
@@ -33064,6 +33154,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -33263,6 +33354,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -33458,6 +33550,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -33653,6 +33746,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -33852,6 +33946,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378533,
       "structure_id": null,
       "support_skills": {
@@ -34043,6 +34138,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378155,
       "structure_id": null,
       "support_skills": {
@@ -34242,6 +34338,7 @@
       "player_id": 20155879,
       "player_name": "뚜뚜 DduDdu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378037,
       "structure_id": null,
       "support_skills": {
@@ -34424,6 +34521,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377453,
       "structure_id": null,
       "support_skills": {
@@ -34627,6 +34725,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377467,
       "structure_id": null,
       "support_skills": {
@@ -34788,6 +34887,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377473,
       "structure_id": null,
       "support_skills": {
@@ -34987,6 +35087,7 @@
       "player_id": 50471265,
       "player_name": "四Ocho 四",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377715,
       "structure_id": null,
       "support_skills": {
@@ -35186,6 +35287,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -35381,6 +35483,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -35580,6 +35683,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -35771,6 +35875,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377551,
       "structure_id": null,
       "support_skills": {
@@ -35970,6 +36075,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -36169,6 +36275,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36368,6 +36475,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36567,6 +36675,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377590,
       "structure_id": null,
       "support_skills": {
@@ -36762,6 +36871,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -36953,6 +37063,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -37148,6 +37259,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377648,
       "structure_id": null,
       "support_skills": {
@@ -37347,6 +37459,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -37538,6 +37651,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -37733,6 +37847,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378012,
       "structure_id": null,
       "support_skills": {
@@ -37936,6 +38051,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377662,
       "structure_id": null,
       "support_skills": {
@@ -38135,6 +38251,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -38326,6 +38443,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -38525,6 +38643,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -38716,6 +38835,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -38890,6 +39010,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -39081,6 +39202,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -39280,6 +39402,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -39479,6 +39602,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -39678,6 +39802,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -39856,6 +39981,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377685,
       "structure_id": null,
       "support_skills": {
@@ -40051,6 +40177,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40246,6 +40373,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40445,6 +40573,7 @@
       "player_id": 129152631,
       "player_name": "Klimson3",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377935,
       "structure_id": null,
       "support_skills": {
@@ -40640,6 +40769,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377940,
       "structure_id": null,
       "support_skills": {
@@ -40839,6 +40969,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -41042,6 +41173,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377737,
       "structure_id": null,
       "support_skills": {
@@ -41220,6 +41352,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377743,
       "structure_id": null,
       "support_skills": {
@@ -41419,6 +41552,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378013,
       "structure_id": null,
       "support_skills": {
@@ -41614,6 +41748,7 @@
       "player_id": 35720589,
       "player_name": "Fiese Hornisse",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378019,
       "structure_id": null,
       "support_skills": {
@@ -41809,6 +41944,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -42004,6 +42140,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377980,
       "structure_id": null,
       "support_skills": {
@@ -42203,6 +42340,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -42402,6 +42540,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -42601,6 +42740,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -42800,6 +42940,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -42999,6 +43140,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379630,
       "structure_id": null,
       "support_skills": {
@@ -43774,6 +43916,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2377835,
       "structure_id": null,
       "support_skills": {
@@ -43973,6 +44116,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377817,
       "structure_id": null,
       "support_skills": {
@@ -44172,6 +44316,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378522,
       "structure_id": null,
       "support_skills": {
@@ -44363,6 +44508,7 @@
       "player_id": 84984958,
       "player_name": "Mystique",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377858,
       "structure_id": null,
       "support_skills": {
@@ -44562,6 +44708,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377865,
       "structure_id": null,
       "support_skills": {
@@ -44761,6 +44908,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -44960,6 +45108,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -45159,6 +45308,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -45350,6 +45500,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378140,
       "structure_id": null,
       "support_skills": {
@@ -45549,6 +45700,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -45744,6 +45896,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -45943,6 +46096,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2377894,
       "structure_id": null,
       "support_skills": {
@@ -46134,6 +46288,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -46333,6 +46488,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -46528,6 +46684,7 @@
       "player_id": 124513829,
       "player_name": "メDmitry82メ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -46727,6 +46884,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -46926,6 +47084,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378152,
       "structure_id": null,
       "support_skills": {
@@ -47121,6 +47280,7 @@
       "player_id": 94732875,
       "player_name": "Ada ㋛",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378024,
       "structure_id": null,
       "support_skills": {
@@ -47320,6 +47480,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -47515,6 +47676,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -47714,6 +47876,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -47909,6 +48072,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -48108,6 +48272,7 @@
       "player_id": 123880685,
       "player_name": "運命ˢToxic",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378873,
       "structure_id": null,
       "support_skills": {
@@ -48290,6 +48455,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378051,
       "structure_id": null,
       "support_skills": {
@@ -48485,6 +48651,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378057,
       "structure_id": null,
       "support_skills": {
@@ -48684,6 +48851,7 @@
       "player_id": 941710,
       "player_name": "SAH4RCOREJZ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -48879,6 +49047,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -49070,6 +49239,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378438,
       "structure_id": null,
       "support_skills": {
@@ -49269,6 +49439,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -49468,6 +49639,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -49646,6 +49818,7 @@
       "player_id": 53674767,
       "player_name": "Krawler12000",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -49845,6 +50018,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50023,6 +50197,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378092,
       "structure_id": null,
       "support_skills": {
@@ -50222,6 +50397,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50417,6 +50593,7 @@
       "player_id": 91774997,
       "player_name": "Sir Skyrr Duck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378107,
       "structure_id": null,
       "support_skills": {
@@ -50616,6 +50793,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50815,6 +50993,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -51014,6 +51193,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51209,6 +51389,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51408,6 +51589,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -51607,6 +51789,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -51806,6 +51989,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52005,6 +52189,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52200,6 +52385,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52378,6 +52564,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378133,
       "structure_id": null,
       "support_skills": {
@@ -52573,6 +52760,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52768,6 +52956,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378428,
       "structure_id": null,
       "support_skills": {
@@ -52967,6 +53156,7 @@
       "player_id": 84168837,
       "player_name": "Paul Atreidês",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378432,
       "structure_id": null,
       "support_skills": {
@@ -53166,6 +53356,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -53361,6 +53552,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378168,
       "structure_id": null,
       "support_skills": {
@@ -53560,6 +53752,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -53759,6 +53952,7 @@
       "player_id": 18916855,
       "player_name": "ツ Governor ツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378180,
       "structure_id": null,
       "support_skills": {
@@ -53954,6 +54148,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -54153,6 +54348,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -54331,6 +54527,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378194,
       "structure_id": null,
       "support_skills": {
@@ -54522,6 +54719,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378200,
       "structure_id": null,
       "support_skills": {
@@ -54717,6 +54915,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -54916,6 +55115,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -55115,6 +55315,7 @@
       "player_id": 11987186,
       "player_name": "I Dare",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -55314,6 +55515,7 @@
       "player_id": 89959030,
       "player_name": "xxRONxx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -55513,6 +55715,7 @@
       "player_id": 27931335,
       "player_name": "Sylvia 00",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -55712,6 +55915,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378453,
       "structure_id": null,
       "support_skills": {
@@ -55907,6 +56111,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378247,
       "structure_id": null,
       "support_skills": {
@@ -56106,6 +56311,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -56305,6 +56511,7 @@
       "player_id": 123803055,
       "player_name": "B4ngB4ng",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -56500,6 +56707,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378269,
       "structure_id": null,
       "support_skills": {
@@ -56691,6 +56899,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -56890,6 +57099,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378278,
       "structure_id": null,
       "support_skills": {
@@ -57089,6 +57299,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -57288,6 +57499,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -57479,6 +57691,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378479,
       "structure_id": null,
       "support_skills": {
@@ -57674,6 +57887,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -57873,6 +58087,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -58072,6 +58287,7 @@
       "player_id": 27102046,
       "player_name": "Captmimi",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -58246,6 +58462,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -58445,6 +58662,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -58644,6 +58862,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -58843,6 +59062,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -59017,6 +59237,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378336,
       "structure_id": null,
       "support_skills": {
@@ -59918,6 +60139,7 @@
       "player_id": 7462352,
       "player_name": "駆逐艦ˢBrHe",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2378374,
       "structure_id": null,
       "support_skills": {
@@ -60117,6 +60339,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -60295,6 +60518,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378359,
       "structure_id": null,
       "support_skills": {
@@ -60494,6 +60718,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -60689,6 +60914,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378385,
       "structure_id": null,
       "support_skills": {
@@ -60888,6 +61114,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378391,
       "structure_id": null,
       "support_skills": {
@@ -61083,6 +61310,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -61274,6 +61502,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -61473,6 +61702,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378466,
       "structure_id": null,
       "support_skills": {
@@ -61671,6 +61901,7 @@
       "player_id": 1019269,
       "player_name": "Aachen 7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -61866,6 +62097,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -62061,6 +62293,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -62260,6 +62493,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378415,
       "structure_id": null,
       "support_skills": {
@@ -62451,6 +62685,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -62646,6 +62881,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -62845,6 +63081,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63044,6 +63281,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63239,6 +63477,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -63438,6 +63677,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378459,
       "structure_id": null,
       "support_skills": {
@@ -63637,6 +63877,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -63828,6 +64069,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379859,
       "structure_id": null,
       "support_skills": {
@@ -64023,6 +64265,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -64222,6 +64465,7 @@
       "player_id": 4713658,
       "player_name": "Zuckachu ヅ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -64421,6 +64665,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378645,
       "structure_id": null,
       "support_skills": {
@@ -64620,6 +64865,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -64815,6 +65061,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378499,
       "structure_id": null,
       "support_skills": {
@@ -65014,6 +65261,7 @@
       "player_id": 21178360,
       "player_name": "FreeRun",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378662,
       "structure_id": null,
       "support_skills": {
@@ -65213,6 +65461,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378531,
       "structure_id": null,
       "support_skills": {
@@ -65412,6 +65661,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -65611,6 +65861,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378738,
       "structure_id": null,
       "support_skills": {
@@ -65806,6 +66057,7 @@
       "player_id": 100987803,
       "player_name": "poisоn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -66005,6 +66257,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -66204,6 +66457,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378580,
       "structure_id": null,
       "support_skills": {
@@ -66403,6 +66657,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378998,
       "structure_id": null,
       "support_skills": {
@@ -66594,6 +66849,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -66793,6 +67049,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -66984,6 +67241,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -67183,6 +67441,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378587,
       "structure_id": null,
       "support_skills": {
@@ -67382,6 +67641,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378663,
       "structure_id": null,
       "support_skills": {
@@ -67581,6 +67841,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -67780,6 +68041,7 @@
       "player_id": 9618231,
       "player_name": "Fürst Wilhelm",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378790,
       "structure_id": null,
       "support_skills": {
@@ -67979,6 +68241,7 @@
       "player_id": 79718328,
       "player_name": "Vabrök",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379005,
       "structure_id": null,
       "support_skills": {
@@ -68178,6 +68441,7 @@
       "player_id": 1422587,
       "player_name": "RandyyRandom",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378593,
       "structure_id": null,
       "support_skills": {
@@ -68373,6 +68637,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -68572,6 +68837,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -68767,6 +69033,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -68962,6 +69229,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378812,
       "structure_id": null,
       "support_skills": {
@@ -69161,6 +69429,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378817,
       "structure_id": null,
       "support_skills": {
@@ -69360,6 +69629,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -69559,6 +69829,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -69758,6 +70029,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -69949,6 +70221,7 @@
       "player_id": 60880084,
       "player_name": "Bobby Wobbler",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378823,
       "structure_id": null,
       "support_skills": {
@@ -70148,6 +70421,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -70347,6 +70621,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -70546,6 +70821,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -70745,6 +71021,7 @@
       "player_id": 38676937,
       "player_name": "VodkaTitten 亗",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -70948,6 +71225,7 @@
       "player_id": 125013933,
       "player_name": "sucior420",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379050,
       "structure_id": null,
       "support_skills": {
@@ -71147,6 +71425,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378896,
       "structure_id": null,
       "support_skills": {
@@ -71346,6 +71625,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -71545,6 +71825,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -71744,6 +72025,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -71943,6 +72225,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -72117,6 +72400,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378709,
       "structure_id": null,
       "support_skills": {
@@ -72312,6 +72596,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -72511,6 +72796,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -72710,6 +72996,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378818,
       "structure_id": null,
       "support_skills": {
@@ -72909,6 +73196,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -73104,6 +73392,7 @@
       "player_id": 91774997,
       "player_name": "Sir Skyrr Duck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73303,6 +73592,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73477,6 +73767,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -73672,6 +73963,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -73867,6 +74159,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378822,
       "structure_id": null,
       "support_skills": {
@@ -74066,6 +74359,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -74261,6 +74555,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378748,
       "structure_id": null,
       "support_skills": {
@@ -74460,6 +74755,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378962,
       "structure_id": null,
       "support_skills": {
@@ -74655,6 +74951,7 @@
       "player_id": 89972565,
       "player_name": "Swiphz",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378756,
       "structure_id": null,
       "support_skills": {
@@ -74854,6 +75151,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379463,
       "structure_id": null,
       "support_skills": {
@@ -75049,6 +75347,7 @@
       "player_id": 959750,
       "player_name": "Moor Fuerst",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378762,
       "structure_id": null,
       "support_skills": {
@@ -75248,6 +75547,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -75447,6 +75747,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -75642,6 +75943,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -75833,6 +76135,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -76032,6 +76335,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379318,
       "structure_id": null,
       "support_skills": {
@@ -76231,6 +76535,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -76430,6 +76735,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -76608,6 +76914,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378797,
       "structure_id": null,
       "support_skills": {
@@ -76786,6 +77093,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -77543,6 +77851,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -77732,6 +78041,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -77927,6 +78237,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -78118,6 +78429,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379698,
       "structure_id": null,
       "support_skills": {
@@ -78317,6 +78629,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -78470,6 +78783,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -78652,6 +78966,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -78843,6 +79158,7 @@
       "player_id": 149256003,
       "player_name": "Sir Bambam",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -79042,6 +79358,7 @@
       "player_id": 952310,
       "player_name": "MaGittis",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -79237,6 +79554,7 @@
       "player_id": 11974910,
       "player_name": "Caesar2019",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378869,
       "structure_id": null,
       "support_skills": {
@@ -79436,6 +79754,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378875,
       "structure_id": null,
       "support_skills": {
@@ -79610,6 +79929,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378880,
       "structure_id": null,
       "support_skills": {
@@ -79805,6 +80125,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -79979,6 +80300,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378913,
       "structure_id": null,
       "support_skills": {
@@ -80178,6 +80500,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379134,
       "structure_id": null,
       "support_skills": {
@@ -80377,6 +80700,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2378938,
       "structure_id": null,
       "support_skills": {
@@ -80572,6 +80896,7 @@
       "player_id": 9791113,
       "player_name": "oldpirate loopy",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -80771,6 +81096,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379158,
       "structure_id": null,
       "support_skills": {
@@ -80970,6 +81296,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -81148,6 +81475,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379012,
       "structure_id": null,
       "support_skills": {
@@ -81347,6 +81675,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -81538,6 +81867,7 @@
       "player_id": 35777523,
       "player_name": "Listige Hummel",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -81716,6 +82046,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -81919,6 +82250,7 @@
       "player_id": 129169775,
       "player_name": "Aydinn",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -82118,6 +82450,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379459,
       "structure_id": null,
       "support_skills": {
@@ -82317,6 +82650,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -82495,6 +82829,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -82690,6 +83025,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379059,
       "structure_id": null,
       "support_skills": {
@@ -82885,6 +83221,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379167,
       "structure_id": null,
       "support_skills": {
@@ -83067,6 +83404,7 @@
       "player_id": 34488395,
       "player_name": "Zwiebelritter79",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379078,
       "structure_id": null,
       "support_skills": {
@@ -83266,6 +83604,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -83461,6 +83800,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -83660,6 +84000,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -83859,6 +84200,7 @@
       "player_id": 924548,
       "player_name": "m212",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379112,
       "structure_id": null,
       "support_skills": {
@@ -84050,6 +84392,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379278,
       "structure_id": null,
       "support_skills": {
@@ -84245,6 +84588,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -84444,6 +84788,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -84614,6 +84959,7 @@
       "player_id": 129258203,
       "player_name": "BLK92",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379500,
       "structure_id": null,
       "support_skills": {
@@ -84813,6 +85159,7 @@
       "player_id": 937280,
       "player_name": "magut",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -85008,6 +85355,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -85207,6 +85555,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -85406,6 +85755,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -85605,6 +85955,7 @@
       "player_id": 62376,
       "player_name": "Bloodypickle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -85804,6 +86155,7 @@
       "player_id": 63949879,
       "player_name": "Bexissᴮᴿ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -85961,6 +86313,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379190,
       "structure_id": null,
       "support_skills": {
@@ -86135,6 +86488,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -86330,6 +86684,7 @@
       "player_id": 49547547,
       "player_name": "ToxıcRıck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -86508,6 +86863,7 @@
       "player_id": 933460,
       "player_name": "Julius Cesar II",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379204,
       "structure_id": null,
       "support_skills": {
@@ -86703,6 +87059,7 @@
       "player_id": 34200656,
       "player_name": "Lässige Biene",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379211,
       "structure_id": null,
       "support_skills": {
@@ -86902,6 +87259,7 @@
       "player_id": 922890,
       "player_name": "BadBunnyBernie",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379371,
       "structure_id": null,
       "support_skills": {
@@ -87076,6 +87434,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -87254,6 +87613,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -87411,6 +87771,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379224,
       "structure_id": null,
       "support_skills": {
@@ -87585,6 +87946,7 @@
       "player_id": 45962268,
       "player_name": "lLii",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379243,
       "structure_id": null,
       "support_skills": {
@@ -87784,6 +88146,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379470,
       "structure_id": null,
       "support_skills": {
@@ -87983,6 +88346,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379255,
       "structure_id": null,
       "support_skills": {
@@ -88178,6 +88542,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379262,
       "structure_id": null,
       "support_skills": {
@@ -88373,6 +88738,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -88568,6 +88934,7 @@
       "player_id": 11395407,
       "player_name": "Trehl",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -88763,6 +89130,7 @@
       "player_id": 949733,
       "player_name": "Greiserich",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379284,
       "structure_id": null,
       "support_skills": {
@@ -88958,6 +89326,7 @@
       "player_id": 124893142,
       "player_name": "ˢˣ乄Daspim",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379456,
       "structure_id": null,
       "support_skills": {
@@ -89157,6 +89526,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379305,
       "structure_id": null,
       "support_skills": {
@@ -89356,6 +89726,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -89555,6 +89926,7 @@
       "player_id": 958858,
       "player_name": "Sir Relington",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -89754,6 +90126,7 @@
       "player_id": 36152860,
       "player_name": "Aldérik",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379345,
       "structure_id": null,
       "support_skills": {
@@ -89907,6 +90280,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -90106,6 +90480,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -90297,6 +90672,7 @@
       "player_id": 11413340,
       "player_name": "DuckTheDuckTeen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90475,6 +90851,7 @@
       "player_id": 53674767,
       "player_name": "Krawler12000",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90674,6 +91051,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -90873,6 +91251,7 @@
       "player_id": 4713658,
       "player_name": "Zuckachu ヅ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -91072,6 +91451,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -91267,6 +91647,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -91466,6 +91847,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379375,
       "structure_id": null,
       "support_skills": {
@@ -91665,6 +92047,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -91860,6 +92243,7 @@
       "player_id": 96907886,
       "player_name": "Joey22587",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379469,
       "structure_id": null,
       "support_skills": {
@@ -92013,6 +92397,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379382,
       "structure_id": null,
       "support_skills": {
@@ -92191,6 +92576,7 @@
       "player_id": 10955557,
       "player_name": "YourLuck",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379390,
       "structure_id": null,
       "support_skills": {
@@ -92386,6 +92772,7 @@
       "player_id": 114763768,
       "player_name": "Basstma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379420,
       "structure_id": null,
       "support_skills": {
@@ -92581,6 +92968,7 @@
       "player_id": 80443266,
       "player_name": "Banna93",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379427,
       "structure_id": null,
       "support_skills": {
@@ -92780,6 +93168,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -92979,6 +93368,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -93174,6 +93564,7 @@
       "player_id": 952217,
       "player_name": "Stop war ua",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -93373,6 +93764,7 @@
       "player_id": 45291241,
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379442,
       "structure_id": null,
       "support_skills": {
@@ -93572,6 +93964,7 @@
       "player_id": 80986677,
       "player_name": "KittySoftPaws",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -93767,6 +94160,7 @@
       "player_id": 7162257,
       "player_name": "6sG 7oker",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -94484,6 +94878,7 @@
       "player_id": 41377732,
       "player_name": "箭ˢJian",
       "rally": true,
+      "server_season": "100",
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -94675,6 +95070,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -94849,6 +95245,7 @@
       "player_id": 971357,
       "player_name": "KastielX",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -95044,6 +95441,7 @@
       "player_id": 17060031,
       "player_name": "义 IIIVMINATI",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -95239,6 +95637,7 @@
       "player_id": 922968,
       "player_name": "MaveK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379483,
       "structure_id": null,
       "support_skills": {
@@ -95438,6 +95837,7 @@
       "player_id": 1019269,
       "player_name": "Aachen 7",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -95637,6 +96037,7 @@
       "player_id": 2483323,
       "player_name": "Starr77",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -95828,6 +96229,7 @@
       "player_id": 38611314,
       "player_name": "Shazb0t",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -95981,6 +96383,7 @@
       "player_id": 12909379,
       "player_name": "Murphatlar",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -96176,6 +96579,7 @@
       "player_id": 941710,
       "player_name": "SAH4RCOREJZ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -96379,6 +96783,7 @@
       "player_id": 20186294,
       "player_name": "Babel 03",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -96578,6 +96983,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -96777,6 +97183,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -96968,6 +97375,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379513,
       "structure_id": null,
       "support_skills": {
@@ -97167,6 +97575,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -97366,6 +97775,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379507,
       "structure_id": null,
       "support_skills": {
@@ -97561,6 +97971,7 @@
       "player_id": 80356744,
       "player_name": "SLIMEY KRAK869",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379722,
       "structure_id": null,
       "support_skills": {
@@ -97735,6 +98146,7 @@
       "player_id": 29156197,
       "player_name": "Judge Jonzement",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379519,
       "structure_id": null,
       "support_skills": {
@@ -97934,6 +98346,7 @@
       "player_id": 10734164,
       "player_name": "King Elma",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -98133,6 +98546,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -98328,6 +98742,7 @@
       "player_id": 20323893,
       "player_name": "٠Helmchen٠",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -98527,6 +98942,7 @@
       "player_id": 14479430,
       "player_name": "Allesauf0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379548,
       "structure_id": null,
       "support_skills": {
@@ -98726,6 +99142,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379598,
       "structure_id": null,
       "support_skills": {
@@ -98925,6 +99342,7 @@
       "player_id": 10052322,
       "player_name": "Sɪʀ Zucks",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -99120,6 +99538,7 @@
       "player_id": 953606,
       "player_name": "iKoSenSei",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379637,
       "structure_id": null,
       "support_skills": {
@@ -99298,6 +99717,7 @@
       "player_id": 11607682,
       "player_name": "Tribun Ludwig",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379645,
       "structure_id": null,
       "support_skills": {
@@ -99497,6 +99917,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379651,
       "structure_id": null,
       "support_skills": {
@@ -99696,6 +100117,7 @@
       "player_id": 4981264,
       "player_name": "㋡Flickツ",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379658,
       "structure_id": null,
       "support_skills": {
@@ -99891,6 +100313,7 @@
       "player_id": 88422443,
       "player_name": "Henry Targaryen",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379666,
       "structure_id": null,
       "support_skills": {
@@ -100090,6 +100513,7 @@
       "player_id": 15894174,
       "player_name": "F4TF4LK",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379670,
       "structure_id": null,
       "support_skills": {
@@ -100264,6 +100688,7 @@
       "player_id": 60805,
       "player_name": "Rummeltrupp",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379678,
       "structure_id": null,
       "support_skills": {
@@ -100442,6 +100867,7 @@
       "player_id": 7547259,
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -100641,6 +101067,7 @@
       "player_id": 6133598,
       "player_name": "Arck0",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -100840,6 +101267,7 @@
       "player_id": 11987186,
       "player_name": "I Dare",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379752,
       "structure_id": null,
       "support_skills": {
@@ -101026,6 +101454,7 @@
       "player_id": 86610794,
       "player_name": "ᵛⁿmoneybo",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379753,
       "structure_id": null,
       "support_skills": {
@@ -101217,6 +101646,7 @@
       "player_id": 13661342,
       "player_name": "ᵛⁿSabu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -101416,6 +101846,7 @@
       "player_id": 74455288,
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -101615,6 +102046,7 @@
       "player_id": 31387633,
       "player_name": "Nostrum33",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -101806,6 +102238,7 @@
       "player_id": 6193256,
       "player_name": "cpt pelle",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -101984,6 +102417,7 @@
       "player_id": 11305942,
       "player_name": "S0fieFlames",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -102183,6 +102617,7 @@
       "player_id": 26016592,
       "player_name": "Sancho0o",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379852,
       "structure_id": null,
       "support_skills": {
@@ -102382,6 +102817,7 @@
       "player_id": 6098505,
       "player_name": "Y A M A",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -102581,6 +103017,7 @@
       "player_id": 27013114,
       "player_name": "hangry",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -102784,6 +103221,7 @@
       "player_id": 226410,
       "player_name": "Mangeer",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379785,
       "structure_id": null,
       "support_skills": {
@@ -102979,6 +103417,7 @@
       "player_id": 962861,
       "player_name": "EDM LORD",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379806,
       "structure_id": null,
       "support_skills": {
@@ -103174,6 +103613,7 @@
       "player_id": 936551,
       "player_name": "Nordsee 300",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379820,
       "structure_id": null,
       "support_skills": {
@@ -103373,6 +103813,7 @@
       "player_id": 6082697,
       "player_name": "Helly Jelly",
       "rally": null,
+      "server_season": "100",
       "start_tick": 2379845,
       "structure_id": null,
       "support_skills": {
@@ -115469,6 +115910,7 @@
     "player_id": 37188990,
     "player_name": "망치丶Black",
     "rally": null,
+    "server_season": "100",
     "structure_id": 52,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 412,
     "mail_id": "8421200117137313126",
     "mail_receiver": "player_46387535",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1713731312680953,
     "report_id": 30641419,
+    "schema": 412,
     "server_id": 1804
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -173,6 +173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -373,6 +374,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -573,6 +575,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -773,6 +776,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -969,6 +973,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1169,6 +1174,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1348,6 +1354,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1548,6 +1555,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1748,6 +1756,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -1940,6 +1949,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2132,6 +2142,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2332,6 +2343,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2511,6 +2523,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2711,6 +2724,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -2911,6 +2925,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3111,6 +3126,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3311,6 +3327,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3503,6 +3520,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3703,6 +3721,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -3899,6 +3918,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4099,6 +4119,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4299,6 +4320,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4499,6 +4521,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4699,6 +4722,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -4891,6 +4915,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5091,6 +5116,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5283,6 +5309,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5483,6 +5510,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5683,6 +5711,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -5883,6 +5912,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6083,6 +6113,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6279,6 +6310,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6479,6 +6511,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6679,6 +6712,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -6879,6 +6913,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7079,6 +7114,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7279,6 +7315,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7475,6 +7512,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7675,6 +7713,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -7875,6 +7914,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8071,6 +8111,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8263,6 +8304,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8463,6 +8505,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8663,6 +8706,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -8838,6 +8882,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -9034,6 +9079,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -9230,6 +9276,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -9430,6 +9477,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -9626,6 +9674,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -9826,6 +9875,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -10022,6 +10072,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -10222,6 +10273,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -10422,6 +10474,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -10622,6 +10675,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -10822,6 +10876,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -11022,6 +11077,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -11222,6 +11278,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -11422,6 +11479,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -11622,6 +11680,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -11822,6 +11881,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -12022,6 +12082,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -12222,6 +12283,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -12422,6 +12484,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -12622,6 +12685,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -12822,6 +12886,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -13022,6 +13087,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -13222,6 +13288,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -13418,6 +13485,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -13618,6 +13686,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -13818,6 +13887,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14018,6 +14088,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14197,6 +14268,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14397,6 +14469,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14593,6 +14666,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14793,6 +14867,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -14993,6 +15068,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -15193,6 +15269,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -15393,6 +15470,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -15593,6 +15671,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -15785,6 +15864,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -15977,6 +16057,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -16177,6 +16258,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -16369,6 +16451,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -16565,6 +16648,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -16761,6 +16845,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -31631,6 +31716,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -32335,6 +32421,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -32535,6 +32622,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -32735,6 +32823,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -32935,6 +33024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -33131,6 +33221,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -33331,6 +33422,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -33527,6 +33619,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -33723,6 +33816,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -33923,6 +34017,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -34115,6 +34210,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -34315,6 +34411,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -34498,6 +34595,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -34702,6 +34800,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -34864,6 +34963,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -35064,6 +35164,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -35264,6 +35365,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -35460,6 +35562,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -35660,6 +35763,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -35852,6 +35956,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -36052,6 +36157,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -36252,6 +36358,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -36452,6 +36559,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -36652,6 +36760,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -36848,6 +36957,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -37040,6 +37150,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -37236,6 +37347,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -37436,6 +37548,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -37628,6 +37741,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -37824,6 +37938,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38028,6 +38143,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38228,6 +38344,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38420,6 +38537,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38620,6 +38738,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38812,6 +38931,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -38987,6 +39107,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -39179,6 +39300,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -39379,6 +39501,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -39579,6 +39702,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -39779,6 +39903,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -39958,6 +40083,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -40154,6 +40280,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -40350,6 +40477,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -40550,6 +40678,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -40746,6 +40875,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -40946,6 +41076,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -41150,6 +41281,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -41329,6 +41461,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -41529,6 +41662,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -41725,6 +41859,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -41921,6 +42056,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -42117,6 +42253,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -42317,6 +42454,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -42517,6 +42655,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -42717,6 +42856,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -42917,6 +43057,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -43117,6 +43258,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -43317,6 +43459,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -44093,6 +44236,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -44293,6 +44437,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -44485,6 +44630,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -44685,6 +44831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -44885,6 +45032,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -45085,6 +45233,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -45285,6 +45434,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -45477,6 +45627,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -45677,6 +45828,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -45873,6 +46025,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -46073,6 +46226,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -46265,6 +46419,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -46465,6 +46620,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -46661,6 +46817,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -46861,6 +47018,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -47061,6 +47219,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -47257,6 +47416,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -47457,6 +47617,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -47653,6 +47814,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -47853,6 +48015,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -48049,6 +48212,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -48249,6 +48413,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -48432,6 +48597,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -48628,6 +48794,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -48828,6 +48995,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49024,6 +49192,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49216,6 +49385,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49416,6 +49586,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49616,6 +49787,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49795,6 +49967,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -49995,6 +50168,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -50174,6 +50348,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -50374,6 +50549,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -50570,6 +50746,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -50770,6 +50947,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -50970,6 +51148,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -51170,6 +51349,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -51366,6 +51546,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -51566,6 +51747,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -51766,6 +51948,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -51966,6 +52149,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -52166,6 +52350,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -52362,6 +52547,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -52541,6 +52727,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -52737,6 +52924,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -52933,6 +53121,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -53133,6 +53322,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -53333,6 +53523,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -53529,6 +53720,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -53729,6 +53921,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -53929,6 +54122,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -54125,6 +54319,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -54325,6 +54520,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -54504,6 +54700,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -54696,6 +54893,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -54892,6 +55090,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -55092,6 +55291,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -55292,6 +55492,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -55492,6 +55693,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -55692,6 +55894,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -55892,6 +56095,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -56088,6 +56292,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -56288,6 +56493,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -56488,6 +56694,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -56684,6 +56891,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -56876,6 +57084,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -57076,6 +57285,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -57276,6 +57486,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -57476,6 +57687,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -57668,6 +57880,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -57864,6 +58077,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -58064,6 +58278,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -58264,6 +58479,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -58439,6 +58655,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -58639,6 +58856,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -58839,6 +59057,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -59039,6 +59258,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -59214,6 +59434,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -59414,6 +59635,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -60316,6 +60538,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -60495,6 +60718,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -60695,6 +60919,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -60891,6 +61116,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -61091,6 +61317,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -61287,6 +61514,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -61479,6 +61707,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -61679,6 +61908,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -61878,6 +62108,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -62074,6 +62305,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -62270,6 +62502,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -62470,6 +62703,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -62662,6 +62896,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -62858,6 +63093,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -63058,6 +63294,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -63258,6 +63495,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -63454,6 +63692,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -63654,6 +63893,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -63854,6 +64094,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -64046,6 +64287,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -64242,6 +64484,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -64442,6 +64685,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -64642,6 +64886,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -64842,6 +65087,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -65038,6 +65284,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -65238,6 +65485,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -65438,6 +65686,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -65638,6 +65887,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -65838,6 +66088,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -66034,6 +66285,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -66234,6 +66486,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -66434,6 +66687,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -66634,6 +66888,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -66826,6 +67081,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -67026,6 +67282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -67218,6 +67475,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -67418,6 +67676,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -67618,6 +67877,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -67818,6 +68078,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -68018,6 +68279,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -68218,6 +68480,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -68418,6 +68681,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -68614,6 +68878,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -68814,6 +69079,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -69010,6 +69276,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -69206,6 +69473,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -69406,6 +69674,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -69606,6 +69875,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -69806,6 +70076,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70006,6 +70277,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70198,6 +70470,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70398,6 +70671,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70598,6 +70872,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70798,6 +71073,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -70998,6 +71274,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -71202,6 +71479,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -71402,6 +71680,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -71602,6 +71881,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -71802,6 +72082,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72002,6 +72283,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72202,6 +72484,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72377,6 +72660,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72573,6 +72857,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72773,6 +73058,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -72973,6 +73259,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -73173,6 +73460,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -73369,6 +73657,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -73569,6 +73858,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -73744,6 +74034,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -73940,6 +74231,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -74136,6 +74428,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -74336,6 +74629,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -74532,6 +74826,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -74732,6 +75027,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -74928,6 +75224,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -75128,6 +75425,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -75324,6 +75622,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -75524,6 +75823,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -75724,6 +76024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -75920,6 +76221,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -76112,6 +76414,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -76312,6 +76615,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -76512,6 +76816,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -76712,6 +77017,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -76891,6 +77197,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -77070,6 +77377,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -77270,6 +77578,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78018,6 +78327,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78214,6 +78524,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78406,6 +78717,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78606,6 +78918,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78760,6 +79073,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -78943,6 +79257,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -79135,6 +79450,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -79335,6 +79651,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -79531,6 +79848,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -79731,6 +80049,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -79906,6 +80225,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -80102,6 +80422,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -80277,6 +80598,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -80477,6 +80799,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -80677,6 +81000,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -80873,6 +81197,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -81073,6 +81398,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -81273,6 +81599,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -81452,6 +81779,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -81652,6 +81980,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -81844,6 +82173,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -82023,6 +82353,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -82227,6 +82558,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -82427,6 +82759,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -82627,6 +82960,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -82806,6 +83140,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83002,6 +83337,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83198,6 +83534,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83381,6 +83718,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83581,6 +83919,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83777,6 +84116,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -83977,6 +84317,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -84177,6 +84518,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -84369,6 +84711,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -84565,6 +84908,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -84765,6 +85109,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -84936,6 +85281,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -85136,6 +85482,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -85332,6 +85679,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -85532,6 +85880,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -85732,6 +86081,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -85932,6 +86282,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -86132,6 +86483,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -86290,6 +86642,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -86465,6 +86818,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -86661,6 +87015,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -86840,6 +87195,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87036,6 +87392,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87236,6 +87593,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87411,6 +87769,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87590,6 +87949,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87748,6 +88108,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -87923,6 +88284,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -88123,6 +88485,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -88323,6 +88686,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -88519,6 +88883,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -88715,6 +89080,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -88911,6 +89277,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -89107,6 +89474,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -89303,6 +89671,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -89503,6 +89872,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -89703,6 +90073,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -89903,6 +90274,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -90103,6 +90475,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -90257,6 +90630,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -90457,6 +90831,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -90649,6 +91024,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -90828,6 +91204,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -91028,6 +91405,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -91228,6 +91606,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -91428,6 +91807,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -91624,6 +92004,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -91824,6 +92205,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92024,6 +92406,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92220,6 +92603,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92374,6 +92758,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92553,6 +92938,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92749,6 +93135,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -92945,6 +93332,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -93145,6 +93533,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -93345,6 +93734,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -93541,6 +93931,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -93741,6 +94132,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -93941,6 +94333,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -94137,6 +94530,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -94333,6 +94727,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -95047,6 +95442,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -95222,6 +95618,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -95418,6 +95815,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -95614,6 +96012,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -95814,6 +96213,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96014,6 +96414,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96206,6 +96607,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96360,6 +96762,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96556,6 +96959,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96760,6 +97164,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -96960,6 +97365,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -97160,6 +97566,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -97352,6 +97759,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -97552,6 +97960,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -97752,6 +98161,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -97948,6 +98358,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -98123,6 +98534,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -98323,6 +98735,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -98523,6 +98936,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -98719,6 +99133,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -98919,6 +99334,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -99119,6 +99535,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -99319,6 +99736,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -99515,6 +99933,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -99694,6 +100113,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -99894,6 +100314,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -100094,6 +100515,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -100290,6 +100712,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -100490,6 +100913,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -100665,6 +101089,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -100844,6 +101269,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -101044,6 +101470,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -101244,6 +101671,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -101431,6 +101859,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -101623,6 +102052,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -101823,6 +102253,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102023,6 +102454,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102215,6 +102647,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102394,6 +102827,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102594,6 +103028,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102794,6 +103229,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -102994,6 +103430,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -103198,6 +103635,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -103394,6 +103832,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -103590,6 +104029,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -103790,6 +104230,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": null,
       "participants": [
         {
           "alliance": {
@@ -103935,6 +104376,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 1102,
+    "package_identifier": null,
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -1,6 +1,7 @@
 {
   "metadata": {
     "kvk": true,
+    "ll_script_schema": 320,
     "mail_id": "914085176607419831",
     "mail_receiver": "player_71738515",
     "mail_role": "gsmp",

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -169,6 +169,7 @@
         "loot": null,
         "type": null
       },
+      "package_identifier": "com.lilithgames.rok.pc.int",
       "participants": [
         {
           "alliance": {
@@ -310,6 +311,7 @@
     },
     "frame_url": "http://imimg.lilithcdn.com/roc/img_AvatarFrame_16.png",
     "kingdom_id": 1804,
+    "package_identifier": "com.lilithgames.rok.pc.int",
     "participants": [
       {
         "alliance": {

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -7,6 +7,7 @@
     "mail_role": "gsmp",
     "mail_time": 1766074198335358,
     "report_id": 6864081,
+    "schema": 320,
     "server_id": 15790
   },
   "opponents": [

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -192,6 +192,7 @@
       "player_id": 37556801,
       "player_name": "Benbu",
       "rally": null,
+      "server_season": "100",
       "start_tick": 31439,
       "structure_id": null,
       "support_skills": {
@@ -332,6 +333,7 @@
     "player_id": 71738515,
     "player_name": "G Var",
     "rally": null,
+    "server_season": "100",
     "structure_id": null,
     "support_skills": {
       "enable": false,


### PR DESCRIPTION
## Summary

- expose the battle report map configuration as nullable `metadata.schema`
- preserve the report value exactly, including zero
- emit `null` when older reports do not provide the field
- regenerate the Battle sample outputs

## Why

The report schema identifies the map configuration when available and can support more precise report classification without changing existing classifications.

## Validation

- `cargo test -p mail-processor-battle`
- `cargo clippy -p mail-processor-battle --all-targets --locked -- -D warnings`
- `cargo run -q -p mail-cli -- samples/Battle`
- `git diff --check`