### PR TITLE
fix(ingress): retain largest v2 mail binary

### DIFF
--- a/crates/services/rokbattles-ingress/src/handlers.rs
+++ b/crates/services/rokbattles-ingress/src/handlers.rs
@@ -173,17 +173,15 @@ async fn store_compressed_raw_mail(
     user_agent: &str,
 ) -> Result<(), ApiError> {
     let checksum = raw_mail::sha256_hex(buffer);
+    let binary_size = i64::try_from(buffer.len())
+        .map_err(|_| ApiError::internal("mail binary is too large to store size"))?;
     let existing = state
         .storage
         .find_existing_compressed_raw(mail_id)
         .await
         .map_err(|error| ApiError::database(error.to_string()))?;
 
-    let action = match existing {
-        None => UploadAction::Insert,
-        Some(existing) if existing.checksum == checksum => UploadAction::Skip,
-        Some(_) => UploadAction::Update,
-    };
+    let action = decide_compressed_raw_action(existing.as_ref(), &checksum, buffer.len());
 
     if matches!(action, UploadAction::Skip) {
         return Ok(());
@@ -213,7 +211,7 @@ async fn store_compressed_raw_mail(
             .map_err(|error| ApiError::database(error.to_string()))?,
         UploadAction::Update => state
             .storage
-            .update_compressed_raw(mail_id, doc)
+            .update_compressed_raw(mail_id, &checksum, binary_size, doc)
             .await
             .map_err(|error| ApiError::database(error.to_string()))?,
         UploadAction::Skip => {}
@@ -399,6 +397,21 @@ fn decide_action(existing_attack_count: Option<i64>, attack_count: i64) -> Uploa
     match existing_attack_count {
         None => UploadAction::Insert,
         Some(existing) if attack_count > existing => UploadAction::Update,
+        Some(_) => UploadAction::Skip,
+    }
+}
+
+fn decide_compressed_raw_action(
+    existing: Option<&crate::storage::ExistingCompressedRawMail>,
+    checksum: &str,
+    size: usize,
+) -> UploadAction {
+    match existing {
+        None => UploadAction::Insert,
+        Some(existing) if existing.checksum.as_deref() == Some(checksum) => UploadAction::Skip,
+        Some(existing) if existing.size.is_some_and(|existing_size| size > existing_size) => {
+            UploadAction::Update
+        }
         Some(_) => UploadAction::Skip,
     }
 }
@@ -714,6 +727,54 @@ mod tests {
     fn decide_action_skips_when_not_newer() {
         assert!(matches!(decide_action(Some(5), 4), UploadAction::Skip));
         assert!(matches!(decide_action(Some(4), 4), UploadAction::Skip));
+    }
+
+    fn existing_compressed_raw(
+        checksum: &str,
+        size: Option<usize>,
+    ) -> crate::storage::ExistingCompressedRawMail {
+        crate::storage::ExistingCompressedRawMail { checksum: Some(checksum.to_string()), size }
+    }
+
+    #[test]
+    fn compressed_raw_action_inserts_when_missing() {
+        let action = decide_compressed_raw_action(None, "new", 100);
+        assert!(matches!(action, UploadAction::Insert));
+    }
+
+    #[test]
+    fn compressed_raw_action_skips_matching_checksum() {
+        let existing = existing_compressed_raw("same", Some(50));
+        let action = decide_compressed_raw_action(Some(&existing), "same", 100);
+        assert!(matches!(action, UploadAction::Skip));
+    }
+
+    #[test]
+    fn compressed_raw_action_updates_different_larger_binary() {
+        let existing = existing_compressed_raw("old", Some(99));
+        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+        assert!(matches!(action, UploadAction::Update));
+    }
+
+    #[test]
+    fn compressed_raw_action_skips_different_equal_size_binary() {
+        let existing = existing_compressed_raw("old", Some(100));
+        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+        assert!(matches!(action, UploadAction::Skip));
+    }
+
+    #[test]
+    fn compressed_raw_action_skips_different_smaller_binary() {
+        let existing = existing_compressed_raw("old", Some(101));
+        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+        assert!(matches!(action, UploadAction::Skip));
+    }
+
+    #[test]
+    fn compressed_raw_action_skips_when_stored_size_is_missing() {
+        let existing = existing_compressed_raw("old", None);
+        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+        assert!(matches!(action, UploadAction::Skip));
     }
 
     #[test]

--- a/crates/services/rokbattles-ingress/src/storage.rs
+++ b/crates/services/rokbattles-ingress/src/storage.rs
@@ -3,7 +3,7 @@
 use core_bson::bson_to_i64;
 use mongodb::{
     Collection, IndexModel,
-    bson::{Document, doc},
+    bson::{Bson, Document, doc},
     options::IndexOptions,
 };
 
@@ -20,10 +20,11 @@ pub struct ExistingMail {
     pub attack_count: i64,
 }
 
-/// V2 raw binary mail metadata needed for checksum dedupe.
+/// V2 raw binary mail metadata needed to decide whether an upload is larger.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExistingCompressedRawMail {
-    pub checksum: String,
+    pub checksum: Option<String>,
+    pub size: Option<usize>,
 }
 
 impl Storage {
@@ -74,7 +75,7 @@ impl Storage {
         Ok(())
     }
 
-    /// Load V2 raw mail checksum metadata, if this mail was already uploaded.
+    /// Load V2 checksum and uncompressed size metadata, if this mail was already uploaded.
     pub async fn find_existing_compressed_raw(
         &self,
         mail_id: &str,
@@ -82,7 +83,7 @@ impl Storage {
         let doc = self
             .compressed_raw
             .find_one(doc! { "mail.id": mail_id })
-            .projection(doc! { "metadata.checksum": 1 })
+            .projection(doc! { "metadata.checksum": 1, "metadata.size": 1 })
             .await?;
         Ok(doc.and_then(parse_existing_compressed_raw))
     }
@@ -93,14 +94,17 @@ impl Storage {
         Ok(())
     }
 
-    /// Replace the mutable fields of an existing V2 raw compressed mail document.
+    /// Replace an existing V2 document only when its checksum differs and stored size is smaller.
     pub async fn update_compressed_raw(
         &self,
         mail_id: &str,
+        checksum: &str,
+        size: i64,
         mut doc: Document,
     ) -> mongodb::error::Result<()> {
         doc.remove("createdAt");
-        self.compressed_raw.update_one(doc! { "mail.id": mail_id }, doc! { "$set": doc }).await?;
+        let filter = compressed_raw_update_filter(mail_id, checksum, size);
+        self.compressed_raw.update_one(filter, doc! { "$set": doc }).await?;
         Ok(())
     }
 
@@ -117,14 +121,30 @@ fn parse_existing(doc: Document) -> Option<ExistingMail> {
 }
 
 fn parse_existing_compressed_raw(doc: Document) -> Option<ExistingCompressedRawMail> {
-    let checksum = doc.get_document("metadata").ok()?.get_str("checksum").ok()?.to_string();
-    Some(ExistingCompressedRawMail { checksum })
+    let metadata = doc.get_document("metadata").ok();
+    let checksum =
+        metadata.and_then(|metadata| metadata.get_str("checksum").ok()).map(str::to_string);
+    let size = metadata
+        .and_then(|metadata| metadata.get("size"))
+        .and_then(|size| match size {
+            Bson::Int32(size) => Some(i64::from(*size)),
+            Bson::Int64(size) => Some(*size),
+            _ => None,
+        })
+        .and_then(|size| usize::try_from(size).ok());
+    Some(ExistingCompressedRawMail { checksum, size })
+}
+
+fn compressed_raw_update_filter(mail_id: &str, checksum: &str, size: i64) -> Document {
+    doc! {
+        "mail.id": mail_id,
+        "metadata.checksum": { "$ne": checksum },
+        "metadata.size": { "$lt": size },
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use mongodb::bson::Bson;
-
     use super::*;
 
     #[test]
@@ -142,10 +162,41 @@ mod tests {
         let doc = doc! {
             "metadata": {
                 "checksum": "abc123",
+                "size": 42_i64,
             },
         };
         let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
-        assert_eq!(existing.checksum, "abc123");
+        assert_eq!(
+            existing,
+            ExistingCompressedRawMail { checksum: Some("abc123".to_string()), size: Some(42) }
+        );
+    }
+
+    #[test]
+    fn parses_existing_compressed_raw_mail_with_missing_size() {
+        let doc = doc! { "metadata": { "checksum": "abc123" } };
+        let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
+        assert_eq!(existing.size, None);
+    }
+
+    #[test]
+    fn parses_existing_compressed_raw_mail_with_invalid_size() {
+        let doc = doc! { "metadata": { "checksum": "abc123", "size": 42.5 } };
+        let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
+        assert_eq!(existing.size, None);
+    }
+
+    #[test]
+    fn compressed_raw_update_filter_requires_different_checksum_and_smaller_stored_size() {
+        let filter = compressed_raw_update_filter("mail-1", "new", 100);
+        assert_eq!(
+            filter,
+            doc! {
+                "mail.id": "mail-1",
+                "metadata.checksum": { "$ne": "new" },
+                "metadata.size": { "$lt": 100_i64 },
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- update `g_rok_mails` only when the incoming binary checksum differs and its uncompressed size is strictly larger
- conservatively retain existing documents when stored size metadata is missing or invalid
- enforce the replacement rule atomically in MongoDB to protect concurrent uploads
- leave the legacy `mails_raw` attack-count behavior unchanged

## Why

The v2 collection stores the exact binary mail and is intended to become the durable source of truth. Replacing it for every checksum change could overwrite a more complete mail with a smaller partial upload.

## Impact

Existing v2 binaries and their processing status remain unchanged for duplicate, equal-size, smaller, or unverifiable uploads. Larger binaries are stored and marked for reprocessing as before.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rokbattles-ingress` (66 passed, 1 benchmark ignored)
- `cargo clippy -p rokbattles-ingress --all-targets --locked -- -D warnings`
- `git diff --check`