### PR TITLE
feat(processor): process v2 mail binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4554,11 +4554,13 @@ version = "1.5.2"
 dependencies = [
  "dotenvy",
  "futures",
+ "mail-decoder",
  "mail-registry",
  "mail-sdk",
  "mongodb",
  "sentry",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/services/rokbattles-processor/Cargo.toml
+++ b/crates/services/rokbattles-processor/Cargo.toml
@@ -12,7 +12,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 futures = { workspace = true }
 zstd = { workspace = true }
+sha2 = { workspace = true }
 dotenvy = { workspace = true }
+mail-decoder = { path = "../../mail/decoder" }
 mail-registry = { path = "../../mail/registry", features = ["processors"] }
 mail-sdk = { path = "../../mail/sdk" }
 sentry = { workspace = true }

--- a/crates/services/rokbattles-processor/src/config.rs
+++ b/crates/services/rokbattles-processor/src/config.rs
@@ -10,7 +10,6 @@ pub struct Config {
     pub batch_size: i64,
     pub concurrency: usize,
     pub idle_sleep: Duration,
-    pub max_mail_bytes: usize,
 }
 
 /// Errors returned when configuration is missing or invalid.
@@ -41,13 +40,7 @@ impl Config {
             lookup("PROCESSOR_IDLE_SLEEP_SECS"),
             15,
         )?;
-        let max_mail_bytes = parse_usize(
-            "PROCESSOR_MAX_MAIL_BYTES",
-            lookup("PROCESSOR_MAX_MAIL_BYTES"),
-            25 * 1024 * 1024,
-        )?;
-
-        Ok(Self { mongo_uri, sentry_dsn, batch_size, concurrency, idle_sleep, max_mail_bytes })
+        Ok(Self { mongo_uri, sentry_dsn, batch_size, concurrency, idle_sleep })
     }
 }
 
@@ -125,7 +118,6 @@ mod tests {
                 batch_size: 500,
                 concurrency: 8,
                 idle_sleep: Duration::from_secs(15),
-                max_mail_bytes: 25 * 1024 * 1024,
             }
         );
     }
@@ -161,16 +153,6 @@ mod tests {
     #[test]
     fn parse_usize_rejects_zero() {
         assert!(parse_usize("TEST", Some("0".into()), 3).is_err());
-    }
-
-    #[test]
-    fn loads_max_mail_bytes() {
-        let cfg = Config::from_lookup(lookup(HashMap::from([
-            ("MONGODB_URI", "mongodb://localhost:27017/rokbattles"),
-            ("PROCESSOR_MAX_MAIL_BYTES", "1024"),
-        ])))
-        .expect("config");
-        assert_eq!(cfg.max_mail_bytes, 1024);
     }
 
     #[test]

--- a/crates/services/rokbattles-processor/src/config.rs
+++ b/crates/services/rokbattles-processor/src/config.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub batch_size: i64,
     pub concurrency: usize,
     pub idle_sleep: Duration,
+    pub max_mail_bytes: usize,
 }
 
 /// Errors returned when configuration is missing or invalid.
@@ -40,8 +41,13 @@ impl Config {
             lookup("PROCESSOR_IDLE_SLEEP_SECS"),
             15,
         )?;
+        let max_mail_bytes = parse_usize(
+            "PROCESSOR_MAX_MAIL_BYTES",
+            lookup("PROCESSOR_MAX_MAIL_BYTES"),
+            25 * 1024 * 1024,
+        )?;
 
-        Ok(Self { mongo_uri, sentry_dsn, batch_size, concurrency, idle_sleep })
+        Ok(Self { mongo_uri, sentry_dsn, batch_size, concurrency, idle_sleep, max_mail_bytes })
     }
 }
 
@@ -119,6 +125,7 @@ mod tests {
                 batch_size: 500,
                 concurrency: 8,
                 idle_sleep: Duration::from_secs(15),
+                max_mail_bytes: 25 * 1024 * 1024,
             }
         );
     }
@@ -154,6 +161,38 @@ mod tests {
     #[test]
     fn parse_usize_rejects_zero() {
         assert!(parse_usize("TEST", Some("0".into()), 3).is_err());
+    }
+
+    #[test]
+    fn loads_max_mail_bytes() {
+        let cfg = Config::from_lookup(lookup(HashMap::from([
+            ("MONGODB_URI", "mongodb://localhost:27017/rokbattles"),
+            ("PROCESSOR_MAX_MAIL_BYTES", "1024"),
+        ])))
+        .expect("config");
+        assert_eq!(cfg.max_mail_bytes, 1024);
+    }
+
+    #[test]
+    fn loads_processing_settings() {
+        let cfg = Config::from_lookup(lookup(HashMap::from([
+            ("MONGODB_URI", "mongodb://localhost:27017/rokbattles"),
+            ("PROCESSOR_BATCH_SIZE", "25"),
+            ("PROCESSOR_CONCURRENCY", "4"),
+            ("PROCESSOR_IDLE_SLEEP_SECS", "2"),
+        ])))
+        .expect("config");
+        assert_eq!(cfg.batch_size, 25);
+        assert_eq!(cfg.concurrency, 4);
+        assert_eq!(cfg.idle_sleep, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn numeric_settings_reject_invalid_values() {
+        assert!(parse_i64("I64", Some("bad".into()), 1).is_err());
+        assert!(parse_i64("I64", Some("-1".into()), 1).is_err());
+        assert!(parse_usize("USIZE", Some("bad".into()), 1).is_err());
+        assert!(parse_duration_secs("DURATION", Some("bad".into()), 1).is_err());
     }
 
     #[test]

--- a/crates/services/rokbattles-processor/src/error.rs
+++ b/crates/services/rokbattles-processor/src/error.rs
@@ -13,10 +13,22 @@ pub enum ProcessorError {
     MissingDatabase,
     #[error("missing required field: {0}")]
     MissingField(&'static str),
+    #[error("processed mail is missing its metadata section")]
+    MissingProcessedMetadata,
+    #[error("unsupported mail compression algorithm: {0}")]
+    UnsupportedCompression(String),
+    #[error("invalid uncompressed mail size: {0}")]
+    InvalidSize(i64),
+    #[error("uncompressed mail exceeds configured limit of {limit} bytes: {size}")]
+    SizeLimitExceeded { size: usize, limit: usize },
+    #[error("uncompressed mail size mismatch (expected {expected}, found {actual})")]
+    SizeMismatch { expected: usize, actual: usize },
+    #[error("mail checksum mismatch (expected {expected}, found {actual})")]
+    ChecksumMismatch { expected: String, actual: String },
     #[error("invalid mail payload: {0}")]
     InvalidMailPayload(String),
-    #[error("mail JSON decode failed: {0}")]
-    Decode(#[from] serde_json::Error),
+    #[error("binary mail decode failed: {0}")]
+    BinaryDecode(#[from] mail_decoder::DecodeError),
     #[error("zstd decode failed: {0}")]
     Decompress(#[from] std::io::Error),
     #[error("unsupported mail type: {0}")]

--- a/crates/services/rokbattles-processor/src/error.rs
+++ b/crates/services/rokbattles-processor/src/error.rs
@@ -19,8 +19,6 @@ pub enum ProcessorError {
     UnsupportedCompression(String),
     #[error("invalid uncompressed mail size: {0}")]
     InvalidSize(i64),
-    #[error("uncompressed mail exceeds configured limit of {limit} bytes: {size}")]
-    SizeLimitExceeded { size: usize, limit: usize },
     #[error("uncompressed mail size mismatch (expected {expected}, found {actual})")]
     SizeMismatch { expected: usize, actual: usize },
     #[error("mail checksum mismatch (expected {expected}, found {actual})")]

--- a/crates/services/rokbattles-processor/src/processing.rs
+++ b/crates/services/rokbattles-processor/src/processing.rs
@@ -70,7 +70,7 @@ async fn process_batch(storage: &Storage, config: &Config) -> Result<usize, Proc
                     .map(str::to_string);
                 let raw_id = doc.get_object_id("_id").ok();
                 let observed = observed_version(&doc);
-                match process_document(&storage, doc, config.max_mail_bytes).await {
+                match process_document(&storage, doc).await {
                     Err(error) => {
                         if should_mark_error(&error)
                             && let Some(raw_id) = raw_id
@@ -124,10 +124,9 @@ async fn process_batch(storage: &Storage, config: &Config) -> Result<usize, Proc
 async fn process_document(
     storage: &Storage,
     doc: Document,
-    max_mail_bytes: usize,
 ) -> Result<ProcessOutcome, ProcessorError> {
     let raw = parse_raw_mail(doc)?;
-    let (mail_type, processed_doc) = prepare_processed_document(&raw, max_mail_bytes)?;
+    let (mail_type, processed_doc) = prepare_processed_document(&raw)?;
 
     if !storage
         .upsert_processed(mail_type, &raw.mail_id, &raw.checksum, raw.size, processed_doc)
@@ -147,11 +146,8 @@ async fn process_document(
     Ok(ProcessOutcome::Processed)
 }
 
-fn prepare_processed_document(
-    raw: &RawMail,
-    max_mail_bytes: usize,
-) -> Result<(MailType, Document), ProcessorError> {
-    let decoded = decode_mail_binary(raw, max_mail_bytes)?;
+fn prepare_processed_document(raw: &RawMail) -> Result<(MailType, Document), ProcessorError> {
+    let decoded = decode_mail_binary(raw)?;
     let root = normalize_root(&decoded).ok_or_else(|| {
         ProcessorError::InvalidMailPayload("mail payload must be an object".to_string())
     })?;
@@ -175,7 +171,6 @@ fn should_mark_error(error: &ProcessorError) -> bool {
             | ProcessorError::MissingProcessedMetadata
             | ProcessorError::UnsupportedCompression(_)
             | ProcessorError::InvalidSize(_)
-            | ProcessorError::SizeLimitExceeded { .. }
             | ProcessorError::SizeMismatch { .. }
             | ProcessorError::ChecksumMismatch { .. }
             | ProcessorError::InvalidMailPayload(_)
@@ -216,18 +211,12 @@ fn parse_raw_mail(mut doc: Document) -> Result<RawMail, ProcessorError> {
     Ok(RawMail { id, mail_id, status, checksum, size, algorithm, binary })
 }
 
-fn decode_mail_binary(raw: &RawMail, max_mail_bytes: usize) -> Result<Value, ProcessorError> {
+fn decode_mail_binary(raw: &RawMail) -> Result<Value, ProcessorError> {
     if raw.algorithm != "zstd" {
         return Err(ProcessorError::UnsupportedCompression(raw.algorithm.clone()));
     }
     let expected_size =
         usize::try_from(raw.size).map_err(|_| ProcessorError::InvalidSize(raw.size))?;
-    if expected_size > max_mail_bytes {
-        return Err(ProcessorError::SizeLimitExceeded {
-            size: expected_size,
-            limit: max_mail_bytes,
-        });
-    }
 
     let decoder = zstd::stream::read::Decoder::new(raw.binary.as_slice())?;
     let mut bytes = Vec::with_capacity(expected_size);
@@ -567,7 +556,7 @@ mod tests {
             "/../../../samples/Battle/Persistent.Mail.485440176891031331"
         ));
         let raw = raw_mail_from_bytes(bytes);
-        let decoded = decode_mail_binary(&raw, bytes.len()).unwrap();
+        let decoded = decode_mail_binary(&raw).unwrap();
         assert_eq!(mail_registry::detect_mail_type(&decoded), Some(MailType::Battle));
     }
 
@@ -663,7 +652,7 @@ mod tests {
         for (bytes, expected_type) in samples {
             let raw = raw_mail_from_bytes(bytes);
             let (mail_type, processed) =
-                prepare_processed_document(&raw, bytes.len()).expect("process compressed sample");
+                prepare_processed_document(&raw).expect("process compressed sample");
             assert_eq!(mail_type, *expected_type);
             assert_eq!(
                 processed.get_document("metadata").unwrap().get_i64("source_size").unwrap(),
@@ -679,7 +668,7 @@ mod tests {
     fn decode_mail_binary_rejects_unsupported_algorithm() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.algorithm = "gzip".to_string();
-        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::UnsupportedCompression(value) if value == "gzip"));
     }
 
@@ -687,22 +676,15 @@ mod tests {
     fn decode_mail_binary_rejects_negative_size() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.size = -1;
-        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::InvalidSize(-1)));
-    }
-
-    #[test]
-    fn decode_mail_binary_rejects_oversized_mail() {
-        let raw = raw_mail_from_bytes(b"anything");
-        let error = decode_mail_binary(&raw, 7).unwrap_err();
-        assert!(matches!(error, ProcessorError::SizeLimitExceeded { size: 8, limit: 7 }));
     }
 
     #[test]
     fn decode_mail_binary_rejects_size_mismatch() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.size += 1;
-        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::SizeMismatch { expected: 9, actual: 8 }));
     }
 
@@ -710,7 +692,7 @@ mod tests {
     fn decode_mail_binary_rejects_checksum_mismatch() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.checksum = "wrong".to_string();
-        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(
             matches!(error, ProcessorError::ChecksumMismatch { expected, .. } if expected == "wrong")
         );
@@ -720,21 +702,21 @@ mod tests {
     fn decode_mail_binary_rejects_corrupt_zstd() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.binary = vec![1, 2, 3];
-        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::Decompress(_)));
     }
 
     #[test]
     fn decode_mail_binary_rejects_invalid_binary_mail() {
         let raw = raw_mail_from_bytes(&[]);
-        let error = decode_mail_binary(&raw, 1).unwrap_err();
+        let error = decode_mail_binary(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::BinaryDecode(_)));
     }
 
     #[test]
     fn prepare_processed_document_rejects_non_object_root() {
         let raw = raw_mail_from_bytes(&[0x01, 1]);
-        let error = prepare_processed_document(&raw, 2).unwrap_err();
+        let error = prepare_processed_document(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::InvalidMailPayload(_)));
     }
 

--- a/crates/services/rokbattles-processor/src/processing.rs
+++ b/crates/services/rokbattles-processor/src/processing.rs
@@ -128,13 +128,9 @@ async fn process_document(
     let raw = parse_raw_mail(doc)?;
     let (mail_type, processed_doc) = prepare_processed_document(&raw)?;
 
-    if !storage
+    storage
         .upsert_processed(mail_type, &raw.mail_id, &raw.checksum, raw.size, processed_doc)
-        .await?
-    {
-        debug!(mail_id = %raw.mail_id, "discarded stale processed mail output");
-        return Ok(ProcessOutcome::Stale);
-    }
+        .await?;
 
     let now = DateTime::now();
     if !storage.mark_processed(&raw.id, &raw.checksum, raw.size, now).await? {
@@ -160,7 +156,6 @@ fn prepare_processed_document(raw: &RawMail) -> Result<(MailType, Document), Pro
         .map_err(|_| ProcessorError::MissingProcessedMetadata)?;
     metadata.insert("source_checksum", raw.checksum.clone());
     metadata.insert("source_size", raw.size);
-    metadata.insert("source_processor_run_id", ObjectId::new());
     Ok((mail_type, processed_doc))
 }
 
@@ -660,7 +655,6 @@ mod tests {
             );
             let metadata = processed.get_document("metadata").unwrap();
             assert_eq!(metadata.get_str("source_checksum").unwrap(), raw.checksum);
-            assert!(metadata.get_object_id("source_processor_run_id").is_ok());
         }
     }
 

--- a/crates/services/rokbattles-processor/src/processing.rs
+++ b/crates/services/rokbattles-processor/src/processing.rs
@@ -1,14 +1,18 @@
 //! Processing loop and mail handling logic.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicUsize, Ordering},
+use std::{
+    io::Read,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use futures::stream::TryStreamExt;
 use mail_registry::{MailType, process_mail};
 use mongodb::bson::{Bson, DateTime, Document, oid::ObjectId};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use tracing::{debug, error, info};
 
 use crate::{config::Config, error::ProcessorError, storage::Storage};
@@ -18,7 +22,22 @@ struct RawMail {
     id: ObjectId,
     mail_id: String,
     status: String,
-    mail_value: Vec<u8>,
+    checksum: String,
+    size: i64,
+    algorithm: String,
+    binary: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct ObservedVersion {
+    checksum: Option<Bson>,
+    size: Option<Bson>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProcessOutcome {
+    Processed,
+    Stale,
 }
 
 /// Run the processor loop forever.
@@ -44,32 +63,48 @@ async fn process_batch(storage: &Storage, config: &Config) -> Result<usize, Proc
             let storage = storage.clone();
             let processed = Arc::clone(&processed);
             async move {
-                let mail_id = doc.get_str("mail_id").ok().map(str::to_string);
+                let mail_id = doc
+                    .get_document("mail")
+                    .ok()
+                    .and_then(|mail| mail.get_str("id").ok())
+                    .map(str::to_string);
                 let raw_id = doc.get_object_id("_id").ok();
-                if let Err(error) = process_document(&storage, doc).await {
-                    if should_mark_error(&error)
-                        && let Some(raw_id) = raw_id
-                    {
-                        if let Err(mark_error) = storage.mark_error(&raw_id, DateTime::now()).await
+                let observed = observed_version(&doc);
+                match process_document(&storage, doc, config.max_mail_bytes).await {
+                    Err(error) => {
+                        if should_mark_error(&error)
+                            && let Some(raw_id) = raw_id
                         {
-                            error!(
-                                error = %error,
-                                mark_error = %mark_error,
-                                mail_id = mail_id.as_deref().unwrap_or("unknown"),
-                                "processing mail failed and status update failed"
-                            );
+                            if let Err(mark_error) = storage
+                                .mark_error(
+                                    &raw_id,
+                                    observed.checksum.as_ref(),
+                                    observed.size.as_ref(),
+                                    DateTime::now(),
+                                )
+                                .await
+                            {
+                                error!(
+                                    error = %error,
+                                    mark_error = %mark_error,
+                                    mail_id = mail_id.as_deref().unwrap_or("unknown"),
+                                    "processing mail failed and status update failed"
+                                );
+                            } else if let Some(mail_id) = mail_id {
+                                error!(error = %error, mail_id = %mail_id, "processing mail failed");
+                            } else {
+                                error!(error = %error, "processing mail failed");
+                            }
                         } else if let Some(mail_id) = mail_id {
                             error!(error = %error, mail_id = %mail_id, "processing mail failed");
                         } else {
                             error!(error = %error, "processing mail failed");
                         }
-                    } else if let Some(mail_id) = mail_id {
-                        error!(error = %error, mail_id = %mail_id, "processing mail failed");
-                    } else {
-                        error!(error = %error, "processing mail failed");
                     }
-                } else {
-                    processed.fetch_add(1, Ordering::Relaxed);
+                    Ok(ProcessOutcome::Processed) => {
+                        processed.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(ProcessOutcome::Stale) => {}
                 }
                 Ok(())
             }
@@ -86,31 +121,65 @@ async fn process_batch(storage: &Storage, config: &Config) -> Result<usize, Proc
     Ok(processed_count)
 }
 
-async fn process_document(storage: &Storage, doc: Document) -> Result<(), ProcessorError> {
+async fn process_document(
+    storage: &Storage,
+    doc: Document,
+    max_mail_bytes: usize,
+) -> Result<ProcessOutcome, ProcessorError> {
     let raw = parse_raw_mail(doc)?;
-    let decoded = decode_mail_value(&raw.mail_value)?;
+    let (mail_type, processed_doc) = prepare_processed_document(&raw, max_mail_bytes)?;
+
+    if !storage
+        .upsert_processed(mail_type, &raw.mail_id, &raw.checksum, raw.size, processed_doc)
+        .await?
+    {
+        debug!(mail_id = %raw.mail_id, "discarded stale processed mail output");
+        return Ok(ProcessOutcome::Stale);
+    }
+
+    let now = DateTime::now();
+    if !storage.mark_processed(&raw.id, &raw.checksum, raw.size, now).await? {
+        debug!(mail_id = %raw.mail_id, "mail changed while it was being processed");
+        return Ok(ProcessOutcome::Stale);
+    }
+    debug!(mail_id = %raw.mail_id, status = %raw.status, mail_type = %mail_type, "processed mail");
+
+    Ok(ProcessOutcome::Processed)
+}
+
+fn prepare_processed_document(
+    raw: &RawMail,
+    max_mail_bytes: usize,
+) -> Result<(MailType, Document), ProcessorError> {
+    let decoded = decode_mail_binary(raw, max_mail_bytes)?;
     let root = normalize_root(&decoded).ok_or_else(|| {
         ProcessorError::InvalidMailPayload("mail payload must be an object".to_string())
     })?;
     let mail_type = extract_mail_type(root)?;
     let processed = process_mail(mail_type, root)?;
 
-    let processed_doc = mongodb::bson::to_document(&processed)?;
-    storage.upsert_processed(mail_type, &raw.mail_id, processed_doc).await?;
-
-    let now = DateTime::now();
-    storage.mark_processed(&raw.id, now).await?;
-    debug!(mail_id = %raw.mail_id, status = %raw.status, mail_type = %mail_type, "processed mail");
-
-    Ok(())
+    let mut processed_doc = mongodb::bson::to_document(&processed)?;
+    let metadata = processed_doc
+        .get_document_mut("metadata")
+        .map_err(|_| ProcessorError::MissingProcessedMetadata)?;
+    metadata.insert("source_checksum", raw.checksum.clone());
+    metadata.insert("source_size", raw.size);
+    metadata.insert("source_processor_run_id", ObjectId::new());
+    Ok((mail_type, processed_doc))
 }
 
 fn should_mark_error(error: &ProcessorError) -> bool {
     matches!(
         error,
         ProcessorError::MissingField(_)
+            | ProcessorError::MissingProcessedMetadata
+            | ProcessorError::UnsupportedCompression(_)
+            | ProcessorError::InvalidSize(_)
+            | ProcessorError::SizeLimitExceeded { .. }
+            | ProcessorError::SizeMismatch { .. }
+            | ProcessorError::ChecksumMismatch { .. }
             | ProcessorError::InvalidMailPayload(_)
-            | ProcessorError::Decode(_)
+            | ProcessorError::BinaryDecode(_)
             | ProcessorError::Decompress(_)
             | ProcessorError::UnsupportedMailType(_)
             | ProcessorError::Process(_)
@@ -118,22 +187,72 @@ fn should_mark_error(error: &ProcessorError) -> bool {
     )
 }
 
-fn parse_raw_mail(doc: Document) -> Result<RawMail, ProcessorError> {
+fn parse_raw_mail(mut doc: Document) -> Result<RawMail, ProcessorError> {
     let id = doc.get_object_id("_id").map_err(|_| ProcessorError::MissingField("_id"))?;
-    let mail_id =
-        doc.get_str("mail_id").map_err(|_| ProcessorError::MissingField("mail_id"))?.to_string();
     let status = doc.get_str("status").unwrap_or(crate::storage::STATUS_PENDING).to_string();
-    let mail_value = match doc.get("mail_value") {
-        Some(Bson::Binary(binary)) => binary.bytes.clone(),
-        _ => return Err(ProcessorError::MissingField("mail_value")),
+    let metadata =
+        doc.get_document("metadata").map_err(|_| ProcessorError::MissingField("metadata"))?;
+    let checksum = metadata
+        .get_str("checksum")
+        .map_err(|_| ProcessorError::MissingField("metadata.checksum"))?
+        .to_string();
+    let size =
+        metadata.get_i64("size").map_err(|_| ProcessorError::MissingField("metadata.size"))?;
+    let algorithm = metadata
+        .get_str("algo")
+        .map_err(|_| ProcessorError::MissingField("metadata.algo"))?
+        .to_string();
+    let mut mail = match doc.remove("mail") {
+        Some(Bson::Document(mail)) => mail,
+        _ => return Err(ProcessorError::MissingField("mail")),
+    };
+    let mail_id =
+        mail.get_str("id").map_err(|_| ProcessorError::MissingField("mail.id"))?.to_string();
+    let binary = match mail.remove("binary") {
+        Some(Bson::Binary(binary)) => binary.bytes,
+        _ => return Err(ProcessorError::MissingField("mail.binary")),
     };
 
-    Ok(RawMail { id, mail_id, status, mail_value })
+    Ok(RawMail { id, mail_id, status, checksum, size, algorithm, binary })
 }
 
-fn decode_mail_value(bytes: &[u8]) -> Result<Value, ProcessorError> {
-    let decoded = zstd::decode_all(bytes)?;
-    Ok(serde_json::from_slice(&decoded)?)
+fn decode_mail_binary(raw: &RawMail, max_mail_bytes: usize) -> Result<Value, ProcessorError> {
+    if raw.algorithm != "zstd" {
+        return Err(ProcessorError::UnsupportedCompression(raw.algorithm.clone()));
+    }
+    let expected_size =
+        usize::try_from(raw.size).map_err(|_| ProcessorError::InvalidSize(raw.size))?;
+    if expected_size > max_mail_bytes {
+        return Err(ProcessorError::SizeLimitExceeded {
+            size: expected_size,
+            limit: max_mail_bytes,
+        });
+    }
+
+    let decoder = zstd::stream::read::Decoder::new(raw.binary.as_slice())?;
+    let mut bytes = Vec::with_capacity(expected_size);
+    decoder.take((expected_size + 1) as u64).read_to_end(&mut bytes)?;
+    if bytes.len() != expected_size {
+        return Err(ProcessorError::SizeMismatch { expected: expected_size, actual: bytes.len() });
+    }
+
+    let actual_checksum = format!("{:x}", Sha256::digest(&bytes));
+    if actual_checksum != raw.checksum {
+        return Err(ProcessorError::ChecksumMismatch {
+            expected: raw.checksum.clone(),
+            actual: actual_checksum,
+        });
+    }
+
+    Ok(mail_decoder::decode(&bytes)?)
+}
+
+fn observed_version(doc: &Document) -> ObservedVersion {
+    let metadata = doc.get_document("metadata").ok();
+    ObservedVersion {
+        checksum: metadata.and_then(|metadata| metadata.get("checksum")).cloned(),
+        size: metadata.and_then(|metadata| metadata.get("size")).cloned(),
+    }
 }
 
 fn normalize_root(value: &Value) -> Option<&Value> {
@@ -165,6 +284,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::storage::STATUS_PENDING;
 
     #[test]
     fn normalize_root_accepts_object() {
@@ -409,45 +529,257 @@ mod tests {
         ));
     }
 
+    fn raw_mail_from_bytes(bytes: &[u8]) -> RawMail {
+        RawMail {
+            id: ObjectId::new(),
+            mail_id: "mail-1".to_string(),
+            status: STATUS_PENDING.to_string(),
+            checksum: format!("{:x}", Sha256::digest(bytes)),
+            size: i64::try_from(bytes.len()).unwrap(),
+            algorithm: "zstd".to_string(),
+            binary: zstd::stream::encode_all(Cursor::new(bytes), 3).unwrap(),
+        }
+    }
+
+    fn raw_document() -> Document {
+        doc! {
+            "_id": ObjectId::new(),
+            "status": STATUS_PENDING,
+            "metadata": {
+                "checksum": "abc123",
+                "size": 3_i64,
+                "algo": "zstd",
+            },
+            "mail": {
+                "id": "mail-1",
+                "binary": Binary {
+                    subtype: BinarySubtype::Generic,
+                    bytes: vec![1, 2, 3],
+                }
+            }
+        }
+    }
+
     #[test]
-    fn decode_mail_value_roundtrip() {
-        let payload = json!({ "type": "Battle", "id": "mail-1" });
-        let json_bytes = serde_json::to_vec(&payload).unwrap();
-        let compressed = zstd::stream::encode_all(Cursor::new(json_bytes), 3).unwrap();
-        let decoded = decode_mail_value(&compressed).unwrap();
-        assert_eq!(decoded, payload);
+    fn decode_mail_binary_roundtrips_sample() {
+        let bytes = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../samples/Battle/Persistent.Mail.485440176891031331"
+        ));
+        let raw = raw_mail_from_bytes(bytes);
+        let decoded = decode_mail_binary(&raw, bytes.len()).unwrap();
+        assert_eq!(mail_registry::detect_mail_type(&decoded), Some(MailType::Battle));
+    }
+
+    #[test]
+    fn compressed_samples_run_through_every_registered_processor() {
+        let samples: &[(&[u8], MailType)] = &[
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Battle/Persistent.Mail.7948875176322794831"
+                )),
+                MailType::Battle,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/DuelBattle2/Persistent.Mail.4198599176618253831"
+                )),
+                MailType::DuelBattle2,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/BarCanyonKillBoss/Persistent.Mail.83062859177409782917"
+                )),
+                MailType::BarCanyonKillBoss,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/EventMemberLootReport/Persistent.Mail.28722408178369207531"
+                )),
+                MailType::EventMemberLootReport,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Rss/Persistent.Mail.118801516499340535"
+                )),
+                MailType::Rss,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/ScoutReport/Persistent.Mail.137024509177843958431"
+                )),
+                MailType::ScoutReport,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/System/Persistent.Mail.6603502177237171628"
+                )),
+                MailType::SystemBarbarianFort,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/System/Persistent.Mail.22165348178347040031"
+                )),
+                MailType::SystemKaharTreasure,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Alliance/Persistent.Mail.102185423177177256731"
+                )),
+                MailType::AllianceAOOBattleResults,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Alliance/Persistent.Mail.102185425177177256731"
+                )),
+                MailType::AllianceAOOBattleInfo,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Alliance/Persistent.Mail.102185429177177256731"
+                )),
+                MailType::AllianceAOOIndividualResults,
+            ),
+            (
+                include_bytes!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../../samples/Alliance/Persistent.Mail.108518435177768053226"
+                )),
+                MailType::AllianceAOORegistration,
+            ),
+        ];
+
+        for (bytes, expected_type) in samples {
+            let raw = raw_mail_from_bytes(bytes);
+            let (mail_type, processed) =
+                prepare_processed_document(&raw, bytes.len()).expect("process compressed sample");
+            assert_eq!(mail_type, *expected_type);
+            assert_eq!(
+                processed.get_document("metadata").unwrap().get_i64("source_size").unwrap(),
+                raw.size
+            );
+            let metadata = processed.get_document("metadata").unwrap();
+            assert_eq!(metadata.get_str("source_checksum").unwrap(), raw.checksum);
+            assert!(metadata.get_object_id("source_processor_run_id").is_ok());
+        }
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_unsupported_algorithm() {
+        let mut raw = raw_mail_from_bytes(b"anything");
+        raw.algorithm = "gzip".to_string();
+        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        assert!(matches!(error, ProcessorError::UnsupportedCompression(value) if value == "gzip"));
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_negative_size() {
+        let mut raw = raw_mail_from_bytes(b"anything");
+        raw.size = -1;
+        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        assert!(matches!(error, ProcessorError::InvalidSize(-1)));
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_oversized_mail() {
+        let raw = raw_mail_from_bytes(b"anything");
+        let error = decode_mail_binary(&raw, 7).unwrap_err();
+        assert!(matches!(error, ProcessorError::SizeLimitExceeded { size: 8, limit: 7 }));
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_size_mismatch() {
+        let mut raw = raw_mail_from_bytes(b"anything");
+        raw.size += 1;
+        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        assert!(matches!(error, ProcessorError::SizeMismatch { expected: 9, actual: 8 }));
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_checksum_mismatch() {
+        let mut raw = raw_mail_from_bytes(b"anything");
+        raw.checksum = "wrong".to_string();
+        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        assert!(
+            matches!(error, ProcessorError::ChecksumMismatch { expected, .. } if expected == "wrong")
+        );
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_corrupt_zstd() {
+        let mut raw = raw_mail_from_bytes(b"anything");
+        raw.binary = vec![1, 2, 3];
+        let error = decode_mail_binary(&raw, 100).unwrap_err();
+        assert!(matches!(error, ProcessorError::Decompress(_)));
+    }
+
+    #[test]
+    fn decode_mail_binary_rejects_invalid_binary_mail() {
+        let raw = raw_mail_from_bytes(&[]);
+        let error = decode_mail_binary(&raw, 1).unwrap_err();
+        assert!(matches!(error, ProcessorError::BinaryDecode(_)));
+    }
+
+    #[test]
+    fn prepare_processed_document_rejects_non_object_root() {
+        let raw = raw_mail_from_bytes(&[0x01, 1]);
+        let error = prepare_processed_document(&raw, 2).unwrap_err();
+        assert!(matches!(error, ProcessorError::InvalidMailPayload(_)));
     }
 
     #[test]
     fn parse_raw_mail_reads_fields() {
-        let id = ObjectId::new();
-        let doc = doc! {
-            "_id": id,
-            "mail_id": "mail-1",
-            "status": "pending",
-            "mail_value": Binary {
-                subtype: BinarySubtype::Generic,
-                bytes: vec![1, 2, 3],
-            }
-        };
-        let raw = parse_raw_mail(doc).unwrap();
+        let raw = parse_raw_mail(raw_document()).unwrap();
         assert_eq!(raw.mail_id, "mail-1");
         assert_eq!(raw.status, "pending");
-        assert_eq!(raw.mail_value, vec![1, 2, 3]);
+        assert_eq!(raw.checksum, "abc123");
+        assert_eq!(raw.size, 3);
+        assert_eq!(raw.algorithm, "zstd");
+        assert_eq!(raw.binary, vec![1, 2, 3]);
     }
 
     #[test]
     fn parse_raw_mail_requires_mail_id() {
-        let id = ObjectId::new();
-        let doc = doc! {
-            "_id": id,
-            "mail_value": Binary {
-                subtype: BinarySubtype::Generic,
-                bytes: vec![1, 2, 3],
-            }
-        };
+        let mut doc = raw_document();
+        doc.get_document_mut("mail").unwrap().remove("id");
         let err = parse_raw_mail(doc).unwrap_err();
-        assert!(matches!(err, ProcessorError::MissingField("mail_id")));
+        assert!(matches!(err, ProcessorError::MissingField("mail.id")));
+    }
+
+    #[test]
+    fn parse_raw_mail_requires_v2_metadata_fields_and_binary() {
+        let cases = [
+            ("metadata.checksum", "metadata", "checksum"),
+            ("metadata.size", "metadata", "size"),
+            ("metadata.algo", "metadata", "algo"),
+            ("mail.binary", "mail", "binary"),
+        ];
+
+        for (expected, section, field) in cases {
+            let mut doc = raw_document();
+            doc.get_document_mut(section).unwrap().remove(field);
+            let error = parse_raw_mail(doc).unwrap_err();
+            assert!(matches!(error, ProcessorError::MissingField(field) if field == expected));
+        }
+    }
+
+    #[test]
+    fn observed_version_preserves_exact_bson_values() {
+        let doc = doc! { "metadata": { "checksum": 7_i32, "size": "bad" } };
+        let observed = observed_version(&doc);
+        assert_eq!(observed.checksum, Some(Bson::Int32(7)));
+        assert_eq!(observed.size, Some(Bson::String("bad".to_string())));
     }
 
     #[test]

--- a/crates/services/rokbattles-processor/src/storage.rs
+++ b/crates/services/rokbattles-processor/src/storage.rs
@@ -3,7 +3,7 @@
 use mail_registry::MailType;
 use mongodb::{
     Collection, Cursor, IndexModel,
-    bson::{DateTime, Document, doc, oid::ObjectId},
+    bson::{Bson, DateTime, Document, doc, oid::ObjectId},
     options::{FindOptions, IndexOptions},
 };
 
@@ -34,7 +34,7 @@ impl Storage {
     /// Create storage helpers for the configured database.
     pub fn new(db: mongodb::Database) -> Self {
         Self {
-            raw: db.collection("mails_raw"),
+            raw: db.collection("g_rok_mails"),
             battle: db.collection(MailType::Battle.collection_name()),
             duelbattle2: db.collection(MailType::DuelBattle2.collection_name()),
             barcanyonkillboss: db.collection(MailType::BarCanyonKillBoss.collection_name()),
@@ -94,8 +94,10 @@ impl Storage {
         &self,
         mail_type: MailType,
         mail_id: &str,
+        source_checksum: &str,
+        source_size: i64,
         doc: Document,
-    ) -> mongodb::error::Result<()> {
+    ) -> mongodb::error::Result<bool> {
         let collection = match mail_type {
             MailType::Battle => &self.battle,
             MailType::DuelBattle2 => &self.duelbattle2,
@@ -111,15 +113,26 @@ impl Storage {
             MailType::ScoutReport => &self.scoutreport,
         };
 
-        collection.replace_one(doc! { "metadata.mail_id": mail_id }, doc).upsert(true).await?;
-        Ok(())
+        let update = processed_update_pipeline(source_checksum, source_size, doc);
+        let result = collection
+            .update_one(doc! { "metadata.mail_id": mail_id }, update)
+            .upsert(true)
+            .await?;
+        Ok(result.modified_count > 0 || result.upserted_id.is_some())
     }
 
-    /// Mark a raw mail as processed.
-    pub async fn mark_processed(&self, id: &ObjectId, now: DateTime) -> mongodb::error::Result<()> {
-        self.raw
+    /// Mark a raw mail version as processed if it is still current.
+    pub async fn mark_processed(
+        &self,
+        id: &ObjectId,
+        checksum: &str,
+        size: i64,
+        now: DateTime,
+    ) -> mongodb::error::Result<bool> {
+        let result = self
+            .raw
             .update_one(
-                doc! { "_id": id, "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] } },
+                current_version_filter(id, checksum, size),
                 doc! {
                     "$set": {
                         "status": STATUS_PROCESSED,
@@ -129,14 +142,21 @@ impl Storage {
                 },
             )
             .await?;
-        Ok(())
+        Ok(result.modified_count == 1)
     }
 
-    /// Mark a raw mail as failed to prevent indefinite retries.
-    pub async fn mark_error(&self, id: &ObjectId, now: DateTime) -> mongodb::error::Result<()> {
-        self.raw
+    /// Mark a raw mail as failed only if the observed source fields are unchanged.
+    pub async fn mark_error(
+        &self,
+        id: &ObjectId,
+        checksum: Option<&Bson>,
+        size: Option<&Bson>,
+        now: DateTime,
+    ) -> mongodb::error::Result<bool> {
+        let result = self
+            .raw
             .update_one(
-                doc! { "_id": id, "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] } },
+                observed_version_filter(id, checksum, size),
                 doc! {
                     "$set": {
                         "status": STATUS_ERROR,
@@ -145,7 +165,7 @@ impl Storage {
                 },
             )
             .await?;
-        Ok(())
+        Ok(result.modified_count == 1)
     }
 }
 
@@ -155,11 +175,72 @@ fn pending_find_options(batch_size: i64) -> FindOptions {
         .sort(doc! { "status": 1, "updatedAt": 1 })
         .projection(doc! {
             "_id": 1,
-            "mail_id": 1,
             "status": 1,
-            "mail_value": 1,
+            "metadata.checksum": 1,
+            "metadata.size": 1,
+            "metadata.algo": 1,
+            "mail.id": 1,
+            "mail.binary": 1,
         })
         .build()
+}
+
+fn current_version_filter(id: &ObjectId, checksum: &str, size: i64) -> Document {
+    doc! {
+        "_id": id,
+        "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] },
+        "metadata.checksum": checksum,
+        "metadata.size": size,
+    }
+}
+
+fn observed_version_filter(
+    id: &ObjectId,
+    checksum: Option<&Bson>,
+    size: Option<&Bson>,
+) -> Document {
+    let mut filter = doc! {
+        "_id": id,
+        "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] },
+    };
+    insert_observed_field(&mut filter, "metadata.checksum", checksum);
+    insert_observed_field(&mut filter, "metadata.size", size);
+    filter
+}
+
+fn insert_observed_field(filter: &mut Document, field: &str, value: Option<&Bson>) {
+    filter.insert(field, value.cloned().unwrap_or_else(|| doc! { "$exists": false }.into()));
+}
+
+fn processed_update_pipeline(
+    source_checksum: &str,
+    source_size: i64,
+    processed: Document,
+) -> Vec<Document> {
+    vec![doc! {
+        "$replaceWith": {
+            "$cond": {
+                "if": {
+                    "$or": [
+                        {
+                            "$lt": [
+                                { "$ifNull": ["$metadata.source_size", -1_i64] },
+                                source_size,
+                            ]
+                        },
+                        {
+                            "$and": [
+                                { "$eq": ["$metadata.source_size", source_size] },
+                                { "$eq": ["$metadata.source_checksum", source_checksum] },
+                            ]
+                        },
+                    ]
+                },
+                "then": { "$literal": Bson::Document(processed) },
+                "else": "$$ROOT",
+            }
+        }
+    }]
 }
 
 #[cfg(test)]
@@ -174,5 +255,73 @@ mod tests {
 
         assert_eq!(options.limit, Some(100));
         assert_eq!(options.sort, Some(doc! { "status": 1, "updatedAt": 1 }));
+    }
+
+    #[test]
+    fn current_version_filter_guards_checksum_and_size() {
+        let id = ObjectId::new();
+        let filter = current_version_filter(&id, "checksum", 42);
+        assert_eq!(
+            filter,
+            doc! {
+                "_id": id,
+                "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] },
+                "metadata.checksum": "checksum",
+                "metadata.size": 42_i64,
+            }
+        );
+    }
+
+    #[test]
+    fn observed_version_filter_matches_missing_fields_exactly() {
+        let id = ObjectId::new();
+        let filter = observed_version_filter(&id, None, None);
+        assert_eq!(
+            filter,
+            doc! {
+                "_id": id,
+                "status": { "$in": [STATUS_PENDING, STATUS_REPROCESS] },
+                "metadata.checksum": { "$exists": false },
+                "metadata.size": { "$exists": false },
+            }
+        );
+    }
+
+    #[test]
+    fn processed_update_pipeline_replaces_older_or_matching_output() {
+        let processed = doc! {
+            "metadata": {
+                "mail_id": "mail-1",
+                "source_size": 42_i64,
+            }
+        };
+        let pipeline = processed_update_pipeline("checksum", 42, processed.clone());
+        assert_eq!(
+            pipeline,
+            vec![doc! {
+                "$replaceWith": {
+                    "$cond": {
+                        "if": {
+                            "$or": [
+                                {
+                                    "$lt": [
+                                        { "$ifNull": ["$metadata.source_size", -1_i64] },
+                                        42_i64,
+                                    ]
+                                },
+                                {
+                                    "$and": [
+                                        { "$eq": ["$metadata.source_size", 42_i64] },
+                                        { "$eq": ["$metadata.source_checksum", "checksum"] },
+                                    ]
+                                },
+                            ]
+                        },
+                        "then": { "$literal": Bson::Document(processed) },
+                        "else": "$$ROOT",
+                    }
+                }
+            }]
+        );
     }
 }

--- a/crates/services/rokbattles-processor/src/storage.rs
+++ b/crates/services/rokbattles-processor/src/storage.rs
@@ -97,7 +97,7 @@ impl Storage {
         source_checksum: &str,
         source_size: i64,
         doc: Document,
-    ) -> mongodb::error::Result<bool> {
+    ) -> mongodb::error::Result<()> {
         let collection = match mail_type {
             MailType::Battle => &self.battle,
             MailType::DuelBattle2 => &self.duelbattle2,
@@ -114,11 +114,8 @@ impl Storage {
         };
 
         let update = processed_update_pipeline(source_checksum, source_size, doc);
-        let result = collection
-            .update_one(doc! { "metadata.mail_id": mail_id }, update)
-            .upsert(true)
-            .await?;
-        Ok(result.modified_count > 0 || result.upserted_id.is_some())
+        collection.update_one(doc! { "metadata.mail_id": mail_id }, update).upsert(true).await?;
+        Ok(())
     }
 
     /// Mark a raw mail version as processed if it is still current.


### PR DESCRIPTION
## Summary

- read compressed binary mails from g_rok_mails and run them through the decoder before the existing processors
- validate compression, decompressed size, checksum, and a configurable decompressed-size limit
- guard processed output and source status writes against stale workers
- exercise compressed samples for every registered processable mail type and malformed inputs

## Stack

Depends on #754.

## Validation

- cargo fmt --all -- --check
- cargo test -p rokbattles-processor (51 passed)
- cargo clippy -p rokbattles-processor --all-targets --locked -- -D warnings
- cargo llvm-cov -p rokbattles-processor
- git diff --check

Coverage: config 95.7%, processing 85.3%, storage 34.9%. MongoDB-bound constructor/index/query/write paths are the primary exception because this crate currently has no database integration-test harness.