### PR TITLE
refactor(storage): remove legacy mail source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,7 +4460,6 @@ version = "1.5.2"
 dependencies = [
  "axum",
  "bytes",
- "core-bson",
  "dotenvy",
  "flate2",
  "mail-decoder",

--- a/crates/services/rokbattles-ingress/Cargo.toml
+++ b/crates/services/rokbattles-ingress/Cargo.toml
@@ -11,7 +11,6 @@ flate2 = { workspace = true, default-features = false, features = ["zlib"] }
 mail-decoder = { path = "../../mail/decoder" }
 mail-registry = { path = "../../mail/registry" }
 mongodb = { workspace = true }
-core-bson = { path = "../../core/bson" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/services/rokbattles-ingress/src/config.rs
+++ b/crates/services/rokbattles-ingress/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub clamav_enabled: bool,
     pub clamav_addr: String,
     pub clamav_timeout_ms: u64,
-    pub raw_zstd_level: i32,
+    pub zstd_level: i32,
     pub max_upload_bytes: usize,
 }
 
@@ -41,7 +41,7 @@ impl Config {
         let clamav_addr = lookup("CLAMAV_ADDR").unwrap_or_else(|| "127.0.0.1:3310".to_string());
         let clamav_timeout_ms =
             parse_u64("CLAMAV_TIMEOUT_MS", lookup("CLAMAV_TIMEOUT_MS"), 15_000)?;
-        let raw_zstd_level = parse_i32("RAW_ZSTD_LEVEL", lookup("RAW_ZSTD_LEVEL"), 6)?;
+        let zstd_level = parse_i32("ZSTD_LEVEL", lookup("ZSTD_LEVEL"), 6)?;
         let max_upload_bytes =
             parse_usize("MAX_UPLOAD_BYTES", lookup("MAX_UPLOAD_BYTES"), 25 * 1024 * 1024)?;
 
@@ -52,7 +52,7 @@ impl Config {
             clamav_enabled,
             clamav_addr,
             clamav_timeout_ms,
-            raw_zstd_level,
+            zstd_level,
             max_upload_bytes,
         })
     }
@@ -132,7 +132,7 @@ mod tests {
                 clamav_enabled: false,
                 clamav_addr: "127.0.0.1:3310".to_string(),
                 clamav_timeout_ms: 15_000,
-                raw_zstd_level: 6,
+                zstd_level: 6,
                 max_upload_bytes: 25 * 1024 * 1024,
             }
         );
@@ -156,13 +156,13 @@ mod tests {
     }
 
     #[test]
-    fn loads_raw_zstd_level() {
+    fn loads_zstd_level() {
         let cfg = Config::from_lookup(lookup(HashMap::from([
             ("MONGODB_URI", "mongodb://localhost:27017/rokbattles"),
-            ("RAW_ZSTD_LEVEL", "8"),
+            ("ZSTD_LEVEL", "8"),
         ])))
         .expect("config");
 
-        assert_eq!(cfg.raw_zstd_level, 8);
+        assert_eq!(cfg.zstd_level, 8);
     }
 }

--- a/crates/services/rokbattles-ingress/src/config.rs
+++ b/crates/services/rokbattles-ingress/src/config.rs
@@ -11,7 +11,6 @@ pub struct Config {
     pub clamav_enabled: bool,
     pub clamav_addr: String,
     pub clamav_timeout_ms: u64,
-    pub zstd_level: i32,
     pub raw_zstd_level: i32,
     pub max_upload_bytes: usize,
 }
@@ -42,7 +41,6 @@ impl Config {
         let clamav_addr = lookup("CLAMAV_ADDR").unwrap_or_else(|| "127.0.0.1:3310".to_string());
         let clamav_timeout_ms =
             parse_u64("CLAMAV_TIMEOUT_MS", lookup("CLAMAV_TIMEOUT_MS"), 15_000)?;
-        let zstd_level = parse_i32("ZSTD_LEVEL", lookup("ZSTD_LEVEL"), 3)?;
         let raw_zstd_level = parse_i32("RAW_ZSTD_LEVEL", lookup("RAW_ZSTD_LEVEL"), 6)?;
         let max_upload_bytes =
             parse_usize("MAX_UPLOAD_BYTES", lookup("MAX_UPLOAD_BYTES"), 25 * 1024 * 1024)?;
@@ -54,7 +52,6 @@ impl Config {
             clamav_enabled,
             clamav_addr,
             clamav_timeout_ms,
-            zstd_level,
             raw_zstd_level,
             max_upload_bytes,
         })
@@ -135,7 +132,6 @@ mod tests {
                 clamav_enabled: false,
                 clamav_addr: "127.0.0.1:3310".to_string(),
                 clamav_timeout_ms: 15_000,
-                zstd_level: 3,
                 raw_zstd_level: 6,
                 max_upload_bytes: 25 * 1024 * 1024,
             }

--- a/crates/services/rokbattles-ingress/src/handlers.rs
+++ b/crates/services/rokbattles-ingress/src/handlers.rs
@@ -1,4 +1,4 @@
-use std::{io::Cursor, sync::Arc};
+use std::sync::Arc;
 
 use axum::{
     Json,
@@ -8,7 +8,7 @@ use axum::{
 };
 use bytes::Bytes;
 use mail_registry::{is_processable_mail_type, is_supported_mail_type};
-use mongodb::bson::{Binary, Bson, DateTime, doc, spec::BinarySubtype};
+use mongodb::bson::DateTime;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -29,7 +29,6 @@ pub struct UploadResponse {
     status: String,
     mail_id: String,
     mail_type: String,
-    mail_attack_count: i64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -91,62 +90,9 @@ pub async fn upload(
         )));
     }
 
-    store_compressed_raw_mail(&state, &buffer, &decoded, &mail_id, &mail_type, &user_agent).await?;
-
-    let attack_count = count_attacks(&decoded) as i64;
-
-    let existing = state
-        .storage
-        .find_existing(&mail_id)
-        .await
-        .map_err(|error| ApiError::database(error.to_string()))?;
-
-    let action = decide_action(existing.as_ref().map(|entry| entry.attack_count), attack_count);
-
-    if matches!(action, UploadAction::Insert | UploadAction::Update) {
-        let compressed = compress_mail_value(&decoded, state.config.zstd_level)?;
-        let now = DateTime::now();
-
-        match action {
-            UploadAction::Insert => {
-                let raw_doc = doc! {
-                    "mail_id": &mail_id,
-                    "mail_attack_count": attack_count,
-                    "user_agent": &user_agent,
-                    "status": insert_status_for_mail_type(&mail_type),
-                    "mail_value": Bson::Binary(Binary {
-                        subtype: BinarySubtype::Generic,
-                        bytes: compressed,
-                    }),
-                    "createdAt": now,
-                    "updatedAt": now,
-                };
-                state
-                    .storage
-                    .insert_raw(raw_doc)
-                    .await
-                    .map_err(|error| ApiError::database(error.to_string()))?;
-            }
-            UploadAction::Update => {
-                let raw_update = doc! {
-                    "mail_attack_count": attack_count,
-                    "user_agent": &user_agent,
-                    "status": update_status_for_mail_type(&mail_type),
-                    "mail_value": Bson::Binary(Binary {
-                        subtype: BinarySubtype::Generic,
-                        bytes: compressed,
-                    }),
-                    "updatedAt": now,
-                };
-                state
-                    .storage
-                    .update_raw(&mail_id, raw_update)
-                    .await
-                    .map_err(|error| ApiError::database(error.to_string()))?;
-            }
-            UploadAction::Skip => {}
-        }
-    }
+    let action =
+        store_compressed_raw_mail(&state, &buffer, &decoded, &mail_id, &mail_type, &user_agent)
+            .await?;
 
     let (status, label) = match action {
         UploadAction::Insert => (StatusCode::CREATED, "stored"),
@@ -154,12 +100,7 @@ pub async fn upload(
         UploadAction::Skip => (StatusCode::OK, "skipped"),
     };
 
-    let response = UploadResponse {
-        status: label.to_string(),
-        mail_id,
-        mail_type,
-        mail_attack_count: attack_count,
-    };
+    let response = UploadResponse { status: label.to_string(), mail_id, mail_type };
 
     Ok((status, Json(response)))
 }
@@ -171,7 +112,7 @@ async fn store_compressed_raw_mail(
     mail_id: &str,
     mail_type: &str,
     user_agent: &str,
-) -> Result<(), ApiError> {
+) -> Result<UploadAction, ApiError> {
     let checksum = raw_mail::sha256_hex(buffer);
     let binary_size = i64::try_from(buffer.len())
         .map_err(|_| ApiError::internal("mail binary is too large to store size"))?;
@@ -184,7 +125,7 @@ async fn store_compressed_raw_mail(
     let action = decide_compressed_raw_action(existing.as_ref(), &checksum, buffer.len());
 
     if matches!(action, UploadAction::Skip) {
-        return Ok(());
+        return Ok(action);
     }
 
     let mail = raw_mail::extract_raw_mail_metadata(decoded)?;
@@ -217,7 +158,7 @@ async fn store_compressed_raw_mail(
         UploadAction::Skip => {}
     }
 
-    Ok(())
+    Ok(action)
 }
 
 /// Acknowledge legacy TCP stream uploads without storing or validating them.
@@ -389,18 +330,6 @@ fn is_probably_json(bytes: &[u8]) -> bool {
     trimmed.starts_with('{') || trimmed.starts_with('[')
 }
 
-fn count_attacks(value: &Value) -> usize {
-    find_attacks_object(value).map_or(0, |attacks| attacks.len())
-}
-
-fn decide_action(existing_attack_count: Option<i64>, attack_count: i64) -> UploadAction {
-    match existing_attack_count {
-        None => UploadAction::Insert,
-        Some(existing) if attack_count > existing => UploadAction::Update,
-        Some(_) => UploadAction::Skip,
-    }
-}
-
 fn decide_compressed_raw_action(
     existing: Option<&crate::storage::ExistingCompressedRawMail>,
     checksum: &str,
@@ -414,31 +343,6 @@ fn decide_compressed_raw_action(
         }
         Some(_) => UploadAction::Skip,
     }
-}
-
-fn find_attacks_object(value: &Value) -> Option<&serde_json::Map<String, Value>> {
-    match value {
-        Value::Object(map) => {
-            if let Some(Value::Object(attacks)) = map.get("Attacks") {
-                return Some(attacks);
-            }
-            for entry in map.values() {
-                if let Some(found) = find_attacks_object(entry) {
-                    return Some(found);
-                }
-            }
-            None
-        }
-        Value::Array(values) => values.iter().find_map(find_attacks_object),
-        _ => None,
-    }
-}
-
-fn compress_mail_value(decoded: &Value, zstd_level: i32) -> Result<Vec<u8>, ApiError> {
-    let json =
-        serde_json::to_vec(decoded).map_err(|error| ApiError::internal(error.to_string()))?;
-    zstd::stream::encode_all(Cursor::new(json), zstd_level)
-        .map_err(|error| ApiError::internal(error.to_string()))
 }
 
 #[cfg(test)]
@@ -695,38 +599,6 @@ mod tests {
     fn extracts_mail_id_from_metadata() {
         let decoded = json!({ "metadata": { "mail_id": "meta-1" } });
         assert_eq!(extract_mail_id(&decoded).as_deref(), Some("meta-1"));
-    }
-
-    #[test]
-    fn counts_attacks_nested() {
-        let decoded = json!({
-            "body": {
-                "content": {
-                    "Attacks": {
-                        "a": { "id": 1 },
-                        "b": { "id": 2 },
-                        "c": { "id": 3 }
-                    }
-                }
-            }
-        });
-        assert_eq!(count_attacks(&decoded), 3);
-    }
-
-    #[test]
-    fn decide_action_inserts_when_missing() {
-        assert!(matches!(decide_action(None, 4), UploadAction::Insert));
-    }
-
-    #[test]
-    fn decide_action_updates_when_newer() {
-        assert!(matches!(decide_action(Some(2), 4), UploadAction::Update));
-    }
-
-    #[test]
-    fn decide_action_skips_when_not_newer() {
-        assert!(matches!(decide_action(Some(5), 4), UploadAction::Skip));
-        assert!(matches!(decide_action(Some(4), 4), UploadAction::Skip));
     }
 
     fn existing_compressed_raw(

--- a/crates/services/rokbattles-ingress/src/handlers.rs
+++ b/crates/services/rokbattles-ingress/src/handlers.rs
@@ -141,7 +141,7 @@ async fn store_compressed_raw_mail(
         mail: &mail,
         status,
         now: DateTime::now(),
-        zstd_level: state.config.raw_zstd_level,
+        zstd_level: state.config.zstd_level,
     })?;
 
     match action {

--- a/crates/services/rokbattles-ingress/src/storage.rs
+++ b/crates/services/rokbattles-ingress/src/storage.rs
@@ -1,6 +1,5 @@
 //! MongoDB access for raw mail uploads.
 
-use core_bson::bson_to_i64;
 use mongodb::{
     Collection, IndexModel,
     bson::{Bson, Document, doc},
@@ -10,14 +9,7 @@ use mongodb::{
 /// Ingress collections used by upload handlers.
 #[derive(Debug, Clone)]
 pub struct Storage {
-    raw: Collection<Document>,
     compressed_raw: Collection<Document>,
-}
-
-/// Mail metadata needed to decide whether an upload is newer.
-#[derive(Debug, Clone, Copy)]
-pub struct ExistingMail {
-    pub attack_count: i64,
 }
 
 /// V2 raw binary mail metadata needed to decide whether an upload is larger.
@@ -30,48 +22,13 @@ pub struct ExistingCompressedRawMail {
 impl Storage {
     /// Bind storage helpers to the configured database.
     pub fn new(db: mongodb::Database) -> Self {
-        Self { raw: db.collection("mails_raw"), compressed_raw: db.collection("g_rok_mails") }
+        Self { compressed_raw: db.collection("g_rok_mails") }
     }
 
     /// Create indexes used by the upload paths.
     pub async fn ensure_indexes(&self) -> mongodb::error::Result<()> {
-        let mail_id_index = IndexModel::builder()
-            .keys(doc! { "mail_id": 1 })
-            .options(IndexOptions::builder().unique(true).build())
-            .build();
+        self.compressed_raw.create_index(source_mail_id_index()).await?;
 
-        self.raw.create_index(mail_id_index).await?;
-
-        let compressed_mail_id_index = IndexModel::builder()
-            .keys(doc! { "mail.id": 1 })
-            .options(IndexOptions::builder().unique(true).build())
-            .build();
-        let compressed_checksum_index =
-            IndexModel::builder().keys(doc! { "metadata.checksum": 1 }).build();
-
-        self.compressed_raw.create_index(compressed_mail_id_index).await?;
-        self.compressed_raw.create_index(compressed_checksum_index).await?;
-
-        Ok(())
-    }
-
-    /// Load existing mail metadata, if this mail was already uploaded.
-    pub async fn find_existing(
-        &self,
-        mail_id: &str,
-    ) -> mongodb::error::Result<Option<ExistingMail>> {
-        let filter = doc! { "mail_id": mail_id };
-        let doc = self
-            .raw
-            .find_one(filter)
-            .projection(doc! { "mail_attack_count": 1, "createdAt": 1 })
-            .await?;
-        Ok(doc.and_then(parse_existing))
-    }
-
-    /// Insert a new raw mail document.
-    pub async fn insert_raw(&self, doc: Document) -> mongodb::error::Result<()> {
-        self.raw.insert_one(doc).await?;
         Ok(())
     }
 
@@ -107,17 +64,13 @@ impl Storage {
         self.compressed_raw.update_one(filter, doc! { "$set": doc }).await?;
         Ok(())
     }
-
-    /// Update an existing raw mail document.
-    pub async fn update_raw(&self, mail_id: &str, update: Document) -> mongodb::error::Result<()> {
-        self.raw.update_one(doc! { "mail_id": mail_id }, doc! { "$set": update }).await?;
-        Ok(())
-    }
 }
 
-fn parse_existing(doc: Document) -> Option<ExistingMail> {
-    let attack_count = doc.get("mail_attack_count").and_then(bson_to_i64).unwrap_or(0);
-    Some(ExistingMail { attack_count })
+fn source_mail_id_index() -> IndexModel {
+    IndexModel::builder()
+        .keys(doc! { "mail.id": 1 })
+        .options(IndexOptions::builder().unique(true).build())
+        .build()
 }
 
 fn parse_existing_compressed_raw(doc: Document) -> Option<ExistingCompressedRawMail> {
@@ -148,13 +101,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_existing_mail() {
-        let doc = doc! {
-            "mail_attack_count": 7,
-            "createdAt": mongodb::bson::DateTime::now(),
-        };
-        let existing = parse_existing(doc).expect("existing mail");
-        assert_eq!(existing.attack_count, 7);
+    fn source_mail_id_index_is_unique() {
+        let index = source_mail_id_index();
+        assert_eq!(index.keys, doc! { "mail.id": 1 });
+        assert_eq!(index.options.and_then(|options| options.unique), Some(true));
     }
 
     #[test]
@@ -197,12 +147,5 @@ mod tests {
                 "metadata.size": { "$lt": 100_i64 },
             }
         );
-    }
-
-    #[test]
-    fn bson_to_i64_handles_numeric_variants() {
-        assert_eq!(bson_to_i64(&Bson::Int32(5)), Some(5));
-        assert_eq!(bson_to_i64(&Bson::Int64(12)), Some(12));
-        assert_eq!(bson_to_i64(&Bson::Double(3.7)), Some(3));
     }
 }

--- a/crates/services/rokbattles-processor/src/storage.rs
+++ b/crates/services/rokbattles-processor/src/storage.rs
@@ -56,13 +56,9 @@ impl Storage {
 
     /// Ensure required indexes exist.
     pub async fn ensure_indexes(&self) -> mongodb::error::Result<()> {
-        let status_index = IndexModel::builder().keys(doc! { "status": 1, "updatedAt": 1 }).build();
-        self.raw.create_index(status_index).await?;
+        self.raw.create_index(source_queue_index()).await?;
 
-        let mail_id_index = IndexModel::builder()
-            .keys(doc! { "metadata.mail_id": 1 })
-            .options(IndexOptions::builder().unique(true).build())
-            .build();
+        let mail_id_index = processed_mail_id_index();
         self.battle.create_index(mail_id_index.clone()).await?;
         self.duelbattle2.create_index(mail_id_index.clone()).await?;
         self.barcanyonkillboss.create_index(mail_id_index.clone()).await?;
@@ -166,6 +162,17 @@ impl Storage {
     }
 }
 
+fn source_queue_index() -> IndexModel {
+    IndexModel::builder().keys(doc! { "status": 1, "updatedAt": 1 }).build()
+}
+
+fn processed_mail_id_index() -> IndexModel {
+    IndexModel::builder()
+        .keys(doc! { "metadata.mail_id": 1 })
+        .options(IndexOptions::builder().unique(true).build())
+        .build()
+}
+
 fn pending_find_options(batch_size: i64) -> FindOptions {
     FindOptions::builder()
         .limit(batch_size)
@@ -243,6 +250,18 @@ fn processed_update_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn source_queue_index_matches_pending_query_and_sort() {
+        assert_eq!(source_queue_index().keys, doc! { "status": 1, "updatedAt": 1 });
+    }
+
+    #[test]
+    fn processed_mail_id_index_is_unique() {
+        let index = processed_mail_id_index();
+        assert_eq!(index.keys, doc! { "metadata.mail_id": 1 });
+        assert_eq!(index.options.and_then(|options| options.unique), Some(true));
+    }
 
     #[test]
     fn pending_mail_is_sorted_before_reprocess_mail() {


### PR DESCRIPTION
## Summary

- make g_rok_mails the only ingress mail write target
- remove the mails_raw lookup, insert, update, JSON recompression, attack counting, and legacy compression configuration
- derive upload response status from the v2 insert/update/skip decision
- retain and test the query-backed indexes: unique mail.id and processor status + updatedAt
- stop creating the unused metadata.checksum index and all legacy collection indexes

## Stack

Depends on #755, which depends on #754.

## Query and index audit

- ingress find/update operations filter by mail.id and use the unique mail.id index
- processor queue reads filter/sort by status and updatedAt and use the compound status + updatedAt index
- checksum is only validated after document retrieval, so its standalone index had no supporting query
- repository-wide search finds no remaining mails_raw, mail_value, mail_attack_count, or legacy storage method references

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo llvm-cov -p rokbattles-ingress -p rokbattles-processor
- git diff --check

Coverage remains below 100% primarily at Axum/MongoDB-bound handler and storage methods without an integration-test harness. Pure index builders and decision logic are directly tested.