### PR TITLE
feat(mail): extract battle player sessions

### DIFF
--- a/crates/mail/processors/battle/src/opponents.rs
+++ b/crates/mail/processors/battle/src/opponents.rs
@@ -775,6 +775,20 @@ mod tests {
     }
 
     #[test]
+    fn opponents_extractor_reads_session_from_sample() {
+        let sample_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../samples/Battle/Persistent.Mail.16210617176935008431.json");
+        let json = fs::read_to_string(sample_path).expect("read sample");
+        let value: Value = serde_json::from_str(&json).expect("parse sample");
+        let extractor = OpponentsExtractor::new();
+
+        let section = extractor.extract(&value).expect("extract sample");
+        let opponents = section.array().expect("opponents array");
+
+        assert_eq!(opponents[0]["session"], json!("cfg_id=4&id=3538&mode=ab&role_id=113&submode="));
+    }
+
+    #[test]
     fn roundtrip_opponents_allows_negative_player_id() {
         let sample_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../../../samples/Battle/Persistent.Mail.1409019176893142331.json");

--- a/crates/mail/processors/battle/src/player.rs
+++ b/crates/mail/processors/battle/src/player.rs
@@ -59,9 +59,8 @@ pub(crate) fn extract_player_fields(
     let (app_id, app_uid) = extract_app_identity(player)?;
     let server_season = optional_string_field(player, "SerSeason")?;
     let package_identifier = optional_string_field(player, "PkgNameNew")?;
-    // Alliance battlefield types: 1 normal, 2 practice, 3 league, 4 invitation,
-    // 5 custom, 6 silver, and 7 tutorial.
     let as_battle_type = optional_u64_field(player, "AsBattleType")?;
+    let session = optional_string_field(player, "Session")?;
     let (avatar_url, frame_url) = parse_avatar(player)?;
     let supreme_strife = extract_supreme_strife(player)?;
 
@@ -111,6 +110,7 @@ pub(crate) fn extract_player_fields(
         "as_battle_type".to_string(),
         as_battle_type.map(Value::from).unwrap_or(Value::Null),
     );
+    fields.insert("session".to_string(), session.map(Value::String).unwrap_or(Value::Null));
     fields.insert("avatar_url".to_string(), avatar_url);
     fields.insert("frame_url".to_string(), frame_url);
     fields.insert("supreme_strife".to_string(), supreme_strife);
@@ -615,6 +615,29 @@ mod tests {
         let fields = extract_player_fields(&base_player()).unwrap();
 
         assert_eq!(fields["as_battle_type"], Value::Null);
+    }
+
+    #[test]
+    fn extract_player_fields_preserves_battle_session() {
+        let mut player = base_player();
+        player.insert(
+            "Session".to_string(),
+            json!("cfg_id=6&id=1953&mode=ab&role_id=120&submode=SilverEgypt"),
+        );
+
+        let fields = extract_player_fields(&player).unwrap();
+
+        assert_eq!(
+            fields["session"],
+            json!("cfg_id=6&id=1953&mode=ab&role_id=120&submode=SilverEgypt")
+        );
+    }
+
+    #[test]
+    fn extract_player_fields_uses_null_when_session_is_absent() {
+        let fields = extract_player_fields(&base_player()).unwrap();
+
+        assert_eq!(fields["session"], Value::Null);
     }
 
     #[test]

--- a/crates/mail/processors/battle/src/sender.rs
+++ b/crates/mail/processors/battle/src/sender.rs
@@ -63,6 +63,13 @@ mod tests {
         serde_json::from_str(&json).expect("parse sample")
     }
 
+    fn load_session_sample() -> Value {
+        let sample_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../samples/Battle/Persistent.Mail.16210617176935008431.json");
+        let json = fs::read_to_string(sample_path).expect("read sample");
+        serde_json::from_str(&json).expect("parse sample")
+    }
+
     #[test]
     fn sender_extractor_reads_basic_fields() {
         let input = json!({
@@ -171,6 +178,19 @@ mod tests {
         assert_eq!(
             section.fields()["auxiliary_skills"],
             json!([{ "hero_id": 141, "level": 5, "skill_id": 1420 }])
+        );
+    }
+
+    #[test]
+    fn sender_extractor_reads_session_from_sample() {
+        let input = load_session_sample();
+        let extractor = SenderExtractor::new();
+
+        let section = extractor.extract(&input).unwrap();
+
+        assert_eq!(
+            section.fields()["session"],
+            json!("cfg_id=4&id=3538&mode=ab&role_id=113&submode=")
         );
     }
 

--- a/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
+++ b/samples/Battle/Persistent.Mail.1002579517552941234-processed.json
@@ -190,6 +190,7 @@
       "player_name": "xAvarice",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 312472,
       "structure_id": null,
       "support_skills": {
@@ -333,6 +334,7 @@
     "player_name": "F7yst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
+++ b/samples/Battle/Persistent.Mail.100439187175234501131-processed.json
@@ -197,6 +197,7 @@
       "player_name": "Kung Fu Tsar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -410,6 +411,7 @@
       "player_name": "Kung Fu Tsar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -619,6 +621,7 @@
       "player_name": "Kung Fu Tsar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -832,6 +835,7 @@
       "player_name": "Kung Fu Tsar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 109500,
       "structure_id": null,
       "support_skills": {
@@ -1041,6 +1045,7 @@
       "player_name": "Kung Fu Tsar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 109507,
       "structure_id": null,
       "support_skills": {
@@ -1542,6 +1547,7 @@
       "player_name": "西伯利亞狼",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 109490,
       "structure_id": null,
       "support_skills": {
@@ -1772,6 +1778,7 @@
     "player_name": "agent G",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
+++ b/samples/Battle/Persistent.Mail.10121648172261838131-processed.json
@@ -201,6 +201,7 @@
       "player_name": "KanomTᵒᵐ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120717,
       "structure_id": null,
       "support_skills": {
@@ -936,6 +937,7 @@
       "player_name": "SOMTAM Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120689,
       "structure_id": null,
       "support_skills": {
@@ -1473,6 +1475,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120793,
       "structure_id": null,
       "support_skills": {
@@ -1682,6 +1685,7 @@
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -1895,6 +1899,7 @@
       "player_name": "KanomPᵃⁿᵍ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2104,6 +2109,7 @@
       "player_name": "Mr Jeep",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120719,
       "structure_id": null,
       "support_skills": {
@@ -2317,6 +2323,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -2530,6 +2537,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -2747,6 +2755,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120705,
       "structure_id": null,
       "support_skills": {
@@ -2941,6 +2950,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120704,
       "structure_id": null,
       "support_skills": {
@@ -3154,6 +3164,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120701,
       "structure_id": null,
       "support_skills": {
@@ -3367,6 +3378,7 @@
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3580,6 +3592,7 @@
       "player_name": "sɪɢᴍᴀ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -3797,6 +3810,7 @@
       "player_name": "亗SlamDawg",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120712,
       "structure_id": null,
       "support_skills": {
@@ -4006,6 +4020,7 @@
       "player_name": "亗SlamDawg",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120709,
       "structure_id": null,
       "support_skills": {
@@ -4219,6 +4234,7 @@
       "player_name": "亗SlamDawg",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120707,
       "structure_id": null,
       "support_skills": {
@@ -4432,6 +4448,7 @@
       "player_name": "亗SlamDawg",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120711,
       "structure_id": null,
       "support_skills": {
@@ -4645,6 +4662,7 @@
       "player_name": "Mr nuer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -4858,6 +4876,7 @@
       "player_name": "Mr nuer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120769,
       "structure_id": null,
       "support_skills": {
@@ -5071,6 +5090,7 @@
       "player_name": "OmOshi Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120702,
       "structure_id": null,
       "support_skills": {
@@ -5273,6 +5293,7 @@
       "player_name": "Niezy Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120783,
       "structure_id": null,
       "support_skills": {
@@ -5486,6 +5507,7 @@
       "player_name": "Niezy Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120777,
       "structure_id": null,
       "support_skills": {
@@ -5699,6 +5721,7 @@
       "player_name": "Niezy Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120767,
       "structure_id": null,
       "support_skills": {
@@ -5904,6 +5927,7 @@
       "player_name": "Niezy Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6117,6 +6141,7 @@
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120781,
       "structure_id": null,
       "support_skills": {
@@ -6326,6 +6351,7 @@
       "player_name": "ﾐ Lemon Mini",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -6539,6 +6565,7 @@
       "player_name": "ﾐ Lemon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -6752,6 +6779,7 @@
       "player_name": "Niezy Miller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120779,
       "structure_id": null,
       "support_skills": {
@@ -6961,6 +6989,7 @@
       "player_name": "ﾐ Lemon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7174,6 +7203,7 @@
       "player_name": "ﾐ Lemon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -7387,6 +7417,7 @@
       "player_name": "ﾐ Lemon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120800,
       "structure_id": null,
       "support_skills": {
@@ -7600,6 +7631,7 @@
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120790,
       "structure_id": null,
       "support_skills": {
@@ -7817,6 +7849,7 @@
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120787,
       "structure_id": null,
       "support_skills": {
@@ -8030,6 +8063,7 @@
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120788,
       "structure_id": null,
       "support_skills": {
@@ -8239,6 +8273,7 @@
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120789,
       "structure_id": null,
       "support_skills": {
@@ -8452,6 +8487,7 @@
       "player_name": "ᵀᴳﾒTHE HULK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 120786,
       "structure_id": null,
       "support_skills": {
@@ -8930,6 +8966,7 @@
     "player_name": "비아티나",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
+++ b/samples/Battle/Persistent.Mail.10163399175529366525-processed.json
@@ -166,6 +166,7 @@
       "player_name": "F4 Benbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 312015,
       "structure_id": null,
       "support_skills": {
@@ -284,6 +285,7 @@
     "player_name": "F6yst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
+++ b/samples/Battle/Persistent.Mail.10200933177249262113-processed.json
@@ -219,6 +219,7 @@
       "player_name": "Raha ツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 315491,
       "structure_id": null,
       "support_skills": {
@@ -568,6 +569,7 @@
     "player_name": "jën x ƒaräɀ",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
+++ b/samples/Battle/Persistent.Mail.10224136175529255431-processed.json
@@ -197,6 +197,7 @@
       "player_name": "ˢNinoveraptor",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -395,6 +396,7 @@
       "player_name": "ˢNinoveraptor",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 310841,
       "structure_id": null,
       "support_skills": {
@@ -538,6 +540,7 @@
     "player_name": "Griggasaurus",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
+++ b/samples/Battle/Persistent.Mail.1036544617552967227-processed.json
@@ -166,6 +166,7 @@
       "player_name": "F4 Benbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 315072,
       "structure_id": null,
       "support_skills": {
@@ -284,6 +285,7 @@
     "player_name": "F12yst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
+++ b/samples/Battle/Persistent.Mail.1036588117552967397-processed.json
@@ -166,6 +166,7 @@
       "player_name": "F4 Benbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 315089,
       "structure_id": null,
       "support_skills": {
@@ -284,6 +285,7 @@
     "player_name": "F12yst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
+++ b/samples/Battle/Persistent.Mail.1036600917552967417-processed.json
@@ -166,6 +166,7 @@
       "player_name": "F4 Benbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 315091,
       "structure_id": null,
       "support_skills": {
@@ -284,6 +285,7 @@
     "player_name": "F12yst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
+++ b/samples/Battle/Persistent.Mail.104653012170810554331-processed.json
@@ -485,6 +485,7 @@
       "player_name": "ミ K H A L I D",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505754,
       "structure_id": null,
       "support_skills": {
@@ -679,6 +680,7 @@
       "player_name": "Dzin Wielki",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -873,6 +875,7 @@
       "player_name": "Dzin Wielki",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1075,6 +1078,7 @@
       "player_name": "Dzin Wielki",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -1277,6 +1281,7 @@
       "player_name": "Dzin Wielki",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -1471,6 +1476,7 @@
       "player_name": "Dzin Wielki",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505876,
       "structure_id": null,
       "support_skills": {
@@ -1669,6 +1675,7 @@
       "player_name": "ミ Solgaleo ミ",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505790,
       "structure_id": null,
       "support_skills": {
@@ -1867,6 +1874,7 @@
       "player_name": "bedebuh",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505772,
       "structure_id": null,
       "support_skills": {
@@ -2065,6 +2073,7 @@
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505817,
       "structure_id": null,
       "support_skills": {
@@ -2259,6 +2268,7 @@
       "player_name": "Nicossss",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -2457,6 +2467,7 @@
       "player_name": "ᴰᶰ SmeeR",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505840,
       "structure_id": null,
       "support_skills": {
@@ -2663,6 +2674,7 @@
       "player_name": "Lelouchhシ",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505811,
       "structure_id": null,
       "support_skills": {
@@ -2865,6 +2877,7 @@
       "player_name": "香水じゅん",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505799,
       "structure_id": null,
       "support_skills": {
@@ -3063,6 +3076,7 @@
       "player_name": "TANSAA",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505823,
       "structure_id": null,
       "support_skills": {
@@ -3261,6 +3275,7 @@
       "player_name": "ヅYusekeᵀᴴ",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505835,
       "structure_id": null,
       "support_skills": {
@@ -3455,6 +3470,7 @@
       "player_name": "TANSAA",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505786,
       "structure_id": null,
       "support_skills": {
@@ -3653,6 +3669,7 @@
       "player_name": "ExCalìbur",
       "rally": null,
       "server_season": "3",
+      "session": null,
       "start_tick": 1505848,
       "structure_id": null,
       "support_skills": {
@@ -4124,6 +4141,7 @@
     "player_name": "ᵀᴼバニー",
     "rally": true,
     "server_season": "3",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
+++ b/samples/Battle/Persistent.Mail.106171761165497242010-processed.json
@@ -1094,6 +1094,7 @@
       "player_name": "Ni丶大佑",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962476,
       "structure_id": null,
       "support_skills": {
@@ -1275,6 +1276,7 @@
       "player_name": "Ni 丶毒城",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962493,
       "structure_id": null,
       "support_skills": {
@@ -1448,6 +1450,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1629,6 +1632,7 @@
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962507,
       "structure_id": null,
       "support_skills": {
@@ -1810,6 +1814,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -1970,6 +1975,7 @@
       "player_name": "不放大極靈",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962521,
       "structure_id": null,
       "support_skills": {
@@ -2147,6 +2153,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -2320,6 +2327,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962529,
       "structure_id": null,
       "support_skills": {
@@ -2501,6 +2509,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2678,6 +2687,7 @@
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962545,
       "structure_id": null,
       "support_skills": {
@@ -2859,6 +2869,7 @@
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962553,
       "structure_id": null,
       "support_skills": {
@@ -3036,6 +3047,7 @@
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962574,
       "structure_id": null,
       "support_skills": {
@@ -3209,6 +3221,7 @@
       "player_name": "慈雲山GAng",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962588,
       "structure_id": null,
       "support_skills": {
@@ -3386,6 +3399,7 @@
       "player_name": "慈雲山GAng",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962595,
       "structure_id": null,
       "support_skills": {
@@ -3567,6 +3581,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -3748,6 +3763,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962603,
       "structure_id": null,
       "support_skills": {
@@ -3933,6 +3949,7 @@
       "player_name": "冇運餅ᴮᴹ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962610,
       "structure_id": null,
       "support_skills": {
@@ -4110,6 +4127,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962624,
       "structure_id": null,
       "support_skills": {
@@ -4287,6 +4305,7 @@
       "player_name": "慈雲山GAng",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4468,6 +4487,7 @@
       "player_name": "相思鸟",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962638,
       "structure_id": null,
       "support_skills": {
@@ -4649,6 +4669,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962652,
       "structure_id": null,
       "support_skills": {
@@ -4822,6 +4843,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962666,
       "structure_id": null,
       "support_skills": {
@@ -4999,6 +5021,7 @@
       "player_name": "300丶mit90109",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962680,
       "structure_id": null,
       "support_skills": {
@@ -5172,6 +5195,7 @@
       "player_name": "Ni Ball Master",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -5349,6 +5373,7 @@
       "player_name": "相思鸟",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962694,
       "structure_id": null,
       "support_skills": {
@@ -5530,6 +5555,7 @@
       "player_name": "Ni丶20低調",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962701,
       "structure_id": null,
       "support_skills": {
@@ -5707,6 +5733,7 @@
       "player_name": "Ni任ส幹ฟ",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 962761,
       "structure_id": null,
       "support_skills": {
@@ -6347,6 +6374,7 @@
     "player_name": "GRRRRRRREAT",
     "rally": true,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
+++ b/samples/Battle/Persistent.Mail.1409019176893142331-processed.json
@@ -159,6 +159,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 35058,
       "structure_id": null,
       "support_skills": {
@@ -293,6 +294,7 @@
     "player_name": "Grigvar",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
+++ b/samples/Battle/Persistent.Mail.152526555167004536031-processed.json
@@ -194,6 +194,7 @@
       "player_name": "Queen SammyJo",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1378409,
       "structure_id": null,
       "support_skills": {
@@ -496,6 +497,7 @@
     "player_name": "Grigvar",
     "rally": true,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
+++ b/samples/Battle/Persistent.Mail.16125090175544125330-processed.json
@@ -201,6 +201,7 @@
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 458684,
       "structure_id": null,
       "support_skills": {
@@ -410,6 +411,7 @@
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 458683,
       "structure_id": null,
       "support_skills": {
@@ -623,6 +625,7 @@
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 458697,
       "structure_id": null,
       "support_skills": {
@@ -836,6 +839,7 @@
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1045,6 +1049,7 @@
       "player_name": "SnaiL蝸牛 ぴっぴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 458696,
       "structure_id": null,
       "support_skills": {
@@ -1203,6 +1208,7 @@
     "player_name": "Viatina乂Fayst",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
+++ b/samples/Battle/Persistent.Mail.16210617176935008431-processed.json
@@ -273,6 +273,7 @@
       "player_name": "TEDDY916",
       "rally": true,
       "server_season": "-1",
+      "session": "cfg_id=4&id=3538&mode=ab&role_id=113&submode=",
       "start_tick": 444,
       "structure_id": null,
       "support_skills": {
@@ -474,6 +475,7 @@
     "player_name": "ˢ vashido",
     "rally": null,
     "server_season": "-1",
+    "session": "cfg_id=4&id=3538&mode=ab&role_id=113&submode=",
     "structure_id": 109,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
+++ b/samples/Battle/Persistent.Mail.18895907175034307923-processed.json
@@ -9057,6 +9057,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627430,
       "structure_id": null,
       "support_skills": {
@@ -9270,6 +9271,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627539,
       "structure_id": null,
       "support_skills": {
@@ -9482,6 +9484,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627514,
       "structure_id": null,
       "support_skills": {
@@ -9692,6 +9695,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627557,
       "structure_id": null,
       "support_skills": {
@@ -9884,6 +9888,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627614,
       "structure_id": null,
       "support_skills": {
@@ -10086,6 +10091,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10288,6 +10294,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627653,
       "structure_id": null,
       "support_skills": {
@@ -10490,6 +10497,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627671,
       "structure_id": null,
       "support_skills": {
@@ -10654,6 +10662,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -10864,6 +10873,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627713,
       "structure_id": null,
       "support_skills": {
@@ -11040,6 +11050,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627730,
       "structure_id": null,
       "support_skills": {
@@ -11205,6 +11216,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627732,
       "structure_id": null,
       "support_skills": {
@@ -11407,6 +11419,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627738,
       "structure_id": null,
       "support_skills": {
@@ -11616,6 +11629,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627769,
       "structure_id": null,
       "support_skills": {
@@ -11820,6 +11834,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627772,
       "structure_id": null,
       "support_skills": {
@@ -12018,6 +12033,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627789,
       "structure_id": null,
       "support_skills": {
@@ -12218,6 +12234,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627827,
       "structure_id": null,
       "support_skills": {
@@ -12416,6 +12433,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627830,
       "structure_id": null,
       "support_skills": {
@@ -12624,6 +12642,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627831,
       "structure_id": null,
       "support_skills": {
@@ -12822,6 +12841,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627836,
       "structure_id": null,
       "support_skills": {
@@ -13003,6 +13023,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627850,
       "structure_id": null,
       "support_skills": {
@@ -13205,6 +13226,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627856,
       "structure_id": null,
       "support_skills": {
@@ -13407,6 +13429,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627860,
       "structure_id": null,
       "support_skills": {
@@ -13624,6 +13647,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627862,
       "structure_id": null,
       "support_skills": {
@@ -13822,6 +13846,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627876,
       "structure_id": null,
       "support_skills": {
@@ -14030,6 +14055,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627882,
       "structure_id": null,
       "support_skills": {
@@ -14247,6 +14273,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627884,
       "structure_id": null,
       "support_skills": {
@@ -14449,6 +14476,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627907,
       "structure_id": null,
       "support_skills": {
@@ -14666,6 +14694,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627910,
       "structure_id": null,
       "support_skills": {
@@ -14868,6 +14897,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -15084,6 +15114,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627930,
       "structure_id": null,
       "support_skills": {
@@ -15289,6 +15320,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627950,
       "structure_id": null,
       "support_skills": {
@@ -15491,6 +15523,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627954,
       "structure_id": null,
       "support_skills": {
@@ -15708,6 +15741,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627956,
       "structure_id": null,
       "support_skills": {
@@ -15906,6 +15940,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627982,
       "structure_id": null,
       "support_skills": {
@@ -16108,6 +16143,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627978,
       "structure_id": null,
       "support_skills": {
@@ -16325,6 +16361,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627981,
       "structure_id": null,
       "support_skills": {
@@ -16527,6 +16564,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 627986,
       "structure_id": null,
       "support_skills": {
@@ -16729,6 +16767,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628001,
       "structure_id": null,
       "support_skills": {
@@ -16946,6 +16985,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628004,
       "structure_id": null,
       "support_skills": {
@@ -17148,6 +17188,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628024,
       "structure_id": null,
       "support_skills": {
@@ -17365,6 +17406,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628027,
       "structure_id": null,
       "support_skills": {
@@ -17526,6 +17568,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628028,
       "structure_id": null,
       "support_skills": {
@@ -17674,6 +17717,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628032,
       "structure_id": null,
       "support_skills": {
@@ -17876,6 +17920,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628034,
       "structure_id": null,
       "support_skills": {
@@ -18070,6 +18115,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628038,
       "structure_id": null,
       "support_skills": {
@@ -18272,6 +18318,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628071,
       "structure_id": null,
       "support_skills": {
@@ -18489,6 +18536,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628073,
       "structure_id": null,
       "support_skills": {
@@ -18691,6 +18739,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628096,
       "structure_id": null,
       "support_skills": {
@@ -18908,6 +18957,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628098,
       "structure_id": null,
       "support_skills": {
@@ -19102,6 +19152,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19300,6 +19351,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628105,
       "structure_id": null,
       "support_skills": {
@@ -19444,6 +19496,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628113,
       "structure_id": null,
       "support_skills": {
@@ -19642,6 +19695,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628114,
       "structure_id": null,
       "support_skills": {
@@ -19821,6 +19875,7 @@
       "player_name": "Ral farm B",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -20019,6 +20074,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628115,
       "structure_id": null,
       "support_skills": {
@@ -20196,6 +20252,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20402,6 +20459,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628117,
       "structure_id": null,
       "support_skills": {
@@ -20583,6 +20641,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628118,
       "structure_id": null,
       "support_skills": {
@@ -20785,6 +20844,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628120,
       "structure_id": null,
       "support_skills": {
@@ -20983,6 +21043,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628123,
       "structure_id": null,
       "support_skills": {
@@ -21187,6 +21248,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628130,
       "structure_id": null,
       "support_skills": {
@@ -21395,6 +21457,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628136,
       "structure_id": null,
       "support_skills": {
@@ -21738,6 +21801,7 @@
       "player_name": "Wongington",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 628199,
       "structure_id": null,
       "support_skills": {
@@ -21905,6 +21969,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628168,
       "structure_id": null,
       "support_skills": {
@@ -22103,6 +22168,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628173,
       "structure_id": null,
       "support_skills": {
@@ -22311,6 +22377,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628175,
       "structure_id": null,
       "support_skills": {
@@ -22528,6 +22595,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628178,
       "structure_id": null,
       "support_skills": {
@@ -22730,6 +22798,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628181,
       "structure_id": null,
       "support_skills": {
@@ -22928,6 +22997,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628184,
       "structure_id": null,
       "support_skills": {
@@ -23132,6 +23202,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628204,
       "structure_id": null,
       "support_skills": {
@@ -23340,6 +23411,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628206,
       "structure_id": null,
       "support_skills": {
@@ -23549,6 +23621,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23755,6 +23828,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628209,
       "structure_id": null,
       "support_skills": {
@@ -23957,6 +24031,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628212,
       "structure_id": null,
       "support_skills": {
@@ -24155,6 +24230,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628215,
       "structure_id": null,
       "support_skills": {
@@ -24355,6 +24431,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628224,
       "structure_id": null,
       "support_skills": {
@@ -24563,6 +24640,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628226,
       "structure_id": null,
       "support_skills": {
@@ -24765,6 +24843,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -24965,6 +25044,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628234,
       "structure_id": null,
       "support_skills": {
@@ -25163,6 +25243,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628249,
       "structure_id": null,
       "support_skills": {
@@ -25371,6 +25452,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628251,
       "structure_id": null,
       "support_skills": {
@@ -25588,6 +25670,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628254,
       "structure_id": null,
       "support_skills": {
@@ -25790,6 +25873,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628257,
       "structure_id": null,
       "support_skills": {
@@ -25988,6 +26072,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628260,
       "structure_id": null,
       "support_skills": {
@@ -26154,6 +26239,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628270,
       "structure_id": null,
       "support_skills": {
@@ -26352,6 +26438,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628274,
       "structure_id": null,
       "support_skills": {
@@ -26556,6 +26643,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628275,
       "structure_id": null,
       "support_skills": {
@@ -26760,6 +26848,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628276,
       "structure_id": null,
       "support_skills": {
@@ -26969,6 +27058,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628278,
       "structure_id": null,
       "support_skills": {
@@ -27173,6 +27263,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628288,
       "structure_id": null,
       "support_skills": {
@@ -27371,6 +27462,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628312,
       "structure_id": null,
       "support_skills": {
@@ -27579,6 +27671,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628315,
       "structure_id": null,
       "support_skills": {
@@ -27796,6 +27889,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628318,
       "structure_id": null,
       "support_skills": {
@@ -27998,6 +28092,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628321,
       "structure_id": null,
       "support_skills": {
@@ -28196,6 +28291,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628324,
       "structure_id": null,
       "support_skills": {
@@ -28400,6 +28496,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628342,
       "structure_id": null,
       "support_skills": {
@@ -28598,6 +28695,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628346,
       "structure_id": null,
       "support_skills": {
@@ -28806,6 +28904,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628348,
       "structure_id": null,
       "support_skills": {
@@ -29023,6 +29122,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628351,
       "structure_id": null,
       "support_skills": {
@@ -29225,6 +29325,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628354,
       "structure_id": null,
       "support_skills": {
@@ -29423,6 +29524,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628357,
       "structure_id": null,
       "support_skills": {
@@ -29627,6 +29729,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628393,
       "structure_id": null,
       "support_skills": {
@@ -29835,6 +29938,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628396,
       "structure_id": null,
       "support_skills": {
@@ -30052,6 +30156,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628399,
       "structure_id": null,
       "support_skills": {
@@ -30225,6 +30330,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30427,6 +30533,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628402,
       "structure_id": null,
       "support_skills": {
@@ -30625,6 +30732,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628405,
       "structure_id": null,
       "support_skills": {
@@ -30792,6 +30900,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628406,
       "structure_id": null,
       "support_skills": {
@@ -30973,6 +31082,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628431,
       "structure_id": null,
       "support_skills": {
@@ -31171,6 +31281,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628459,
       "structure_id": null,
       "support_skills": {
@@ -31325,6 +31436,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628461,
       "structure_id": null,
       "support_skills": {
@@ -31527,6 +31639,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628471,
       "structure_id": null,
       "support_skills": {
@@ -31699,6 +31812,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628472,
       "structure_id": null,
       "support_skills": {
@@ -31905,6 +32019,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628473,
       "structure_id": null,
       "support_skills": {
@@ -32107,6 +32222,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628476,
       "structure_id": null,
       "support_skills": {
@@ -32305,6 +32421,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628479,
       "structure_id": null,
       "support_skills": {
@@ -32492,6 +32609,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32686,6 +32804,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628490,
       "structure_id": null,
       "support_skills": {
@@ -32888,6 +33007,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628504,
       "structure_id": null,
       "support_skills": {
@@ -33105,6 +33225,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628507,
       "structure_id": null,
       "support_skills": {
@@ -33307,6 +33428,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628510,
       "structure_id": null,
       "support_skills": {
@@ -33505,6 +33627,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628513,
       "structure_id": null,
       "support_skills": {
@@ -33861,6 +33984,7 @@
       "player_name": "Wongington",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 628560,
       "structure_id": null,
       "support_skills": {
@@ -34074,6 +34198,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628532,
       "structure_id": null,
       "support_skills": {
@@ -34291,6 +34416,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628535,
       "structure_id": null,
       "support_skills": {
@@ -34468,6 +34594,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628536,
       "structure_id": null,
       "support_skills": {
@@ -34670,6 +34797,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628538,
       "structure_id": null,
       "support_skills": {
@@ -34868,6 +34996,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628541,
       "structure_id": null,
       "support_skills": {
@@ -35055,6 +35184,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628581,
       "structure_id": null,
       "support_skills": {
@@ -35257,6 +35387,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628590,
       "structure_id": null,
       "support_skills": {
@@ -35474,6 +35605,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628592,
       "structure_id": null,
       "support_skills": {
@@ -35676,6 +35808,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628595,
       "structure_id": null,
       "support_skills": {
@@ -35874,6 +36007,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628598,
       "structure_id": null,
       "support_skills": {
@@ -36082,6 +36216,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628639,
       "structure_id": null,
       "support_skills": {
@@ -36299,6 +36434,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628641,
       "structure_id": null,
       "support_skills": {
@@ -36455,6 +36591,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628642,
       "structure_id": null,
       "support_skills": {
@@ -36657,6 +36794,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628644,
       "structure_id": null,
       "support_skills": {
@@ -36855,6 +36993,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628647,
       "structure_id": null,
       "support_skills": {
@@ -37055,6 +37194,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628660,
       "structure_id": null,
       "support_skills": {
@@ -37253,6 +37393,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628693,
       "structure_id": null,
       "support_skills": {
@@ -37451,6 +37592,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628694,
       "structure_id": null,
       "support_skills": {
@@ -37659,6 +37801,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628697,
       "structure_id": null,
       "support_skills": {
@@ -37876,6 +38019,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628700,
       "structure_id": null,
       "support_skills": {
@@ -38078,6 +38222,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628703,
       "structure_id": null,
       "support_skills": {
@@ -38276,6 +38421,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628706,
       "structure_id": null,
       "support_skills": {
@@ -38443,6 +38589,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628725,
       "structure_id": null,
       "support_skills": {
@@ -38641,6 +38788,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628751,
       "structure_id": null,
       "support_skills": {
@@ -38849,6 +38997,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628753,
       "structure_id": null,
       "support_skills": {
@@ -39051,6 +39200,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628754,
       "structure_id": null,
       "support_skills": {
@@ -39268,6 +39418,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628757,
       "structure_id": null,
       "support_skills": {
@@ -39466,6 +39617,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628759,
       "structure_id": null,
       "support_skills": {
@@ -39668,6 +39820,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628760,
       "structure_id": null,
       "support_skills": {
@@ -39866,6 +40019,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628763,
       "structure_id": null,
       "support_skills": {
@@ -40070,6 +40224,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628776,
       "structure_id": null,
       "support_skills": {
@@ -40278,6 +40433,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628779,
       "structure_id": null,
       "support_skills": {
@@ -40495,6 +40651,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628782,
       "structure_id": null,
       "support_skills": {
@@ -40693,6 +40850,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628785,
       "structure_id": null,
       "support_skills": {
@@ -40880,6 +41038,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628828,
       "structure_id": null,
       "support_skills": {
@@ -41078,6 +41237,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628829,
       "structure_id": null,
       "support_skills": {
@@ -41286,6 +41446,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628831,
       "structure_id": null,
       "support_skills": {
@@ -41491,6 +41652,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628832,
       "structure_id": null,
       "support_skills": {
@@ -41672,6 +41834,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -41878,6 +42041,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628834,
       "structure_id": null,
       "support_skills": {
@@ -42080,6 +42244,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628837,
       "structure_id": null,
       "support_skills": {
@@ -42244,6 +42409,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628838,
       "structure_id": null,
       "support_skills": {
@@ -42417,6 +42583,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42615,6 +42782,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628840,
       "structure_id": null,
       "support_skills": {
@@ -42823,6 +42991,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628850,
       "structure_id": null,
       "support_skills": {
@@ -43027,6 +43196,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628855,
       "structure_id": null,
       "support_skills": {
@@ -43235,6 +43405,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628857,
       "structure_id": null,
       "support_skills": {
@@ -43452,6 +43623,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628860,
       "structure_id": null,
       "support_skills": {
@@ -43654,6 +43826,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628868,
       "structure_id": null,
       "support_skills": {
@@ -43974,6 +44147,7 @@
       "player_name": "Wongington",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 628908,
       "structure_id": null,
       "support_skills": {
@@ -44187,6 +44361,7 @@
       "player_name": "ᴸᴸ Handy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628878,
       "structure_id": null,
       "support_skills": {
@@ -44389,6 +44564,7 @@
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628886,
       "structure_id": null,
       "support_skills": {
@@ -44593,6 +44769,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628897,
       "structure_id": null,
       "support_skills": {
@@ -44801,6 +44978,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628900,
       "structure_id": null,
       "support_skills": {
@@ -45018,6 +45196,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628903,
       "structure_id": null,
       "support_skills": {
@@ -45220,6 +45399,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628906,
       "structure_id": null,
       "support_skills": {
@@ -45418,6 +45598,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628909,
       "structure_id": null,
       "support_skills": {
@@ -45601,6 +45782,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628915,
       "structure_id": null,
       "support_skills": {
@@ -45805,6 +45987,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628922,
       "structure_id": null,
       "support_skills": {
@@ -46003,6 +46186,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628933,
       "structure_id": null,
       "support_skills": {
@@ -46211,6 +46395,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628935,
       "structure_id": null,
       "support_skills": {
@@ -46428,6 +46613,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628938,
       "structure_id": null,
       "support_skills": {
@@ -46630,6 +46816,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628941,
       "structure_id": null,
       "support_skills": {
@@ -46828,6 +47015,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628944,
       "structure_id": null,
       "support_skills": {
@@ -46994,6 +47182,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628969,
       "structure_id": null,
       "support_skills": {
@@ -47188,6 +47377,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628973,
       "structure_id": null,
       "support_skills": {
@@ -47386,6 +47576,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628981,
       "structure_id": null,
       "support_skills": {
@@ -47594,6 +47785,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628983,
       "structure_id": null,
       "support_skills": {
@@ -47811,6 +48003,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628986,
       "structure_id": null,
       "support_skills": {
@@ -48013,6 +48206,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628989,
       "structure_id": null,
       "support_skills": {
@@ -48211,6 +48405,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628992,
       "structure_id": null,
       "support_skills": {
@@ -48415,6 +48610,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 628993,
       "structure_id": null,
       "support_skills": {
@@ -48609,6 +48805,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629009,
       "structure_id": null,
       "support_skills": {
@@ -48815,6 +49012,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629011,
       "structure_id": null,
       "support_skills": {
@@ -49021,6 +49219,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629035,
       "structure_id": null,
       "support_skills": {
@@ -49230,6 +49429,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629032,
       "structure_id": null,
       "support_skills": {
@@ -49438,6 +49638,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629033,
       "structure_id": null,
       "support_skills": {
@@ -49655,6 +49856,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629037,
       "structure_id": null,
       "support_skills": {
@@ -49857,6 +50059,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629040,
       "structure_id": null,
       "support_skills": {
@@ -50055,6 +50258,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629043,
       "structure_id": null,
       "support_skills": {
@@ -50259,6 +50463,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629053,
       "structure_id": null,
       "support_skills": {
@@ -50471,6 +50676,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629055,
       "structure_id": null,
       "support_skills": {
@@ -50669,6 +50875,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629068,
       "structure_id": null,
       "support_skills": {
@@ -50867,6 +51074,7 @@
       "player_name": "wzz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629072,
       "structure_id": null,
       "support_skills": {
@@ -51071,6 +51279,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629085,
       "structure_id": null,
       "support_skills": {
@@ -51279,6 +51488,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629087,
       "structure_id": null,
       "support_skills": {
@@ -51496,6 +51706,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629090,
       "structure_id": null,
       "support_skills": {
@@ -51698,6 +51909,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629093,
       "structure_id": null,
       "support_skills": {
@@ -51896,6 +52108,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629096,
       "structure_id": null,
       "support_skills": {
@@ -52100,6 +52313,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629108,
       "structure_id": null,
       "support_skills": {
@@ -52308,6 +52522,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629110,
       "structure_id": null,
       "support_skills": {
@@ -52525,6 +52740,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629113,
       "structure_id": null,
       "support_skills": {
@@ -52723,6 +52939,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629116,
       "structure_id": null,
       "support_skills": {
@@ -52894,6 +53111,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -53088,6 +53306,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629134,
       "structure_id": null,
       "support_skills": {
@@ -53290,6 +53509,7 @@
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -53490,6 +53710,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -53655,6 +53876,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629140,
       "structure_id": null,
       "support_skills": {
@@ -53828,6 +54050,7 @@
       "player_name": "Ral farm B",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629142,
       "structure_id": null,
       "support_skills": {
@@ -54022,6 +54245,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629149,
       "structure_id": null,
       "support_skills": {
@@ -54220,6 +54444,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629159,
       "structure_id": null,
       "support_skills": {
@@ -54428,6 +54653,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629162,
       "structure_id": null,
       "support_skills": {
@@ -54645,6 +54871,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629165,
       "structure_id": null,
       "support_skills": {
@@ -54847,6 +55074,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629168,
       "structure_id": null,
       "support_skills": {
@@ -55045,6 +55273,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629170,
       "structure_id": null,
       "support_skills": {
@@ -55459,6 +55688,7 @@
       "player_name": "wzz",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 629221,
       "structure_id": null,
       "support_skills": {
@@ -55664,6 +55894,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -55858,6 +56089,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -56060,6 +56292,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629178,
       "structure_id": null,
       "support_skills": {
@@ -56258,6 +56491,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629188,
       "structure_id": null,
       "support_skills": {
@@ -56456,6 +56690,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629189,
       "structure_id": null,
       "support_skills": {
@@ -56643,6 +56878,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629190,
       "structure_id": null,
       "support_skills": {
@@ -56845,6 +57081,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629192,
       "structure_id": null,
       "support_skills": {
@@ -57062,6 +57299,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629194,
       "structure_id": null,
       "support_skills": {
@@ -57264,6 +57502,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629198,
       "structure_id": null,
       "support_skills": {
@@ -57462,6 +57701,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629201,
       "structure_id": null,
       "support_skills": {
@@ -57670,6 +57910,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629211,
       "structure_id": null,
       "support_skills": {
@@ -57872,6 +58113,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629219,
       "structure_id": null,
       "support_skills": {
@@ -58078,6 +58320,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629236,
       "structure_id": null,
       "support_skills": {
@@ -58276,6 +58519,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629238,
       "structure_id": null,
       "support_skills": {
@@ -58480,6 +58724,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -58688,6 +58933,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629240,
       "structure_id": null,
       "support_skills": {
@@ -58905,6 +59151,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629243,
       "structure_id": null,
       "support_skills": {
@@ -59086,6 +59333,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629245,
       "structure_id": null,
       "support_skills": {
@@ -59294,6 +59542,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629246,
       "structure_id": null,
       "support_skills": {
@@ -59492,6 +59741,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629249,
       "structure_id": null,
       "support_skills": {
@@ -59696,6 +59946,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629267,
       "structure_id": null,
       "support_skills": {
@@ -59904,6 +60155,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629269,
       "structure_id": null,
       "support_skills": {
@@ -60121,6 +60373,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629272,
       "structure_id": null,
       "support_skills": {
@@ -60323,6 +60576,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629275,
       "structure_id": null,
       "support_skills": {
@@ -60521,6 +60775,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629278,
       "structure_id": null,
       "support_skills": {
@@ -60725,6 +60980,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629287,
       "structure_id": null,
       "support_skills": {
@@ -60923,6 +61179,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629295,
       "structure_id": null,
       "support_skills": {
@@ -61121,6 +61378,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629318,
       "structure_id": null,
       "support_skills": {
@@ -61329,6 +61587,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629321,
       "structure_id": null,
       "support_skills": {
@@ -61546,6 +61805,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629323,
       "structure_id": null,
       "support_skills": {
@@ -61748,6 +62008,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629327,
       "structure_id": null,
       "support_skills": {
@@ -61946,6 +62207,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629330,
       "structure_id": null,
       "support_skills": {
@@ -62133,6 +62395,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629335,
       "structure_id": null,
       "support_skills": {
@@ -62331,6 +62594,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629341,
       "structure_id": null,
       "support_skills": {
@@ -62539,6 +62803,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629343,
       "structure_id": null,
       "support_skills": {
@@ -62756,6 +63021,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -62950,6 +63216,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629346,
       "structure_id": null,
       "support_skills": {
@@ -63144,6 +63411,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629348,
       "structure_id": null,
       "support_skills": {
@@ -63346,6 +63614,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629349,
       "structure_id": null,
       "support_skills": {
@@ -63544,6 +63813,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629352,
       "structure_id": null,
       "support_skills": {
@@ -63748,6 +64018,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629358,
       "structure_id": null,
       "support_skills": {
@@ -63921,6 +64192,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629390,
       "structure_id": null,
       "support_skills": {
@@ -64119,6 +64391,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629395,
       "structure_id": null,
       "support_skills": {
@@ -64327,6 +64600,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629398,
       "structure_id": null,
       "support_skills": {
@@ -64536,6 +64810,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -64742,6 +65017,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629401,
       "structure_id": null,
       "support_skills": {
@@ -64944,6 +65220,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629416,
       "structure_id": null,
       "support_skills": {
@@ -65149,6 +65426,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629402,
       "structure_id": null,
       "support_skills": {
@@ -65351,6 +65629,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629404,
       "structure_id": null,
       "support_skills": {
@@ -65549,6 +65828,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629407,
       "structure_id": null,
       "support_skills": {
@@ -65753,6 +66033,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629423,
       "structure_id": null,
       "support_skills": {
@@ -65961,6 +66242,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629425,
       "structure_id": null,
       "support_skills": {
@@ -66170,6 +66452,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629427,
       "structure_id": null,
       "support_skills": {
@@ -66376,6 +66659,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629428,
       "structure_id": null,
       "support_skills": {
@@ -66532,6 +66816,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629430,
       "structure_id": null,
       "support_skills": {
@@ -66734,6 +67019,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629431,
       "structure_id": null,
       "support_skills": {
@@ -66932,6 +67218,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629434,
       "structure_id": null,
       "support_skills": {
@@ -67111,6 +67398,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -67317,6 +67605,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -67493,6 +67782,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629457,
       "structure_id": null,
       "support_skills": {
@@ -67674,6 +67964,7 @@
       "player_name": "EidensDonkey",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629459,
       "structure_id": null,
       "support_skills": {
@@ -67876,6 +68167,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629463,
       "structure_id": null,
       "support_skills": {
@@ -68074,6 +68366,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629480,
       "structure_id": null,
       "support_skills": {
@@ -68282,6 +68575,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629482,
       "structure_id": null,
       "support_skills": {
@@ -68499,6 +68793,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629485,
       "structure_id": null,
       "support_skills": {
@@ -68701,6 +68996,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629488,
       "structure_id": null,
       "support_skills": {
@@ -68899,6 +69195,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629491,
       "structure_id": null,
       "support_skills": {
@@ -69053,6 +69350,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629498,
       "structure_id": null,
       "support_skills": {
@@ -69255,6 +69553,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -69457,6 +69756,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629502,
       "structure_id": null,
       "support_skills": {
@@ -69659,6 +69959,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629504,
       "structure_id": null,
       "support_skills": {
@@ -69823,6 +70124,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629510,
       "structure_id": null,
       "support_skills": {
@@ -70004,6 +70306,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629529,
       "structure_id": null,
       "support_skills": {
@@ -70202,6 +70505,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629533,
       "structure_id": null,
       "support_skills": {
@@ -70400,6 +70704,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629547,
       "structure_id": null,
       "support_skills": {
@@ -70608,6 +70913,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629549,
       "structure_id": null,
       "support_skills": {
@@ -72125,6 +72431,7 @@
       "player_name": "wzz",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 629595,
       "structure_id": null,
       "support_skills": {
@@ -72342,6 +72649,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629552,
       "structure_id": null,
       "support_skills": {
@@ -72544,6 +72852,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629555,
       "structure_id": null,
       "support_skills": {
@@ -72742,6 +73051,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629557,
       "structure_id": null,
       "support_skills": {
@@ -72946,6 +73256,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629571,
       "structure_id": null,
       "support_skills": {
@@ -73154,6 +73465,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629573,
       "structure_id": null,
       "support_skills": {
@@ -73346,6 +73658,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629583,
       "structure_id": null,
       "support_skills": {
@@ -73552,6 +73865,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629576,
       "structure_id": null,
       "support_skills": {
@@ -73754,6 +74068,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629579,
       "structure_id": null,
       "support_skills": {
@@ -73952,6 +74267,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629582,
       "structure_id": null,
       "support_skills": {
@@ -74156,6 +74472,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629605,
       "structure_id": null,
       "support_skills": {
@@ -74369,6 +74686,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629611,
       "structure_id": null,
       "support_skills": {
@@ -74546,6 +74864,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629617,
       "structure_id": null,
       "support_skills": {
@@ -74750,6 +75069,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629619,
       "structure_id": null,
       "support_skills": {
@@ -74959,6 +75279,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629622,
       "structure_id": null,
       "support_skills": {
@@ -75167,6 +75488,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629623,
       "structure_id": null,
       "support_skills": {
@@ -75369,6 +75691,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629624,
       "structure_id": null,
       "support_skills": {
@@ -75582,6 +75905,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -75794,6 +76118,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629627,
       "structure_id": null,
       "support_skills": {
@@ -75996,6 +76321,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629628,
       "structure_id": null,
       "support_skills": {
@@ -76204,6 +76530,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629630,
       "structure_id": null,
       "support_skills": {
@@ -76402,6 +76729,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629633,
       "structure_id": null,
       "support_skills": {
@@ -76610,6 +76938,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629634,
       "structure_id": null,
       "support_skills": {
@@ -76816,6 +77145,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629636,
       "structure_id": null,
       "support_skills": {
@@ -77018,6 +77348,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629642,
       "structure_id": null,
       "support_skills": {
@@ -77216,6 +77547,7 @@
       "player_name": "SleepyシEmre",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629648,
       "structure_id": null,
       "support_skills": {
@@ -77420,6 +77752,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -77618,6 +77951,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629649,
       "structure_id": null,
       "support_skills": {
@@ -77826,6 +78160,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629651,
       "structure_id": null,
       "support_skills": {
@@ -78043,6 +78378,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629654,
       "structure_id": null,
       "support_skills": {
@@ -78245,6 +78581,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629657,
       "structure_id": null,
       "support_skills": {
@@ -78439,6 +78776,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629658,
       "structure_id": null,
       "support_skills": {
@@ -78637,6 +78975,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629660,
       "structure_id": null,
       "support_skills": {
@@ -78824,6 +79163,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629667,
       "structure_id": null,
       "support_skills": {
@@ -79022,6 +79362,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -79231,6 +79572,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629679,
       "structure_id": null,
       "support_skills": {
@@ -79412,6 +79754,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -79595,6 +79938,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -79803,6 +80147,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629690,
       "structure_id": null,
       "support_skills": {
@@ -80001,6 +80346,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629692,
       "structure_id": null,
       "support_skills": {
@@ -80209,6 +80555,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629703,
       "structure_id": null,
       "support_skills": {
@@ -80411,6 +80758,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629707,
       "structure_id": null,
       "support_skills": {
@@ -80613,6 +80961,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629712,
       "structure_id": null,
       "support_skills": {
@@ -80811,6 +81160,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629713,
       "structure_id": null,
       "support_skills": {
@@ -81019,6 +81369,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629715,
       "structure_id": null,
       "support_skills": {
@@ -81236,6 +81587,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629718,
       "structure_id": null,
       "support_skills": {
@@ -81434,6 +81786,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629721,
       "structure_id": null,
       "support_skills": {
@@ -81638,6 +81991,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629729,
       "structure_id": null,
       "support_skills": {
@@ -81840,6 +82194,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -82046,6 +82401,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629741,
       "structure_id": null,
       "support_skills": {
@@ -82240,6 +82596,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629743,
       "structure_id": null,
       "support_skills": {
@@ -82442,6 +82799,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -82636,6 +82994,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -82813,6 +83172,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629753,
       "structure_id": null,
       "support_skills": {
@@ -82986,6 +83346,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629755,
       "structure_id": null,
       "support_skills": {
@@ -83180,6 +83541,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -83382,6 +83744,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -83580,6 +83943,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629759,
       "structure_id": null,
       "support_skills": {
@@ -83793,6 +84157,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629766,
       "structure_id": null,
       "support_skills": {
@@ -84009,6 +84374,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629770,
       "structure_id": null,
       "support_skills": {
@@ -84213,6 +84579,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629772,
       "structure_id": null,
       "support_skills": {
@@ -84411,6 +84778,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629778,
       "structure_id": null,
       "support_skills": {
@@ -84609,6 +84977,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629790,
       "structure_id": null,
       "support_skills": {
@@ -84822,6 +85191,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -85016,6 +85386,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629794,
       "structure_id": null,
       "support_skills": {
@@ -85220,6 +85591,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629799,
       "structure_id": null,
       "support_skills": {
@@ -85380,6 +85752,7 @@
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629807,
       "structure_id": null,
       "support_skills": {
@@ -85557,6 +85930,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629811,
       "structure_id": null,
       "support_skills": {
@@ -85765,6 +86139,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -85925,6 +86300,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -86119,6 +86495,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629817,
       "structure_id": null,
       "support_skills": {
@@ -86321,6 +86698,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629825,
       "structure_id": null,
       "support_skills": {
@@ -86519,6 +86897,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -86721,6 +87100,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629830,
       "structure_id": null,
       "support_skills": {
@@ -86923,6 +87303,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629857,
       "structure_id": null,
       "support_skills": {
@@ -87121,6 +87502,7 @@
       "player_name": "SleepyシEmre",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629875,
       "structure_id": null,
       "support_skills": {
@@ -87287,6 +87669,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629887,
       "structure_id": null,
       "support_skills": {
@@ -87489,6 +87872,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629889,
       "structure_id": null,
       "support_skills": {
@@ -87687,6 +88071,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -87903,6 +88288,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629905,
       "structure_id": null,
       "support_skills": {
@@ -88111,6 +88497,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629911,
       "structure_id": null,
       "support_skills": {
@@ -88309,6 +88696,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629913,
       "structure_id": null,
       "support_skills": {
@@ -88507,6 +88895,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -88698,6 +89087,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629929,
       "structure_id": null,
       "support_skills": {
@@ -88900,6 +89290,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -89108,6 +89499,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629931,
       "structure_id": null,
       "support_skills": {
@@ -89310,6 +89702,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -89491,6 +89884,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -89674,6 +90068,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629937,
       "structure_id": null,
       "support_skills": {
@@ -89878,6 +90273,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -90076,6 +90472,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629965,
       "structure_id": null,
       "support_skills": {
@@ -90278,6 +90675,7 @@
       "player_name": "EidenR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -90476,6 +90874,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629975,
       "structure_id": null,
       "support_skills": {
@@ -90636,6 +91035,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629977,
       "structure_id": null,
       "support_skills": {
@@ -90842,6 +91242,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -91025,6 +91426,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -91209,6 +91611,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629981,
       "structure_id": null,
       "support_skills": {
@@ -91407,6 +91810,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629987,
       "structure_id": null,
       "support_skills": {
@@ -91616,6 +92020,7 @@
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 629995,
       "structure_id": null,
       "support_skills": {
@@ -91824,6 +92229,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -92030,6 +92436,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630010,
       "structure_id": null,
       "support_skills": {
@@ -92232,6 +92639,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -92430,6 +92838,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630016,
       "structure_id": null,
       "support_skills": {
@@ -92640,6 +93049,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -92849,6 +93259,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -93053,6 +93464,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630018,
       "structure_id": null,
       "support_skills": {
@@ -93255,6 +93667,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -93457,6 +93870,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630021,
       "structure_id": null,
       "support_skills": {
@@ -93670,6 +94084,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630031,
       "structure_id": null,
       "support_skills": {
@@ -93883,6 +94298,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630033,
       "structure_id": null,
       "support_skills": {
@@ -94089,6 +94505,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630034,
       "structure_id": null,
       "support_skills": {
@@ -94291,6 +94708,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630037,
       "structure_id": null,
       "support_skills": {
@@ -94489,6 +94907,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630040,
       "structure_id": null,
       "support_skills": {
@@ -94693,6 +95112,7 @@
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630050,
       "structure_id": null,
       "support_skills": {
@@ -94897,6 +95317,7 @@
       "player_name": "SleepyシEmre",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630062,
       "structure_id": null,
       "support_skills": {
@@ -95101,6 +95522,7 @@
       "player_name": "Grymne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630080,
       "structure_id": null,
       "support_skills": {
@@ -95282,6 +95704,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630087,
       "structure_id": null,
       "support_skills": {
@@ -95459,6 +95882,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -95646,6 +96070,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630099,
       "structure_id": null,
       "support_skills": {
@@ -95833,6 +96258,7 @@
       "player_name": "ᴸᴸ Handy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630103,
       "structure_id": null,
       "support_skills": {
@@ -96035,6 +96461,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630109,
       "structure_id": null,
       "support_skills": {
@@ -96233,6 +96660,7 @@
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630115,
       "structure_id": null,
       "support_skills": {
@@ -96441,6 +96869,7 @@
       "player_name": "ᴸᴸ Handy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630123,
       "structure_id": null,
       "support_skills": {
@@ -96643,6 +97072,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630127,
       "structure_id": null,
       "support_skills": {
@@ -96818,6 +97248,7 @@
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -97024,6 +97455,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630129,
       "structure_id": null,
       "support_skills": {
@@ -97226,6 +97658,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630132,
       "structure_id": null,
       "support_skills": {
@@ -97428,6 +97861,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630133,
       "structure_id": null,
       "support_skills": {
@@ -97626,6 +98060,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630135,
       "structure_id": null,
       "support_skills": {
@@ -97842,6 +98277,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630146,
       "structure_id": null,
       "support_skills": {
@@ -98055,6 +98491,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -98261,6 +98698,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630160,
       "structure_id": null,
       "support_skills": {
@@ -98459,6 +98897,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630166,
       "structure_id": null,
       "support_skills": {
@@ -98661,6 +99100,7 @@
       "player_name": "Forgo义Preyla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -98842,6 +99282,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630172,
       "structure_id": null,
       "support_skills": {
@@ -99044,6 +99485,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630189,
       "structure_id": null,
       "support_skills": {
@@ -99261,6 +99703,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630191,
       "structure_id": null,
       "support_skills": {
@@ -99463,6 +99906,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630194,
       "structure_id": null,
       "support_skills": {
@@ -99661,6 +100105,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630197,
       "structure_id": null,
       "support_skills": {
@@ -99869,6 +100314,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630207,
       "structure_id": null,
       "support_skills": {
@@ -100071,6 +100517,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630232,
       "structure_id": null,
       "support_skills": {
@@ -100273,6 +100720,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630238,
       "structure_id": null,
       "support_skills": {
@@ -100454,6 +100902,7 @@
       "player_name": "booty squad 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630249,
       "structure_id": null,
       "support_skills": {
@@ -100660,6 +101109,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -100862,6 +101312,7 @@
       "player_name": "Wongington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630279,
       "structure_id": null,
       "support_skills": {
@@ -101064,6 +101515,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630291,
       "structure_id": null,
       "support_skills": {
@@ -101277,6 +101729,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630304,
       "structure_id": null,
       "support_skills": {
@@ -101494,6 +101947,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630306,
       "structure_id": null,
       "support_skills": {
@@ -101696,6 +102150,7 @@
       "player_name": "ItsJustDave",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -101844,6 +102299,7 @@
       "player_name": "EidensMule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630312,
       "structure_id": null,
       "support_skills": {
@@ -102038,6 +102494,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -102244,6 +102701,7 @@
       "player_name": "ᴸᴸKapten",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630319,
       "structure_id": null,
       "support_skills": {
@@ -102442,6 +102900,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -102615,6 +103074,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -102803,6 +103263,7 @@
       "player_name": "FakeFarm01",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630324,
       "structure_id": null,
       "support_skills": {
@@ -103001,6 +103462,7 @@
       "player_name": "wzz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630333,
       "structure_id": null,
       "support_skills": {
@@ -103205,6 +103667,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -103388,6 +103851,7 @@
       "player_name": "FakeFarm01",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630338,
       "structure_id": null,
       "support_skills": {
@@ -103573,6 +104037,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630357,
       "structure_id": null,
       "support_skills": {
@@ -103771,6 +104236,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630383,
       "structure_id": null,
       "support_skills": {
@@ -103975,6 +104441,7 @@
       "player_name": "Toxic㋡Bunny",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630404,
       "structure_id": null,
       "support_skills": {
@@ -104188,6 +104655,7 @@
       "player_name": "Roach Biz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630442,
       "structure_id": null,
       "support_skills": {
@@ -104401,6 +104869,7 @@
       "player_name": "Roach Biz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630448,
       "structure_id": null,
       "support_skills": {
@@ -104614,6 +105083,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630492,
       "structure_id": null,
       "support_skills": {
@@ -104808,6 +105278,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630501,
       "structure_id": null,
       "support_skills": {
@@ -105666,6 +106137,7 @@
       "player_name": "wzz",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 630607,
       "structure_id": null,
       "support_skills": {
@@ -105850,6 +106322,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630577,
       "structure_id": null,
       "support_skills": {
@@ -106048,6 +106521,7 @@
       "player_name": "Toxic㋡Bunny",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630591,
       "structure_id": null,
       "support_skills": {
@@ -106256,6 +106730,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630638,
       "structure_id": null,
       "support_skills": {
@@ -106462,6 +106937,7 @@
       "player_name": "乂 YÂMÎ 乂",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630642,
       "structure_id": null,
       "support_skills": {
@@ -106656,6 +107132,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630654,
       "structure_id": null,
       "support_skills": {
@@ -106812,6 +107289,7 @@
       "player_name": "NCTメOneMoreBeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630660,
       "structure_id": null,
       "support_skills": {
@@ -107018,6 +107496,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630662,
       "structure_id": null,
       "support_skills": {
@@ -107213,6 +107692,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -107407,6 +107887,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630697,
       "structure_id": null,
       "support_skills": {
@@ -107609,6 +108090,7 @@
       "player_name": "ʳᵉˣHihu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -107782,6 +108264,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630723,
       "structure_id": null,
       "support_skills": {
@@ -107938,6 +108421,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630726,
       "structure_id": null,
       "support_skills": {
@@ -108144,6 +108628,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -108304,6 +108789,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -108483,6 +108969,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630728,
       "structure_id": null,
       "support_skills": {
@@ -108678,6 +109165,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630732,
       "structure_id": null,
       "support_skills": {
@@ -108888,6 +109376,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630767,
       "structure_id": null,
       "support_skills": {
@@ -109101,6 +109590,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630780,
       "structure_id": null,
       "support_skills": {
@@ -109299,6 +109789,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -109472,6 +109963,7 @@
       "player_name": "Ral Farm C",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630801,
       "structure_id": null,
       "support_skills": {
@@ -109674,6 +110166,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630807,
       "structure_id": null,
       "support_skills": {
@@ -109876,6 +110369,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630818,
       "structure_id": null,
       "support_skills": {
@@ -110084,6 +110578,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630844,
       "structure_id": null,
       "support_skills": {
@@ -110292,6 +110787,7 @@
       "player_name": "ᶠᵀᴾRust",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630850,
       "structure_id": null,
       "support_skills": {
@@ -110496,6 +110992,7 @@
       "player_name": "Paulo 災",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630854,
       "structure_id": null,
       "support_skills": {
@@ -110696,6 +111193,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630856,
       "structure_id": null,
       "support_skills": {
@@ -110875,6 +111373,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -111063,6 +111562,7 @@
       "player_name": "FakeFarm01",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630860,
       "structure_id": null,
       "support_skills": {
@@ -111265,6 +111765,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630919,
       "structure_id": null,
       "support_skills": {
@@ -111463,6 +111964,7 @@
       "player_name": "Sheir0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630924,
       "structure_id": null,
       "support_skills": {
@@ -111667,6 +112169,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -111869,6 +112372,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630926,
       "structure_id": null,
       "support_skills": {
@@ -112067,6 +112571,7 @@
       "player_name": "Toxic㋡Bunny",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630930,
       "structure_id": null,
       "support_skills": {
@@ -112275,6 +112780,7 @@
       "player_name": "FuhrerBiscotte",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630938,
       "structure_id": null,
       "support_skills": {
@@ -112477,6 +112983,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630947,
       "structure_id": null,
       "support_skills": {
@@ -112654,6 +113161,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -112860,6 +113368,7 @@
       "player_name": "wzz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630953,
       "structure_id": null,
       "support_skills": {
@@ -113058,6 +113567,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -113264,6 +113774,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 630965,
       "structure_id": null,
       "support_skills": {
@@ -113466,6 +113977,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -113674,6 +114186,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631007,
       "structure_id": null,
       "support_skills": {
@@ -113862,6 +114375,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631018,
       "structure_id": null,
       "support_skills": {
@@ -114060,6 +114574,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -114258,6 +114773,7 @@
       "player_name": "FuhrerBiscotte",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631024,
       "structure_id": null,
       "support_skills": {
@@ -114439,6 +114955,7 @@
       "player_name": "Roach Biz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631033,
       "structure_id": null,
       "support_skills": {
@@ -114655,6 +115172,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -114859,6 +115377,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631037,
       "structure_id": null,
       "support_skills": {
@@ -115055,6 +115574,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631055,
       "structure_id": null,
       "support_skills": {
@@ -115253,6 +115773,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631085,
       "structure_id": null,
       "support_skills": {
@@ -115413,6 +115934,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631063,
       "structure_id": null,
       "support_skills": {
@@ -115615,6 +116137,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -115824,6 +116347,7 @@
       "player_name": "Zinaaje",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -116028,6 +116552,7 @@
       "player_name": "DaveSleepwalker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631069,
       "structure_id": null,
       "support_skills": {
@@ -116230,6 +116755,7 @@
       "player_name": "Dixierect",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631073,
       "structure_id": null,
       "support_skills": {
@@ -116438,6 +116964,7 @@
       "player_name": "ヤFakeRules 乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631075,
       "structure_id": null,
       "support_skills": {
@@ -116640,6 +117167,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631097,
       "structure_id": null,
       "support_skills": {
@@ -116838,6 +117366,7 @@
       "player_name": "Toxic㋡Bunny",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631117,
       "structure_id": null,
       "support_skills": {
@@ -117046,6 +117575,7 @@
       "player_name": "MrLimeton",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631123,
       "structure_id": null,
       "support_skills": {
@@ -117259,6 +117789,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631163,
       "structure_id": null,
       "support_skills": {
@@ -117423,6 +117954,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631170,
       "structure_id": null,
       "support_skills": {
@@ -117640,6 +118172,7 @@
       "player_name": "Aragorn VI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631182,
       "structure_id": null,
       "support_skills": {
@@ -117804,6 +118337,7 @@
       "player_name": "Ralbro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631195,
       "structure_id": null,
       "support_skills": {
@@ -118017,6 +118551,7 @@
       "player_name": "WarArrow",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631231,
       "structure_id": null,
       "support_skills": {
@@ -118173,6 +118708,7 @@
       "player_name": "booty squad 22",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631239,
       "structure_id": null,
       "support_skills": {
@@ -118346,6 +118882,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -118544,6 +119081,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -118746,6 +119284,7 @@
       "player_name": "Prime Kxan",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631251,
       "structure_id": null,
       "support_skills": {
@@ -118944,6 +119483,7 @@
       "player_name": "FuhrerBiscotte",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631259,
       "structure_id": null,
       "support_skills": {
@@ -119125,6 +119665,7 @@
       "player_name": "Roach Biz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631271,
       "structure_id": null,
       "support_skills": {
@@ -119302,6 +119843,7 @@
       "player_name": "booty squad c1",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631281,
       "structure_id": null,
       "support_skills": {
@@ -119504,6 +120046,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631288,
       "structure_id": null,
       "support_skills": {
@@ -119717,6 +120260,7 @@
       "player_name": "거지 Eiden",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 631292,
       "structure_id": null,
       "support_skills": {
@@ -128821,6 +129365,7 @@
     "player_name": "ˢJian x Laars",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
+++ b/samples/Battle/Persistent.Mail.2225911117695327552-processed.json
@@ -12675,6 +12675,7 @@
       "player_name": "Liberlitas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595330,
       "structure_id": 38,
       "support_skills": {
@@ -12873,6 +12874,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13071,6 +13073,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13273,6 +13276,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13467,6 +13471,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -13665,6 +13670,7 @@
       "player_name": "Sparkx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595343,
       "structure_id": null,
       "support_skills": {
@@ -13863,6 +13869,7 @@
       "player_name": "刀劍Kir",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -14057,6 +14064,7 @@
       "player_name": "Paw pаw",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595352,
       "structure_id": null,
       "support_skills": {
@@ -14259,6 +14267,7 @@
       "player_name": "7sKi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14457,6 +14466,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -14655,6 +14665,7 @@
       "player_name": "7sKi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -14857,6 +14868,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595335,
       "structure_id": null,
       "support_skills": {
@@ -15055,6 +15067,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15253,6 +15266,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15455,6 +15469,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15657,6 +15672,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595333,
       "structure_id": null,
       "support_skills": {
@@ -15855,6 +15871,7 @@
       "player_name": "7sKi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -16053,6 +16070,7 @@
       "player_name": "Kitty Gang",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595360,
       "structure_id": null,
       "support_skills": {
@@ -16251,6 +16269,7 @@
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -16449,6 +16468,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595353,
       "structure_id": null,
       "support_skills": {
@@ -16643,6 +16663,7 @@
       "player_name": "мᴀXXuм",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595554,
       "structure_id": null,
       "support_skills": {
@@ -16841,6 +16862,7 @@
       "player_name": "Nycko乂CactusJ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -17039,6 +17061,7 @@
       "player_name": "SuperLuffy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595394,
       "structure_id": null,
       "support_skills": {
@@ -17237,6 +17260,7 @@
       "player_name": "ZombiNuggies13",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595488,
       "structure_id": null,
       "support_skills": {
@@ -17435,6 +17459,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595764,
       "structure_id": null,
       "support_skills": {
@@ -17633,6 +17658,7 @@
       "player_name": "KateRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595350,
       "structure_id": null,
       "support_skills": {
@@ -17831,6 +17857,7 @@
       "player_name": "Rimuru 림",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595904,
       "structure_id": null,
       "support_skills": {
@@ -18029,6 +18056,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18231,6 +18259,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18433,6 +18462,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -18631,6 +18661,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -18829,6 +18860,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -19031,6 +19063,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595400,
       "structure_id": null,
       "support_skills": {
@@ -19233,6 +19266,7 @@
       "player_name": "乄7 Itachi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -19435,6 +19469,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -19633,6 +19668,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -19831,6 +19867,7 @@
       "player_name": "乄7 Itachi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -20033,6 +20070,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595384,
       "structure_id": null,
       "support_skills": {
@@ -20231,6 +20269,7 @@
       "player_name": "乄7 Itachi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595356,
       "structure_id": null,
       "support_skills": {
@@ -20429,6 +20468,7 @@
       "player_name": "ʚFujiɞ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -20631,6 +20671,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -20829,6 +20870,7 @@
       "player_name": "乄7 Itachi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595367,
       "structure_id": null,
       "support_skills": {
@@ -21027,6 +21069,7 @@
       "player_name": "xCosma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595725,
       "structure_id": null,
       "support_skills": {
@@ -21221,6 +21264,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595382,
       "structure_id": null,
       "support_skills": {
@@ -21419,6 +21463,7 @@
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -21621,6 +21666,7 @@
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595355,
       "structure_id": null,
       "support_skills": {
@@ -21823,6 +21869,7 @@
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -22021,6 +22068,7 @@
       "player_name": "ᴋɪʟʟᴇʀx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595359,
       "structure_id": null,
       "support_skills": {
@@ -22219,6 +22267,7 @@
       "player_name": "Sinỳ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595349,
       "structure_id": null,
       "support_skills": {
@@ -22417,6 +22466,7 @@
       "player_name": "Sinỳ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595351,
       "structure_id": null,
       "support_skills": {
@@ -22615,6 +22665,7 @@
       "player_name": "彡tktk彡",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595376,
       "structure_id": null,
       "support_skills": {
@@ -22817,6 +22868,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595776,
       "structure_id": null,
       "support_skills": {
@@ -23015,6 +23067,7 @@
       "player_name": "MGKing Legacy S",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -23213,6 +23266,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23411,6 +23465,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595358,
       "structure_id": null,
       "support_skills": {
@@ -23613,6 +23668,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595397,
       "structure_id": null,
       "support_skills": {
@@ -23815,6 +23871,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595396,
       "structure_id": null,
       "support_skills": {
@@ -24013,6 +24070,7 @@
       "player_name": "Zoned Out",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596454,
       "structure_id": null,
       "support_skills": {
@@ -24211,6 +24269,7 @@
       "player_name": "兵士Spida",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24409,6 +24468,7 @@
       "player_name": "兵士Spida",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24607,6 +24667,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595457,
       "structure_id": null,
       "support_skills": {
@@ -24801,6 +24862,7 @@
       "player_name": "兵士Spida",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -24999,6 +25061,7 @@
       "player_name": "MALJAHAメWolfy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595371,
       "structure_id": null,
       "support_skills": {
@@ -25197,6 +25260,7 @@
       "player_name": "ZombiNuggies13",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595485,
       "structure_id": null,
       "support_skills": {
@@ -25399,6 +25463,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595505,
       "structure_id": null,
       "support_skills": {
@@ -25593,6 +25658,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -25795,6 +25861,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595503,
       "structure_id": null,
       "support_skills": {
@@ -25993,6 +26060,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595383,
       "structure_id": null,
       "support_skills": {
@@ -26187,6 +26255,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26385,6 +26454,7 @@
       "player_name": "Fox 444",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595834,
       "structure_id": null,
       "support_skills": {
@@ -26583,6 +26653,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595704,
       "structure_id": null,
       "support_skills": {
@@ -26781,6 +26852,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595705,
       "structure_id": null,
       "support_skills": {
@@ -26979,6 +27051,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596468,
       "structure_id": null,
       "support_skills": {
@@ -27177,6 +27250,7 @@
       "player_name": "SpicySquid",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595520,
       "structure_id": null,
       "support_skills": {
@@ -27375,6 +27449,7 @@
       "player_name": "TânメNguyễn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595897,
       "structure_id": null,
       "support_skills": {
@@ -27577,6 +27652,7 @@
       "player_name": "Liberlitas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595403,
       "structure_id": null,
       "support_skills": {
@@ -27775,6 +27851,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -27973,6 +28050,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28175,6 +28253,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28377,6 +28456,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595443,
       "structure_id": null,
       "support_skills": {
@@ -28571,6 +28651,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28773,6 +28854,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595442,
       "structure_id": null,
       "support_skills": {
@@ -28967,6 +29049,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595426,
       "structure_id": null,
       "support_skills": {
@@ -29295,6 +29378,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595456,
       "structure_id": null,
       "support_skills": {
@@ -29497,6 +29581,7 @@
       "player_name": "۞T۞ Infinite",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595657,
       "structure_id": null,
       "support_skills": {
@@ -29695,6 +29780,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595573,
       "structure_id": null,
       "support_skills": {
@@ -29893,6 +29979,7 @@
       "player_name": "BØBA",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595762,
       "structure_id": null,
       "support_skills": {
@@ -30095,6 +30182,7 @@
       "player_name": "SevenZeroOne",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595470,
       "structure_id": null,
       "support_skills": {
@@ -30409,6 +30497,7 @@
       "player_name": "Baronita",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595500,
       "structure_id": null,
       "support_skills": {
@@ -30573,6 +30662,7 @@
       "player_name": "MrNayef p7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30771,6 +30861,7 @@
       "player_name": "MrNayef p7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -30948,6 +31039,7 @@
       "player_name": "MrNayef p7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -31129,6 +31221,7 @@
       "player_name": "MrNayef p7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595478,
       "structure_id": null,
       "support_skills": {
@@ -31327,6 +31420,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31525,6 +31619,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31727,6 +31822,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -31929,6 +32025,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595504,
       "structure_id": null,
       "support_skills": {
@@ -32127,6 +32224,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32325,6 +32423,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32527,6 +32626,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595637,
       "structure_id": null,
       "support_skills": {
@@ -32721,6 +32821,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595636,
       "structure_id": null,
       "support_skills": {
@@ -33067,6 +33168,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595600,
       "structure_id": null,
       "support_skills": {
@@ -33269,6 +33371,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595778,
       "structure_id": null,
       "support_skills": {
@@ -33467,6 +33570,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33669,6 +33773,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595953,
       "structure_id": null,
       "support_skills": {
@@ -33975,6 +34080,7 @@
       "player_name": "M  P",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595634,
       "structure_id": null,
       "support_skills": {
@@ -34169,6 +34275,7 @@
       "player_name": "xCosma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595632,
       "structure_id": null,
       "support_skills": {
@@ -34363,6 +34470,7 @@
       "player_name": "Goofyᴴᴳ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596177,
       "structure_id": null,
       "support_skills": {
@@ -34561,6 +34669,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34763,6 +34872,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -34961,6 +35071,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35163,6 +35274,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35357,6 +35469,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35559,6 +35672,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -35757,6 +35871,7 @@
       "player_name": "PoonSquad",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -35959,6 +36074,7 @@
       "player_name": "PoonSquad",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595798,
       "structure_id": null,
       "support_skills": {
@@ -36161,6 +36277,7 @@
       "player_name": "Đouglas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595695,
       "structure_id": null,
       "support_skills": {
@@ -36359,6 +36476,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595831,
       "structure_id": null,
       "support_skills": {
@@ -36557,6 +36675,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595899,
       "structure_id": null,
       "support_skills": {
@@ -36730,6 +36849,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595975,
       "structure_id": null,
       "support_skills": {
@@ -36928,6 +37048,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37126,6 +37247,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37328,6 +37450,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37530,6 +37653,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37732,6 +37856,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595976,
       "structure_id": null,
       "support_skills": {
@@ -37926,6 +38051,7 @@
       "player_name": "Fox 444",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -38128,6 +38254,7 @@
       "player_name": "Fox 444",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595896,
       "structure_id": null,
       "support_skills": {
@@ -38330,6 +38457,7 @@
       "player_name": "ᴱ ᴸ ᴼM1Lo",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596153,
       "structure_id": null,
       "support_skills": {
@@ -38528,6 +38656,7 @@
       "player_name": "Jade StaR",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595837,
       "structure_id": null,
       "support_skills": {
@@ -38726,6 +38855,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595907,
       "structure_id": null,
       "support_skills": {
@@ -38928,6 +39058,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -39292,6 +39423,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595750,
       "structure_id": null,
       "support_skills": {
@@ -39486,6 +39618,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595998,
       "structure_id": null,
       "support_skills": {
@@ -39814,6 +39947,7 @@
       "player_name": "父 TY ЯR 父",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595790,
       "structure_id": null,
       "support_skills": {
@@ -40012,6 +40146,7 @@
       "player_name": "22 Armani",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 595997,
       "structure_id": null,
       "support_skills": {
@@ -40214,6 +40349,7 @@
       "player_name": "Hᴏɴᴄʜᴏ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -40578,6 +40714,7 @@
       "player_name": "Bladezメkizzy",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595934,
       "structure_id": null,
       "support_skills": {
@@ -40776,6 +40913,7 @@
       "player_name": "FeilongX Yeager",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596163,
       "structure_id": null,
       "support_skills": {
@@ -40974,6 +41112,7 @@
       "player_name": "Sparkx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596150,
       "structure_id": null,
       "support_skills": {
@@ -41172,6 +41311,7 @@
       "player_name": "Nycko乂CactusJ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -41374,6 +41514,7 @@
       "player_name": "Skʏ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596055,
       "structure_id": null,
       "support_skills": {
@@ -41572,6 +41713,7 @@
       "player_name": "白蘭丶亮",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596048,
       "structure_id": null,
       "support_skills": {
@@ -41770,6 +41912,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -41972,6 +42115,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42354,6 +42498,7 @@
       "player_name": "M  P",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 595954,
       "structure_id": null,
       "support_skills": {
@@ -42548,6 +42693,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596105,
       "structure_id": null,
       "support_skills": {
@@ -42746,6 +42892,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -42948,6 +43095,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596104,
       "structure_id": null,
       "support_skills": {
@@ -43146,6 +43294,7 @@
       "player_name": "Rayes 77 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596550,
       "structure_id": null,
       "support_skills": {
@@ -43344,6 +43493,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -43542,6 +43692,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -43740,6 +43891,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -43942,6 +44094,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596295,
       "structure_id": null,
       "support_skills": {
@@ -44144,6 +44297,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44338,6 +44492,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44540,6 +44695,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -44742,6 +44898,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596294,
       "structure_id": null,
       "support_skills": {
@@ -44944,6 +45101,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596293,
       "structure_id": null,
       "support_skills": {
@@ -45138,6 +45296,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -45336,6 +45495,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596483,
       "structure_id": null,
       "support_skills": {
@@ -45538,6 +45698,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596494,
       "structure_id": null,
       "support_skills": {
@@ -45736,6 +45897,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -45934,6 +46096,7 @@
       "player_name": "Tueiut",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596085,
       "structure_id": null,
       "support_skills": {
@@ -46136,6 +46299,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46334,6 +46498,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596282,
       "structure_id": null,
       "support_skills": {
@@ -46528,6 +46693,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46726,6 +46892,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596281,
       "structure_id": null,
       "support_skills": {
@@ -46928,6 +47095,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47130,6 +47298,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47324,6 +47493,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47522,6 +47692,7 @@
       "player_name": "eter乂noob",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596103,
       "structure_id": null,
       "support_skills": {
@@ -47720,6 +47891,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -47918,6 +48090,7 @@
       "player_name": "Snoo ᴿᴮ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596264,
       "structure_id": null,
       "support_skills": {
@@ -48116,6 +48289,7 @@
       "player_name": "Cʜᴀʀᴏɴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596146,
       "structure_id": null,
       "support_skills": {
@@ -48480,6 +48654,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596093,
       "structure_id": null,
       "support_skills": {
@@ -48678,6 +48853,7 @@
       "player_name": "WarDaddyBradSki",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -49042,6 +49218,7 @@
       "player_name": "父 TY ЯR 父",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596128,
       "structure_id": null,
       "support_skills": {
@@ -49240,6 +49417,7 @@
       "player_name": "Pocahontas ツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596309,
       "structure_id": null,
       "support_skills": {
@@ -49413,6 +49591,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596591,
       "structure_id": null,
       "support_skills": {
@@ -49615,6 +49794,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596592,
       "structure_id": null,
       "support_skills": {
@@ -49817,6 +49997,7 @@
       "player_name": "ᴷᴹBeso 88",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596593,
       "structure_id": null,
       "support_skills": {
@@ -50015,6 +50196,7 @@
       "player_name": "Nycko乂CactusJ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596301,
       "structure_id": null,
       "support_skills": {
@@ -50213,6 +50395,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -50411,6 +50594,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50613,6 +50797,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -50807,6 +50992,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -51009,6 +51195,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596258,
       "structure_id": null,
       "support_skills": {
@@ -51207,6 +51394,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -51401,6 +51589,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -51599,6 +51788,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596571,
       "structure_id": null,
       "support_skills": {
@@ -51797,6 +51987,7 @@
       "player_name": "AbuAntaaar 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596321,
       "structure_id": null,
       "support_skills": {
@@ -51995,6 +52186,7 @@
       "player_name": "Chofen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596461,
       "structure_id": null,
       "support_skills": {
@@ -52323,6 +52515,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596257,
       "structure_id": null,
       "support_skills": {
@@ -52521,6 +52714,7 @@
       "player_name": "Ember       s",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596324,
       "structure_id": null,
       "support_skills": {
@@ -52715,6 +52909,7 @@
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596594,
       "structure_id": null,
       "support_skills": {
@@ -52913,6 +53108,7 @@
       "player_name": "Peak Gacs",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596600,
       "structure_id": null,
       "support_skills": {
@@ -53249,6 +53445,7 @@
       "player_name": "M  P",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596290,
       "structure_id": null,
       "support_skills": {
@@ -53451,6 +53648,7 @@
       "player_name": "мᴀXXuм",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596667,
       "structure_id": null,
       "support_skills": {
@@ -53649,6 +53847,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -53847,6 +54046,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596435,
       "structure_id": null,
       "support_skills": {
@@ -54045,6 +54245,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54243,6 +54444,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596439,
       "structure_id": null,
       "support_skills": {
@@ -54445,6 +54647,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54639,6 +54842,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -54841,6 +55045,7 @@
       "player_name": "Calò 乂 dòll",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596438,
       "structure_id": null,
       "support_skills": {
@@ -55043,6 +55248,7 @@
       "player_name": "۞T۞ Infinite",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596443,
       "structure_id": null,
       "support_skills": {
@@ -55241,6 +55447,7 @@
       "player_name": "Hallゞ翰",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -55439,6 +55646,7 @@
       "player_name": "兵士Spida",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596674,
       "structure_id": null,
       "support_skills": {
@@ -55633,6 +55841,7 @@
       "player_name": "Skʏ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596433,
       "structure_id": null,
       "support_skills": {
@@ -55827,6 +56036,7 @@
       "player_name": "Hallゞ翰",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596950,
       "structure_id": null,
       "support_skills": {
@@ -56025,6 +56235,7 @@
       "player_name": "TânメNguyễn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596517,
       "structure_id": null,
       "support_skills": {
@@ -56223,6 +56434,7 @@
       "player_name": "火 Truth 火",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -56421,6 +56633,7 @@
       "player_name": "Sleepy fr",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596666,
       "structure_id": null,
       "support_skills": {
@@ -56767,6 +56980,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596432,
       "structure_id": null,
       "support_skills": {
@@ -56965,6 +57179,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -57167,6 +57382,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596477,
       "structure_id": null,
       "support_skills": {
@@ -57369,6 +57585,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -57567,6 +57784,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -57765,6 +57983,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596659,
       "structure_id": null,
       "support_skills": {
@@ -57967,6 +58186,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596478,
       "structure_id": null,
       "support_skills": {
@@ -58169,6 +58389,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58363,6 +58584,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58565,6 +58787,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596649,
       "structure_id": null,
       "support_skills": {
@@ -58767,6 +58990,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -58969,6 +59193,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -59171,6 +59396,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596658,
       "structure_id": null,
       "support_skills": {
@@ -59365,6 +59591,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596648,
       "structure_id": null,
       "support_skills": {
@@ -59711,6 +59938,7 @@
       "player_name": "父 TY ЯR 父",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596470,
       "structure_id": null,
       "support_skills": {
@@ -59913,6 +60141,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596663,
       "structure_id": null,
       "support_skills": {
@@ -60107,6 +60336,7 @@
       "player_name": "LORD OF ALL Dk",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -60305,6 +60535,7 @@
       "player_name": "Barça",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -60499,6 +60730,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -60697,6 +60929,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -60899,6 +61132,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596672,
       "structure_id": null,
       "support_skills": {
@@ -61101,6 +61335,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61303,6 +61538,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61501,6 +61737,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61703,6 +61940,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -61897,6 +62135,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -62095,6 +62334,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -62297,6 +62537,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -62499,6 +62740,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -62693,6 +62935,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -62891,6 +63134,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596619,
       "structure_id": null,
       "support_skills": {
@@ -63089,6 +63333,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596813,
       "structure_id": null,
       "support_skills": {
@@ -63291,6 +63536,7 @@
       "player_name": "Sinỳ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596662,
       "structure_id": null,
       "support_skills": {
@@ -63489,6 +63735,7 @@
       "player_name": "忠GhostMiracle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -63691,6 +63938,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596654,
       "structure_id": null,
       "support_skills": {
@@ -63889,6 +64137,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596791,
       "structure_id": null,
       "support_skills": {
@@ -64087,6 +64336,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -64289,6 +64539,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596793,
       "structure_id": null,
       "support_skills": {
@@ -64491,6 +64742,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596792,
       "structure_id": null,
       "support_skills": {
@@ -64837,6 +65089,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596596,
       "structure_id": null,
       "support_skills": {
@@ -65035,6 +65288,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65237,6 +65491,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65435,6 +65690,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65633,6 +65889,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -65831,6 +66088,7 @@
       "player_name": "TSUNAMIBO TALAL",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -66029,6 +66287,7 @@
       "player_name": "xCosma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -66231,6 +66490,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596618,
       "structure_id": null,
       "support_skills": {
@@ -66433,6 +66693,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596812,
       "structure_id": null,
       "support_skills": {
@@ -66631,6 +66892,7 @@
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596965,
       "structure_id": null,
       "support_skills": {
@@ -66825,6 +67087,7 @@
       "player_name": "nhathuyhihi ᴬ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596966,
       "structure_id": null,
       "support_skills": {
@@ -67027,6 +67290,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596814,
       "structure_id": null,
       "support_skills": {
@@ -67535,6 +67799,7 @@
       "player_name": "M  P",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596640,
       "structure_id": null,
       "support_skills": {
@@ -67729,6 +67994,7 @@
       "player_name": "SupEr",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -67927,6 +68193,7 @@
       "player_name": "Chisgule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -68129,6 +68396,7 @@
       "player_name": "Chisgule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596988,
       "structure_id": null,
       "support_skills": {
@@ -68331,6 +68599,7 @@
       "player_name": "Chisgule",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -68529,6 +68798,7 @@
       "player_name": "メFACELESSメ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -68727,6 +68997,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -68929,6 +69200,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -69131,6 +69403,7 @@
       "player_name": "MÄD乄SaLva98",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -69325,6 +69598,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597019,
       "structure_id": null,
       "support_skills": {
@@ -69523,6 +69797,7 @@
       "player_name": "Fahad Sensei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597020,
       "structure_id": null,
       "support_skills": {
@@ -69721,6 +69996,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -69923,6 +70199,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -70125,6 +70402,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -70327,6 +70605,7 @@
       "player_name": "SAO Pink",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597003,
       "structure_id": null,
       "support_skills": {
@@ -70525,6 +70804,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -70723,6 +71003,7 @@
       "player_name": "Mr Yahya",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596957,
       "structure_id": null,
       "support_skills": {
@@ -70921,6 +71202,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -71115,6 +71397,7 @@
       "player_name": "SAO Pink",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597061,
       "structure_id": null,
       "support_skills": {
@@ -71313,6 +71596,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -71515,6 +71799,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -71717,6 +72002,7 @@
       "player_name": "Mr Yahya",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -71919,6 +72205,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -72113,6 +72400,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596752,
       "structure_id": null,
       "support_skills": {
@@ -72315,6 +72603,7 @@
       "player_name": "GhostRider99",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596753,
       "structure_id": null,
       "support_skills": {
@@ -72509,6 +72798,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -72711,6 +73001,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596956,
       "structure_id": null,
       "support_skills": {
@@ -72913,6 +73204,7 @@
       "player_name": "义 N E X T 义",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -73115,6 +73407,7 @@
       "player_name": "Pangea",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596976,
       "structure_id": null,
       "support_skills": {
@@ -73313,6 +73606,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -73511,6 +73805,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -73713,6 +74008,7 @@
       "player_name": "忠GhostMiracle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -73911,6 +74207,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -74113,6 +74410,7 @@
       "player_name": "Fox 444",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -74311,6 +74609,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -74513,6 +74812,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596818,
       "structure_id": null,
       "support_skills": {
@@ -74707,6 +75007,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -74905,6 +75206,7 @@
       "player_name": "niicii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596987,
       "structure_id": null,
       "support_skills": {
@@ -75107,6 +75409,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596817,
       "structure_id": null,
       "support_skills": {
@@ -75305,6 +75608,7 @@
       "player_name": "SpicySquid",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -75669,6 +75973,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596758,
       "structure_id": null,
       "support_skills": {
@@ -75867,6 +76172,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -76065,6 +76371,7 @@
       "player_name": "Ghøstboy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -76263,6 +76570,7 @@
       "player_name": "Guardian019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -76461,6 +76769,7 @@
       "player_name": "Guardian019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -76663,6 +76972,7 @@
       "player_name": "少東East",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596955,
       "structure_id": null,
       "support_skills": {
@@ -76861,6 +77171,7 @@
       "player_name": "Guardian019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -77063,6 +77374,7 @@
       "player_name": "Guardian019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -77265,6 +77577,7 @@
       "player_name": "Guardian019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -77463,6 +77776,7 @@
       "player_name": "ᶜʰᵉᶠ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596970,
       "structure_id": null,
       "support_skills": {
@@ -77661,6 +77975,7 @@
       "player_name": "1baller",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597009,
       "structure_id": null,
       "support_skills": {
@@ -77863,6 +78178,7 @@
       "player_name": "DarthBelugaツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596992,
       "structure_id": null,
       "support_skills": {
@@ -78061,6 +78377,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597001,
       "structure_id": null,
       "support_skills": {
@@ -78255,6 +78572,7 @@
       "player_name": "SpicySquid",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -78453,6 +78771,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -78651,6 +78970,7 @@
       "player_name": "父 TY ЯR 父",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -78853,6 +79173,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -79051,6 +79372,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79249,6 +79571,7 @@
       "player_name": "忠GhostMiracle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -79451,6 +79774,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79653,6 +79977,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -79851,6 +80176,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -80049,6 +80375,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -80243,6 +80570,7 @@
       "player_name": "BØBA",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597006,
       "structure_id": null,
       "support_skills": {
@@ -80437,6 +80765,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -80639,6 +80968,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -80833,6 +81163,7 @@
       "player_name": "스닉간식 BȺE",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597022,
       "structure_id": null,
       "support_skills": {
@@ -81035,6 +81366,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -81233,6 +81565,7 @@
       "player_name": "Umbra ﾒ Dragon",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -81431,6 +81764,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -81629,6 +81963,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -81827,6 +82162,7 @@
       "player_name": "Mayoh",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596979,
       "structure_id": null,
       "support_skills": {
@@ -82025,6 +82361,7 @@
       "player_name": "۞T۞ Infinite",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597010,
       "structure_id": null,
       "support_skills": {
@@ -82223,6 +82560,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -82425,6 +82763,7 @@
       "player_name": "乄Bin乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -82619,6 +82958,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -82821,6 +83161,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -83023,6 +83364,7 @@
       "player_name": "BaoBun248",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -83221,6 +83563,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597011,
       "structure_id": null,
       "support_skills": {
@@ -83423,6 +83766,7 @@
       "player_name": "MAD S3S3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597004,
       "structure_id": null,
       "support_skills": {
@@ -83621,6 +83965,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -83823,6 +84168,7 @@
       "player_name": "Tsuzilla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597032,
       "structure_id": null,
       "support_skills": {
@@ -84025,6 +84371,7 @@
       "player_name": "乄Bin乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -84227,6 +84574,7 @@
       "player_name": "BaoBun248",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -84425,6 +84773,7 @@
       "player_name": "乄Bin乄",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -84627,6 +84976,7 @@
       "player_name": "ʚïɞce ⁿʷ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596998,
       "structure_id": null,
       "support_skills": {
@@ -84821,6 +85171,7 @@
       "player_name": "忠GhostMiracle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597045,
       "structure_id": null,
       "support_skills": {
@@ -85023,6 +85374,7 @@
       "player_name": "DarthBelugaツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -85221,6 +85573,7 @@
       "player_name": "Skʏ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596986,
       "structure_id": null,
       "support_skills": {
@@ -85575,6 +85928,7 @@
       "player_name": "M  P",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596851,
       "structure_id": null,
       "support_skills": {
@@ -85773,6 +86127,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -85971,6 +86326,7 @@
       "player_name": "ironvox",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -86173,6 +86529,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86371,6 +86728,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86573,6 +86931,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86771,6 +87130,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -86969,6 +87329,7 @@
       "player_name": "sNaXs",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597053,
       "structure_id": null,
       "support_skills": {
@@ -87171,6 +87532,7 @@
       "player_name": "Colonel J",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -87369,6 +87731,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596969,
       "structure_id": null,
       "support_skills": {
@@ -87567,6 +87930,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596968,
       "structure_id": null,
       "support_skills": {
@@ -87765,6 +88129,7 @@
       "player_name": "DarthBelugaツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596991,
       "structure_id": null,
       "support_skills": {
@@ -87963,6 +88328,7 @@
       "player_name": "ORIGINALxKILLER",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597012,
       "structure_id": null,
       "support_skills": {
@@ -88161,6 +88527,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -88363,6 +88730,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597029,
       "structure_id": null,
       "support_skills": {
@@ -88557,6 +88925,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -88751,6 +89120,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -88949,6 +89319,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89151,6 +89522,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596990,
       "structure_id": null,
       "support_skills": {
@@ -89349,6 +89721,7 @@
       "player_name": "Pocahontas ツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -89547,6 +89920,7 @@
       "player_name": "Goliathᴰᴴ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -89745,6 +90119,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -89943,6 +90318,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -90137,6 +90513,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -90339,6 +90716,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -90537,6 +90915,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -90735,6 +91114,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -90937,6 +91317,7 @@
       "player_name": "김릴리Lily",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597036,
       "structure_id": null,
       "support_skills": {
@@ -91139,6 +91520,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -91337,6 +91719,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -91535,6 +91918,7 @@
       "player_name": "xCosma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -91737,6 +92121,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -91935,6 +92320,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 596999,
       "structure_id": null,
       "support_skills": {
@@ -92129,6 +92515,7 @@
       "player_name": "Tad Phrayncke",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597000,
       "structure_id": null,
       "support_skills": {
@@ -92327,6 +92714,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -92525,6 +92913,7 @@
       "player_name": "anothersin",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597038,
       "structure_id": null,
       "support_skills": {
@@ -92723,6 +93112,7 @@
       "player_name": "Lyonardo",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597039,
       "structure_id": null,
       "support_skills": {
@@ -92925,6 +93315,7 @@
       "player_name": "Lyonardo",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597040,
       "structure_id": null,
       "support_skills": {
@@ -93123,6 +93514,7 @@
       "player_name": "AJ ᴴᴳ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597002,
       "structure_id": null,
       "support_skills": {
@@ -93321,6 +93713,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597034,
       "structure_id": null,
       "support_skills": {
@@ -93523,6 +93916,7 @@
       "player_name": "Liberlitas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -93721,6 +94115,7 @@
       "player_name": "Liberlitas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -93923,6 +94318,7 @@
       "player_name": "Liberlitas",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597014,
       "structure_id": null,
       "support_skills": {
@@ -94121,6 +94517,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597035,
       "structure_id": null,
       "support_skills": {
@@ -94485,6 +94882,7 @@
       "player_name": "IBRAHIM ﾒ QuMi",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 596949,
       "structure_id": null,
       "support_skills": {
@@ -94687,6 +95085,7 @@
       "player_name": "Arch3llen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597051,
       "structure_id": null,
       "support_skills": {
@@ -94889,6 +95288,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597047,
       "structure_id": null,
       "support_skills": {
@@ -95091,6 +95491,7 @@
       "player_name": "LuboBG",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -95289,6 +95690,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -95487,6 +95889,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -95685,6 +96088,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -95887,6 +96291,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597048,
       "structure_id": null,
       "support_skills": {
@@ -96085,6 +96490,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -96287,6 +96693,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597049,
       "structure_id": null,
       "support_skills": {
@@ -96489,6 +96896,7 @@
       "player_name": "JzB",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -96687,6 +97095,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -96885,6 +97294,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -97083,6 +97493,7 @@
       "player_name": "vanjie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597007,
       "structure_id": null,
       "support_skills": {
@@ -97285,6 +97696,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597059,
       "structure_id": null,
       "support_skills": {
@@ -97483,6 +97895,7 @@
       "player_name": "JAV Marlboro",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597054,
       "structure_id": null,
       "support_skills": {
@@ -97681,6 +98094,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -97879,6 +98293,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597058,
       "structure_id": null,
       "support_skills": {
@@ -98077,6 +98492,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597016,
       "structure_id": null,
       "support_skills": {
@@ -98275,6 +98691,7 @@
       "player_name": "skol",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597060,
       "structure_id": null,
       "support_skills": {
@@ -98473,6 +98890,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -98675,6 +99093,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597018,
       "structure_id": null,
       "support_skills": {
@@ -98869,6 +99288,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -99071,6 +99491,7 @@
       "player_name": "MAD Mocote5",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 597017,
       "structure_id": null,
       "support_skills": {
@@ -99633,6 +100054,7 @@
       "player_name": "Røñín",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 597033,
       "structure_id": null,
       "support_skills": {
@@ -111646,6 +112068,7 @@
     "player_name": "Acanada",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
+++ b/samples/Battle/Persistent.Mail.28700881175578047431-processed.json
@@ -143,6 +143,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 798757,
       "structure_id": null,
       "support_skills": {
@@ -304,6 +305,7 @@
     "player_name": "Griggasaurus",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
+++ b/samples/Battle/Persistent.Mail.29048795175579066131-processed.json
@@ -143,6 +143,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 809011,
       "structure_id": null,
       "support_skills": {
@@ -290,6 +291,7 @@
     "player_name": "Griggasaurus",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
+++ b/samples/Battle/Persistent.Mail.30346123155694137715-processed.json
@@ -164,6 +164,7 @@
       "player_name": "hasan pilay",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 421258,
       "structure_id": null,
       "support_skills": {
@@ -278,6 +279,7 @@
     "player_name": "Resir",
     "rally": null,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
+++ b/samples/Battle/Persistent.Mail.31709368176977161019-processed.json
@@ -143,6 +143,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 875164,
       "structure_id": null,
       "support_skills": {
@@ -304,6 +305,7 @@
     "player_name": "QuackerOats",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
+++ b/samples/Battle/Persistent.Mail.32282022178380122828-processed.json
@@ -168,6 +168,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -337,6 +338,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 922766,
       "structure_id": null,
       "support_skills": {
@@ -506,6 +508,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 922765,
       "structure_id": null,
       "support_skills": {
@@ -675,6 +678,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 922800,
       "structure_id": null,
       "support_skills": {
@@ -824,6 +828,7 @@
     "player_name": "Atomicbunny",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131-processed.json
@@ -159,6 +159,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 906332,
       "structure_id": null,
       "support_skills": {
@@ -303,6 +304,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 906321,
       "structure_id": null,
       "support_skills": {
@@ -464,6 +466,7 @@
     "player_name": "Grigvar",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
+++ b/samples/Battle/Persistent.Mail.41633096157514072311-processed.json
@@ -842,6 +842,7 @@
       "player_name": "Eiden2018",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 474937,
       "structure_id": null,
       "support_skills": {
@@ -1019,6 +1020,7 @@
       "player_name": "dabrus",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475002,
       "structure_id": null,
       "support_skills": {
@@ -1175,6 +1177,7 @@
       "player_name": "dabrus",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475013,
       "structure_id": null,
       "support_skills": {
@@ -1352,6 +1355,7 @@
       "player_name": "Nhi   Hí",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475104,
       "structure_id": null,
       "support_skills": {
@@ -1508,6 +1512,7 @@
       "player_name": "Simon시몬",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475111,
       "structure_id": null,
       "support_skills": {
@@ -1681,6 +1686,7 @@
       "player_name": "Navion69",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475200,
       "structure_id": null,
       "support_skills": {
@@ -1854,6 +1860,7 @@
       "player_name": "Gunz88",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475232,
       "structure_id": null,
       "support_skills": {
@@ -2027,6 +2034,7 @@
       "player_name": "cruack",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475371,
       "structure_id": null,
       "support_skills": {
@@ -2200,6 +2208,7 @@
       "player_name": "EOB 喵腳",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2373,6 +2382,7 @@
       "player_name": "cruack",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475433,
       "structure_id": null,
       "support_skills": {
@@ -2550,6 +2560,7 @@
       "player_name": "Wanger94",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475440,
       "structure_id": null,
       "support_skills": {
@@ -2723,6 +2734,7 @@
       "player_name": "Sanya007",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475461,
       "structure_id": null,
       "support_skills": {
@@ -2904,6 +2916,7 @@
       "player_name": "VirusLoveLy",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475547,
       "structure_id": null,
       "support_skills": {
@@ -3077,6 +3090,7 @@
       "player_name": "Sanya007",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475568,
       "structure_id": null,
       "support_skills": {
@@ -3258,6 +3272,7 @@
       "player_name": "VirusLoveLy",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475603,
       "structure_id": null,
       "support_skills": {
@@ -3414,6 +3429,7 @@
       "player_name": "Phocidea",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475640,
       "structure_id": null,
       "support_skills": {
@@ -3591,6 +3607,7 @@
       "player_name": "Eiden2018",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475666,
       "structure_id": null,
       "support_skills": {
@@ -3764,6 +3781,7 @@
       "player_name": "dabrus",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475678,
       "structure_id": null,
       "support_skills": {
@@ -3937,6 +3955,7 @@
       "player_name": "Sorcerer Tim",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475682,
       "structure_id": null,
       "support_skills": {
@@ -4114,6 +4133,7 @@
       "player_name": "MemphusX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 475825,
       "structure_id": null,
       "support_skills": {
@@ -4758,6 +4778,7 @@
     "player_name": "Ø Heimdall Ø",
     "rally": true,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
+++ b/samples/Battle/Persistent.Mail.47051167177023603224-processed.json
@@ -201,6 +201,7 @@
       "player_name": "Corsaire",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -399,6 +400,7 @@
       "player_name": "Corsaire",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -597,6 +599,7 @@
       "player_name": "Corsaire",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339450,
       "structure_id": null,
       "support_skills": {
@@ -795,6 +798,7 @@
       "player_name": "Corsaire",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -993,6 +997,7 @@
       "player_name": "Corsaire",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339451,
       "structure_id": null,
       "support_skills": {
@@ -1191,6 +1196,7 @@
       "player_name": "ᴴᴮMoretti",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339448,
       "structure_id": null,
       "support_skills": {
@@ -1393,6 +1399,7 @@
       "player_name": "ᴴᴮMoretti",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1339449,
       "structure_id": null,
       "support_skills": {
@@ -1503,6 +1510,7 @@
     "player_name": "Smallest Madas",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.485440176891031331-processed.json
+++ b/samples/Battle/Persistent.Mail.485440176891031331-processed.json
@@ -168,6 +168,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 13857,
       "structure_id": null,
       "support_skills": {
@@ -319,6 +320,7 @@
     "player_name": "Grigvar",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
+++ b/samples/Battle/Persistent.Mail.53118177176782122317-processed.json
@@ -119,6 +119,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1314485,
       "structure_id": null,
       "support_skills": {
@@ -241,6 +242,7 @@
     "player_name": "Benbu",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
+++ b/samples/Battle/Persistent.Mail.54530308177357763431-processed.json
@@ -143,6 +143,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 375269,
       "structure_id": null,
       "support_skills": {
@@ -317,6 +318,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 375279,
       "structure_id": null,
       "support_skills": {
@@ -654,6 +656,7 @@
     "player_name": "Pro100WRyj ツ",
     "rally": true,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
+++ b/samples/Battle/Persistent.Mail.58600202175658527723-processed.json
@@ -201,6 +201,7 @@
       "player_name": "Titanobenbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 1603621,
       "structure_id": null,
       "support_skills": {
@@ -290,6 +291,7 @@
     "player_name": "Faystonychus",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
+++ b/samples/Battle/Persistent.Mail.60719727166813248216-processed.json
@@ -176,6 +176,7 @@
       "player_name": "Old s",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536214,
       "structure_id": null,
       "support_skills": {
@@ -357,6 +358,7 @@
       "player_name": "Саrnagе",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536215,
       "structure_id": null,
       "support_skills": {
@@ -534,6 +536,7 @@
       "player_name": "Саrnagе",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -711,6 +714,7 @@
       "player_name": "Саrnagе",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -888,6 +892,7 @@
       "player_name": "Саrnagе",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1069,6 +1074,7 @@
       "player_name": "VIP맹인",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536211,
       "structure_id": null,
       "support_skills": {
@@ -1246,6 +1252,7 @@
       "player_name": "VIP맹인",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536205,
       "structure_id": null,
       "support_skills": {
@@ -1427,6 +1434,7 @@
       "player_name": "VIP맹인",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536206,
       "structure_id": null,
       "support_skills": {
@@ -1608,6 +1616,7 @@
       "player_name": "VIP맹인",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536212,
       "structure_id": null,
       "support_skills": {
@@ -1789,6 +1798,7 @@
       "player_name": "Fear of God",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536220,
       "structure_id": null,
       "support_skills": {
@@ -1966,6 +1976,7 @@
       "player_name": "Саrnagе",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1536213,
       "structure_id": null,
       "support_skills": {
@@ -2142,6 +2153,7 @@
     "player_name": "wb74",
     "rally": null,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
+++ b/samples/Battle/Persistent.Mail.67826590176494996531-processed.json
@@ -147,6 +147,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 101149,
       "structure_id": null,
       "support_skills": {
@@ -294,6 +295,7 @@
     "player_name": "Grigvar",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
+++ b/samples/Battle/Persistent.Mail.69428020161978725321-processed.json
@@ -176,6 +176,7 @@
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -360,6 +361,7 @@
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1470642,
       "structure_id": null,
       "support_skills": {
@@ -544,6 +546,7 @@
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1470649,
       "structure_id": null,
       "support_skills": {
@@ -732,6 +735,7 @@
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1470644,
       "structure_id": null,
       "support_skills": {
@@ -909,6 +913,7 @@
       "player_name": "XxX  JOKER  XxX",
       "rally": null,
       "server_season": null,
+      "session": null,
       "start_tick": 1470634,
       "structure_id": null,
       "support_skills": {
@@ -1042,6 +1047,7 @@
     "player_name": "精武丶羅剎",
     "rally": null,
     "server_season": null,
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
+++ b/samples/Battle/Persistent.Mail.7948875176322794831-processed.json
@@ -143,6 +143,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 208770,
       "structure_id": null,
       "support_skills": {
@@ -232,6 +233,7 @@
     "player_name": "Grigvar",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
+++ b/samples/Battle/Persistent.Mail.80922048176537396031-processed.json
@@ -147,6 +147,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 525144,
       "structure_id": null,
       "support_skills": {
@@ -290,6 +291,7 @@
     "player_name": "G Var",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407016178308431431-processed.json
@@ -168,6 +168,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 205396,
       "structure_id": null,
       "support_skills": {
@@ -290,6 +291,7 @@
     "player_name": "Grigvar x Dimi",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
+++ b/samples/Battle/Persistent.Mail.8407037178308431431-processed.json
@@ -168,6 +168,7 @@
       "player_name": "",
       "rally": null,
       "server_season": "",
+      "session": null,
       "start_tick": 205395,
       "structure_id": null,
       "support_skills": {
@@ -302,6 +303,7 @@
     "player_name": "Grigvar x Dimi",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": true,

--- a/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
+++ b/samples/Battle/Persistent.Mail.8421200117137313126-processed.json
@@ -201,6 +201,7 @@
       "player_name": "ˢˣ火TDouche",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378833,
       "structure_id": null,
       "support_skills": {
@@ -403,6 +404,7 @@
       "player_name": "АLex",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -605,6 +607,7 @@
       "player_name": "oldpirate loopy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -807,6 +810,7 @@
       "player_name": "oldpirate loopy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -1005,6 +1009,7 @@
       "player_name": "oldpirate loopy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378832,
       "structure_id": null,
       "support_skills": {
@@ -1207,6 +1212,7 @@
       "player_name": "magut",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377880,
       "structure_id": null,
       "support_skills": {
@@ -1388,6 +1394,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377995,
       "structure_id": null,
       "support_skills": {
@@ -1590,6 +1597,7 @@
       "player_name": "Julius Cesar II",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378182,
       "structure_id": null,
       "support_skills": {
@@ -1792,6 +1800,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -1986,6 +1995,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -2180,6 +2190,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -2382,6 +2393,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -2563,6 +2575,7 @@
       "player_name": "Ğrumpy Čhris",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -2765,6 +2778,7 @@
       "player_name": "Tribun Ludwig",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -2967,6 +2981,7 @@
       "player_name": "MercilessNoob",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -3169,6 +3184,7 @@
       "player_name": "BadBunnyBernie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378675,
       "structure_id": null,
       "support_skills": {
@@ -3371,6 +3387,7 @@
       "player_name": "BadBunnyBernie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378347,
       "structure_id": null,
       "support_skills": {
@@ -3565,6 +3582,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3767,6 +3785,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -3965,6 +3984,7 @@
       "player_name": "m212",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -4167,6 +4187,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -4369,6 +4390,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -4571,6 +4593,7 @@
       "player_name": "ToxıcRıck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377390,
       "structure_id": null,
       "support_skills": {
@@ -4773,6 +4796,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -4967,6 +4991,7 @@
       "player_name": "Mystique",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -5169,6 +5194,7 @@
       "player_name": "anfis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -5363,6 +5389,7 @@
       "player_name": "anfis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5565,6 +5592,7 @@
       "player_name": "anfis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377370,
       "structure_id": null,
       "support_skills": {
@@ -5767,6 +5795,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -5969,6 +5998,7 @@
       "player_name": "Zwiebelritter79",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -6171,6 +6201,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -6369,6 +6400,7 @@
       "player_name": "B4ngB4ng",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379179,
       "structure_id": null,
       "support_skills": {
@@ -6571,6 +6603,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6773,6 +6806,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377433,
       "structure_id": null,
       "support_skills": {
@@ -6975,6 +7009,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -7177,6 +7212,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -7379,6 +7415,7 @@
       "player_name": "x Twitty x",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378646,
       "structure_id": null,
       "support_skills": {
@@ -7577,6 +7614,7 @@
       "player_name": "武士道Hercs",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378000,
       "structure_id": null,
       "support_skills": {
@@ -7779,6 +7817,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -7981,6 +8020,7 @@
       "player_name": "ˢAuthentiks",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -8179,6 +8219,7 @@
       "player_name": "ˢAuthentiks",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377761,
       "structure_id": null,
       "support_skills": {
@@ -8373,6 +8414,7 @@
       "player_name": "Thorin lonestar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378636,
       "structure_id": null,
       "support_skills": {
@@ -8575,6 +8617,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -8777,6 +8820,7 @@
       "player_name": "Paul Atreidês",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -8954,6 +8998,7 @@
       "player_name": "Thorin lonestar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -9152,6 +9197,7 @@
       "player_name": "poisоn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -9350,6 +9396,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -9552,6 +9599,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377378,
       "structure_id": null,
       "support_skills": {
@@ -9750,6 +9798,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -9952,6 +10001,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -10150,6 +10200,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377377,
       "structure_id": null,
       "support_skills": {
@@ -10352,6 +10403,7 @@
       "player_name": "Helly Jelly",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377400,
       "structure_id": null,
       "support_skills": {
@@ -10554,6 +10606,7 @@
       "player_name": "Paul Atreidês",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377828,
       "structure_id": null,
       "support_skills": {
@@ -10756,6 +10809,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -10958,6 +11012,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377357,
       "structure_id": null,
       "support_skills": {
@@ -11160,6 +11215,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -11362,6 +11418,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377530,
       "structure_id": null,
       "support_skills": {
@@ -11564,6 +11621,7 @@
       "player_name": "霊ˢ Kleines",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -11766,6 +11824,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -11968,6 +12027,7 @@
       "player_name": "BABA YAGA 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377419,
       "structure_id": null,
       "support_skills": {
@@ -12170,6 +12230,7 @@
       "player_name": "BABA YAGA 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377315,
       "structure_id": null,
       "support_skills": {
@@ -12372,6 +12433,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377352,
       "structure_id": null,
       "support_skills": {
@@ -12574,6 +12636,7 @@
       "player_name": "BABA YAGA 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377517,
       "structure_id": null,
       "support_skills": {
@@ -12776,6 +12839,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377346,
       "structure_id": null,
       "support_skills": {
@@ -12978,6 +13042,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377409,
       "structure_id": null,
       "support_skills": {
@@ -13180,6 +13245,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -13382,6 +13448,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -13580,6 +13647,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -13782,6 +13850,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377384,
       "structure_id": null,
       "support_skills": {
@@ -13984,6 +14053,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -14186,6 +14256,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377515,
       "structure_id": null,
       "support_skills": {
@@ -14367,6 +14438,7 @@
       "player_name": "Julius Cesar II",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -14569,6 +14641,7 @@
       "player_name": "lLii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -14767,6 +14840,7 @@
       "player_name": "ツ Governor ツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377395,
       "structure_id": null,
       "support_skills": {
@@ -14969,6 +15043,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377522,
       "structure_id": null,
       "support_skills": {
@@ -15171,6 +15246,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -15373,6 +15449,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377960,
       "structure_id": null,
       "support_skills": {
@@ -15575,6 +15652,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377389,
       "structure_id": null,
       "support_skills": {
@@ -15777,6 +15855,7 @@
       "player_name": "KittySoftPaws",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -15971,6 +16050,7 @@
       "player_name": "KittySoftPaws",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377764,
       "structure_id": null,
       "support_skills": {
@@ -16165,6 +16245,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378318,
       "structure_id": null,
       "support_skills": {
@@ -16367,6 +16448,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377758,
       "structure_id": null,
       "support_skills": {
@@ -16561,6 +16643,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377426,
       "structure_id": null,
       "support_skills": {
@@ -16759,6 +16842,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -31627,6 +31711,7 @@
       "player_name": "Ğrumpy Čhris",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377305,
       "structure_id": null,
       "support_skills": {
@@ -32333,6 +32418,7 @@
       "player_name": "箭ˢJian",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377313,
       "structure_id": null,
       "support_skills": {
@@ -32535,6 +32621,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -32737,6 +32824,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377572,
       "structure_id": null,
       "support_skills": {
@@ -32939,6 +33027,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377415,
       "structure_id": null,
       "support_skills": {
@@ -33141,6 +33230,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377584,
       "structure_id": null,
       "support_skills": {
@@ -33339,6 +33429,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377401,
       "structure_id": null,
       "support_skills": {
@@ -33541,6 +33632,7 @@
       "player_name": "Y A M A",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -33739,6 +33831,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377508,
       "structure_id": null,
       "support_skills": {
@@ -33937,6 +34030,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377571,
       "structure_id": null,
       "support_skills": {
@@ -34139,6 +34233,7 @@
       "player_name": "Y A M A",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378533,
       "structure_id": null,
       "support_skills": {
@@ -34333,6 +34428,7 @@
       "player_name": "Y A M A",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378155,
       "structure_id": null,
       "support_skills": {
@@ -34535,6 +34631,7 @@
       "player_name": "뚜뚜 DduDdu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378037,
       "structure_id": null,
       "support_skills": {
@@ -34720,6 +34817,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377453,
       "structure_id": null,
       "support_skills": {
@@ -34926,6 +35024,7 @@
       "player_name": "Moor Fuerst",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377467,
       "structure_id": null,
       "support_skills": {
@@ -35090,6 +35189,7 @@
       "player_name": "Captmimi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377473,
       "structure_id": null,
       "support_skills": {
@@ -35292,6 +35392,7 @@
       "player_name": "四Ocho 四",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377715,
       "structure_id": null,
       "support_skills": {
@@ -35494,6 +35595,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -35692,6 +35794,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377771,
       "structure_id": null,
       "support_skills": {
@@ -35894,6 +35997,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -36088,6 +36192,7 @@
       "player_name": "Listige Hummel",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377551,
       "structure_id": null,
       "support_skills": {
@@ -36290,6 +36395,7 @@
       "player_name": "KastielX",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377558,
       "structure_id": null,
       "support_skills": {
@@ -36492,6 +36598,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36694,6 +36801,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377765,
       "structure_id": null,
       "support_skills": {
@@ -36896,6 +37004,7 @@
       "player_name": "Sylvia 00",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377590,
       "structure_id": null,
       "support_skills": {
@@ -37094,6 +37203,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -37288,6 +37398,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377769,
       "structure_id": null,
       "support_skills": {
@@ -37486,6 +37597,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377648,
       "structure_id": null,
       "support_skills": {
@@ -37688,6 +37800,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -37882,6 +37995,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377797,
       "structure_id": null,
       "support_skills": {
@@ -38080,6 +38194,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378012,
       "structure_id": null,
       "support_skills": {
@@ -38286,6 +38401,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377662,
       "structure_id": null,
       "support_skills": {
@@ -38488,6 +38604,7 @@
       "player_name": "Caesar2019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -38682,6 +38799,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -38884,6 +39002,7 @@
       "player_name": "Nostrum33",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -39078,6 +39197,7 @@
       "player_name": "Captmimi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -39255,6 +39375,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377678,
       "structure_id": null,
       "support_skills": {
@@ -39449,6 +39570,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -39651,6 +39773,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377778,
       "structure_id": null,
       "support_skills": {
@@ -39853,6 +39976,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377953,
       "structure_id": null,
       "support_skills": {
@@ -40055,6 +40179,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -40236,6 +40361,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377685,
       "structure_id": null,
       "support_skills": {
@@ -40434,6 +40560,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40632,6 +40759,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377784,
       "structure_id": null,
       "support_skills": {
@@ -40834,6 +40962,7 @@
       "player_name": "Klimson3",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377935,
       "structure_id": null,
       "support_skills": {
@@ -41032,6 +41161,7 @@
       "player_name": "poisоn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377940,
       "structure_id": null,
       "support_skills": {
@@ -41234,6 +41364,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -41440,6 +41571,7 @@
       "player_name": "Moor Fuerst",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377737,
       "structure_id": null,
       "support_skills": {
@@ -41621,6 +41753,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377743,
       "structure_id": null,
       "support_skills": {
@@ -41823,6 +41956,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378013,
       "structure_id": null,
       "support_skills": {
@@ -42021,6 +42155,7 @@
       "player_name": "Fiese Hornisse",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378019,
       "structure_id": null,
       "support_skills": {
@@ -42219,6 +42354,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377987,
       "structure_id": null,
       "support_skills": {
@@ -42417,6 +42553,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377980,
       "structure_id": null,
       "support_skills": {
@@ -42619,6 +42756,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378003,
       "structure_id": null,
       "support_skills": {
@@ -42821,6 +42959,7 @@
       "player_name": "Listige Hummel",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -43023,6 +43162,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377777,
       "structure_id": null,
       "support_skills": {
@@ -43225,6 +43365,7 @@
       "player_name": "Mangeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377789,
       "structure_id": null,
       "support_skills": {
@@ -43427,6 +43568,7 @@
       "player_name": "EDM LORD",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379630,
       "structure_id": null,
       "support_skills": {
@@ -44205,6 +44347,7 @@
       "player_name": "箭ˢJian",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377835,
       "structure_id": null,
       "support_skills": {
@@ -44407,6 +44550,7 @@
       "player_name": "RandyyRandom",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377817,
       "structure_id": null,
       "support_skills": {
@@ -44609,6 +44753,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378522,
       "structure_id": null,
       "support_skills": {
@@ -44803,6 +44948,7 @@
       "player_name": "Mystique",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377858,
       "structure_id": null,
       "support_skills": {
@@ -45005,6 +45151,7 @@
       "player_name": "Helly Jelly",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377865,
       "structure_id": null,
       "support_skills": {
@@ -45207,6 +45354,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -45409,6 +45557,7 @@
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377871,
       "structure_id": null,
       "support_skills": {
@@ -45611,6 +45760,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -45805,6 +45955,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378140,
       "structure_id": null,
       "support_skills": {
@@ -46007,6 +46158,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378009,
       "structure_id": null,
       "support_skills": {
@@ -46205,6 +46357,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378016,
       "structure_id": null,
       "support_skills": {
@@ -46407,6 +46560,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2377894,
       "structure_id": null,
       "support_skills": {
@@ -46601,6 +46755,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378145,
       "structure_id": null,
       "support_skills": {
@@ -46803,6 +46958,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -47001,6 +47157,7 @@
       "player_name": "メDmitry82メ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378443,
       "structure_id": null,
       "support_skills": {
@@ -47203,6 +47360,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -47405,6 +47563,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378152,
       "structure_id": null,
       "support_skills": {
@@ -47603,6 +47762,7 @@
       "player_name": "Ada ㋛",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378024,
       "structure_id": null,
       "support_skills": {
@@ -47805,6 +47965,7 @@
       "player_name": "lLii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -48003,6 +48164,7 @@
       "player_name": "义 IIIVMINATI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378160,
       "structure_id": null,
       "support_skills": {
@@ -48205,6 +48367,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -48403,6 +48566,7 @@
       "player_name": "义 IIIVMINATI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -48605,6 +48769,7 @@
       "player_name": "運命ˢToxic",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378873,
       "structure_id": null,
       "support_skills": {
@@ -48790,6 +48955,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378051,
       "structure_id": null,
       "support_skills": {
@@ -48988,6 +49154,7 @@
       "player_name": "Moor Fuerst",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378057,
       "structure_id": null,
       "support_skills": {
@@ -49190,6 +49357,7 @@
       "player_name": "SAH4RCOREJZ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -49388,6 +49556,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378063,
       "structure_id": null,
       "support_skills": {
@@ -49582,6 +49751,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378438,
       "structure_id": null,
       "support_skills": {
@@ -49784,6 +49954,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -49986,6 +50157,7 @@
       "player_name": "Sylvia 00",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -50167,6 +50339,7 @@
       "player_name": "Krawler12000",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378080,
       "structure_id": null,
       "support_skills": {
@@ -50369,6 +50542,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50550,6 +50724,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378092,
       "structure_id": null,
       "support_skills": {
@@ -50752,6 +50927,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -50950,6 +51126,7 @@
       "player_name": "Sir Skyrr Duck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378107,
       "structure_id": null,
       "support_skills": {
@@ -51152,6 +51329,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378316,
       "structure_id": null,
       "support_skills": {
@@ -51354,6 +51532,7 @@
       "player_name": "Caesar2019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -51556,6 +51735,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51754,6 +51934,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378334,
       "structure_id": null,
       "support_skills": {
@@ -51956,6 +52137,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378472,
       "structure_id": null,
       "support_skills": {
@@ -52158,6 +52340,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378296,
       "structure_id": null,
       "support_skills": {
@@ -52360,6 +52543,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52562,6 +52746,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52760,6 +52945,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -52941,6 +53127,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378133,
       "structure_id": null,
       "support_skills": {
@@ -53139,6 +53326,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -53337,6 +53525,7 @@
       "player_name": "poisоn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378428,
       "structure_id": null,
       "support_skills": {
@@ -53539,6 +53728,7 @@
       "player_name": "Paul Atreidês",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378432,
       "structure_id": null,
       "support_skills": {
@@ -53741,6 +53931,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -53939,6 +54130,7 @@
       "player_name": "Caesar2019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378168,
       "structure_id": null,
       "support_skills": {
@@ -54141,6 +54333,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -54343,6 +54536,7 @@
       "player_name": "ツ Governor ツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378180,
       "structure_id": null,
       "support_skills": {
@@ -54541,6 +54735,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378501,
       "structure_id": null,
       "support_skills": {
@@ -54743,6 +54938,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -54924,6 +55120,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378194,
       "structure_id": null,
       "support_skills": {
@@ -55118,6 +55315,7 @@
       "player_name": "RandyyRandom",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378200,
       "structure_id": null,
       "support_skills": {
@@ -55316,6 +55514,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -55518,6 +55717,7 @@
       "player_name": "Y A M A",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378207,
       "structure_id": null,
       "support_skills": {
@@ -55720,6 +55920,7 @@
       "player_name": "I Dare",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -55922,6 +56123,7 @@
       "player_name": "xxRONxx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378213,
       "structure_id": null,
       "support_skills": {
@@ -56124,6 +56326,7 @@
       "player_name": "Sylvia 00",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -56326,6 +56529,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378453,
       "structure_id": null,
       "support_skills": {
@@ -56524,6 +56728,7 @@
       "player_name": "Swiphz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378247,
       "structure_id": null,
       "support_skills": {
@@ -56726,6 +56931,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -56928,6 +57134,7 @@
       "player_name": "B4ngB4ng",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -57126,6 +57333,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378269,
       "structure_id": null,
       "support_skills": {
@@ -57320,6 +57528,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -57522,6 +57731,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378278,
       "structure_id": null,
       "support_skills": {
@@ -57724,6 +57934,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378441,
       "structure_id": null,
       "support_skills": {
@@ -57926,6 +58137,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378638,
       "structure_id": null,
       "support_skills": {
@@ -58120,6 +58332,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378479,
       "structure_id": null,
       "support_skills": {
@@ -58318,6 +58531,7 @@
       "player_name": "㋡Flickツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -58520,6 +58734,7 @@
       "player_name": "KastielX",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378294,
       "structure_id": null,
       "support_skills": {
@@ -58722,6 +58937,7 @@
       "player_name": "Captmimi",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -58899,6 +59115,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378310,
       "structure_id": null,
       "support_skills": {
@@ -59101,6 +59318,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378464,
       "structure_id": null,
       "support_skills": {
@@ -59303,6 +59521,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378538,
       "structure_id": null,
       "support_skills": {
@@ -59505,6 +59724,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -59682,6 +59902,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378336,
       "structure_id": null,
       "support_skills": {
@@ -60586,6 +60807,7 @@
       "player_name": "駆逐艦ˢBrHe",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378374,
       "structure_id": null,
       "support_skills": {
@@ -60788,6 +61010,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -60969,6 +61192,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378359,
       "structure_id": null,
       "support_skills": {
@@ -61171,6 +61395,7 @@
       "player_name": "magut",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -61369,6 +61594,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378385,
       "structure_id": null,
       "support_skills": {
@@ -61571,6 +61797,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378391,
       "structure_id": null,
       "support_skills": {
@@ -61769,6 +61996,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378537,
       "structure_id": null,
       "support_skills": {
@@ -61963,6 +62191,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -62165,6 +62394,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378466,
       "structure_id": null,
       "support_skills": {
@@ -62366,6 +62596,7 @@
       "player_name": "Aachen 7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -62564,6 +62795,7 @@
       "player_name": "Caesar2019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378402,
       "structure_id": null,
       "support_skills": {
@@ -62762,6 +62994,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378492,
       "structure_id": null,
       "support_skills": {
@@ -62964,6 +63197,7 @@
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378415,
       "structure_id": null,
       "support_skills": {
@@ -63158,6 +63392,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -63356,6 +63591,7 @@
       "player_name": "Swiphz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378434,
       "structure_id": null,
       "support_skills": {
@@ -63558,6 +63794,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63760,6 +63997,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378640,
       "structure_id": null,
       "support_skills": {
@@ -63958,6 +64196,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -64160,6 +64399,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378459,
       "structure_id": null,
       "support_skills": {
@@ -64362,6 +64602,7 @@
       "player_name": "DuckTheDuckTeen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -64556,6 +64797,7 @@
       "player_name": "DuckTheDuckTeen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379859,
       "structure_id": null,
       "support_skills": {
@@ -64754,6 +64996,7 @@
       "player_name": "ToxıcRıck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378478,
       "structure_id": null,
       "support_skills": {
@@ -64956,6 +65199,7 @@
       "player_name": "Zuckachu ヅ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378485,
       "structure_id": null,
       "support_skills": {
@@ -65158,6 +65402,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378645,
       "structure_id": null,
       "support_skills": {
@@ -65360,6 +65605,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -65558,6 +65804,7 @@
       "player_name": "Lässige Biene",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378499,
       "structure_id": null,
       "support_skills": {
@@ -65760,6 +66007,7 @@
       "player_name": "FreeRun",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378662,
       "structure_id": null,
       "support_skills": {
@@ -65962,6 +66210,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378531,
       "structure_id": null,
       "support_skills": {
@@ -66164,6 +66413,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378545,
       "structure_id": null,
       "support_skills": {
@@ -66366,6 +66616,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378738,
       "structure_id": null,
       "support_skills": {
@@ -66564,6 +66815,7 @@
       "player_name": "poisоn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -66766,6 +67018,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -66968,6 +67221,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378580,
       "structure_id": null,
       "support_skills": {
@@ -67170,6 +67424,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378998,
       "structure_id": null,
       "support_skills": {
@@ -67364,6 +67619,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -67566,6 +67822,7 @@
       "player_name": "lLii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -67760,6 +68017,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -67962,6 +68220,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378587,
       "structure_id": null,
       "support_skills": {
@@ -68164,6 +68423,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378663,
       "structure_id": null,
       "support_skills": {
@@ -68366,6 +68626,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -68568,6 +68829,7 @@
       "player_name": "Fürst Wilhelm",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378790,
       "structure_id": null,
       "support_skills": {
@@ -68770,6 +69032,7 @@
       "player_name": "Vabrök",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379005,
       "structure_id": null,
       "support_skills": {
@@ -68972,6 +69235,7 @@
       "player_name": "RandyyRandom",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378593,
       "structure_id": null,
       "support_skills": {
@@ -69170,6 +69434,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -69372,6 +69637,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -69570,6 +69836,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378654,
       "structure_id": null,
       "support_skills": {
@@ -69768,6 +70035,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378812,
       "structure_id": null,
       "support_skills": {
@@ -69970,6 +70238,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378817,
       "structure_id": null,
       "support_skills": {
@@ -70172,6 +70441,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -70374,6 +70644,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -70576,6 +70847,7 @@
       "player_name": "Starr77",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378626,
       "structure_id": null,
       "support_skills": {
@@ -70770,6 +71042,7 @@
       "player_name": "Bobby Wobbler",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378823,
       "structure_id": null,
       "support_skills": {
@@ -70972,6 +71245,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378828,
       "structure_id": null,
       "support_skills": {
@@ -71174,6 +71448,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -71376,6 +71651,7 @@
       "player_name": "KastielX",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378634,
       "structure_id": null,
       "support_skills": {
@@ -71578,6 +71854,7 @@
       "player_name": "VodkaTitten 亗",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378982,
       "structure_id": null,
       "support_skills": {
@@ -71784,6 +72061,7 @@
       "player_name": "sucior420",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379050,
       "structure_id": null,
       "support_skills": {
@@ -71986,6 +72264,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378896,
       "structure_id": null,
       "support_skills": {
@@ -72188,6 +72467,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -72390,6 +72670,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -72592,6 +72873,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -72794,6 +73076,7 @@
       "player_name": "BadBunnyBernie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -72971,6 +73254,7 @@
       "player_name": "ᵛⁿSabu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378709,
       "structure_id": null,
       "support_skills": {
@@ -73169,6 +73453,7 @@
       "player_name": "Lässige Biene",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -73371,6 +73656,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378722,
       "structure_id": null,
       "support_skills": {
@@ -73573,6 +73859,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378818,
       "structure_id": null,
       "support_skills": {
@@ -73775,6 +74062,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -73973,6 +74261,7 @@
       "player_name": "Sir Skyrr Duck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -74175,6 +74464,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -74352,6 +74642,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378736,
       "structure_id": null,
       "support_skills": {
@@ -74550,6 +74841,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -74748,6 +75040,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378822,
       "structure_id": null,
       "support_skills": {
@@ -74950,6 +75243,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378956,
       "structure_id": null,
       "support_skills": {
@@ -75148,6 +75442,7 @@
       "player_name": "Mangeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378748,
       "structure_id": null,
       "support_skills": {
@@ -75350,6 +75645,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378962,
       "structure_id": null,
       "support_skills": {
@@ -75548,6 +75844,7 @@
       "player_name": "Swiphz",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378756,
       "structure_id": null,
       "support_skills": {
@@ -75750,6 +76047,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379463,
       "structure_id": null,
       "support_skills": {
@@ -75948,6 +76246,7 @@
       "player_name": "Moor Fuerst",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378762,
       "structure_id": null,
       "support_skills": {
@@ -76150,6 +76449,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378990,
       "structure_id": null,
       "support_skills": {
@@ -76352,6 +76652,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -76550,6 +76851,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -76744,6 +77046,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378968,
       "structure_id": null,
       "support_skills": {
@@ -76946,6 +77249,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379318,
       "structure_id": null,
       "support_skills": {
@@ -77148,6 +77452,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379177,
       "structure_id": null,
       "support_skills": {
@@ -77350,6 +77655,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378957,
       "structure_id": null,
       "support_skills": {
@@ -77531,6 +77837,7 @@
       "player_name": "m212",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378797,
       "structure_id": null,
       "support_skills": {
@@ -77712,6 +78019,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -78472,6 +78780,7 @@
       "player_name": "箭ˢJian",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -78664,6 +78973,7 @@
       "player_name": "ToxıcRıck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378834,
       "structure_id": null,
       "support_skills": {
@@ -78862,6 +79172,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378841,
       "structure_id": null,
       "support_skills": {
@@ -79056,6 +79367,7 @@
       "player_name": "m212",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379698,
       "structure_id": null,
       "support_skills": {
@@ -79258,6 +79570,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -79414,6 +79727,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -79599,6 +79913,7 @@
       "player_name": "Tribun Ludwig",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378862,
       "structure_id": null,
       "support_skills": {
@@ -79793,6 +80108,7 @@
       "player_name": "Sir Bambam",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -79995,6 +80311,7 @@
       "player_name": "MaGittis",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -80193,6 +80510,7 @@
       "player_name": "Caesar2019",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378869,
       "structure_id": null,
       "support_skills": {
@@ -80395,6 +80713,7 @@
       "player_name": "Starr77",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378875,
       "structure_id": null,
       "support_skills": {
@@ -80572,6 +80891,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378880,
       "structure_id": null,
       "support_skills": {
@@ -80770,6 +81090,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378951,
       "structure_id": null,
       "support_skills": {
@@ -80947,6 +81268,7 @@
       "player_name": "lLii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378913,
       "structure_id": null,
       "support_skills": {
@@ -81149,6 +81471,7 @@
       "player_name": "Helly Jelly",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379134,
       "structure_id": null,
       "support_skills": {
@@ -81351,6 +81674,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2378938,
       "structure_id": null,
       "support_skills": {
@@ -81549,6 +81873,7 @@
       "player_name": "oldpirate loopy",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -81751,6 +82076,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379158,
       "structure_id": null,
       "support_skills": {
@@ -81953,6 +82279,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379164,
       "structure_id": null,
       "support_skills": {
@@ -82134,6 +82461,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379012,
       "structure_id": null,
       "support_skills": {
@@ -82336,6 +82664,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -82530,6 +82859,7 @@
       "player_name": "Listige Hummel",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379019,
       "structure_id": null,
       "support_skills": {
@@ -82711,6 +83041,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -82917,6 +83248,7 @@
       "player_name": "Aydinn",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379026,
       "structure_id": null,
       "support_skills": {
@@ -83119,6 +83451,7 @@
       "player_name": "箭ˢJian",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379459,
       "structure_id": null,
       "support_skills": {
@@ -83321,6 +83654,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -83502,6 +83836,7 @@
       "player_name": "Tribun Ludwig",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379052,
       "structure_id": null,
       "support_skills": {
@@ -83700,6 +84035,7 @@
       "player_name": "EDM LORD",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379059,
       "structure_id": null,
       "support_skills": {
@@ -83898,6 +84234,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379167,
       "structure_id": null,
       "support_skills": {
@@ -84083,6 +84420,7 @@
       "player_name": "Zwiebelritter79",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379078,
       "structure_id": null,
       "support_skills": {
@@ -84285,6 +84623,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379170,
       "structure_id": null,
       "support_skills": {
@@ -84483,6 +84822,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -84685,6 +85025,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -84887,6 +85228,7 @@
       "player_name": "m212",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379112,
       "structure_id": null,
       "support_skills": {
@@ -85081,6 +85423,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379278,
       "structure_id": null,
       "support_skills": {
@@ -85279,6 +85622,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379311,
       "structure_id": null,
       "support_skills": {
@@ -85481,6 +85825,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379324,
       "structure_id": null,
       "support_skills": {
@@ -85654,6 +85999,7 @@
       "player_name": "BLK92",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379500,
       "structure_id": null,
       "support_skills": {
@@ -85856,6 +86202,7 @@
       "player_name": "magut",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -86054,6 +86401,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -86256,6 +86604,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379331,
       "structure_id": null,
       "support_skills": {
@@ -86458,6 +86807,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379554,
       "structure_id": null,
       "support_skills": {
@@ -86660,6 +87010,7 @@
       "player_name": "Bloodypickle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -86862,6 +87213,7 @@
       "player_name": "Bexissᴮᴿ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379183,
       "structure_id": null,
       "support_skills": {
@@ -87022,6 +87374,7 @@
       "player_name": "Tribun Ludwig",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379190,
       "structure_id": null,
       "support_skills": {
@@ -87199,6 +87552,7 @@
       "player_name": "ᵛⁿSabu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -87397,6 +87751,7 @@
       "player_name": "ToxıcRıck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379202,
       "structure_id": null,
       "support_skills": {
@@ -87578,6 +87933,7 @@
       "player_name": "Julius Cesar II",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379204,
       "structure_id": null,
       "support_skills": {
@@ -87776,6 +88132,7 @@
       "player_name": "Lässige Biene",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379211,
       "structure_id": null,
       "support_skills": {
@@ -87978,6 +88335,7 @@
       "player_name": "BadBunnyBernie",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379371,
       "structure_id": null,
       "support_skills": {
@@ -88155,6 +88513,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -88336,6 +88695,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379217,
       "structure_id": null,
       "support_skills": {
@@ -88496,6 +88856,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379224,
       "structure_id": null,
       "support_skills": {
@@ -88673,6 +89034,7 @@
       "player_name": "lLii",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379243,
       "structure_id": null,
       "support_skills": {
@@ -88875,6 +89237,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379470,
       "structure_id": null,
       "support_skills": {
@@ -89077,6 +89440,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379255,
       "structure_id": null,
       "support_skills": {
@@ -89275,6 +89639,7 @@
       "player_name": "Nostrum33",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379262,
       "structure_id": null,
       "support_skills": {
@@ -89473,6 +89838,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -89671,6 +90037,7 @@
       "player_name": "Trehl",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379562,
       "structure_id": null,
       "support_skills": {
@@ -89869,6 +90236,7 @@
       "player_name": "Greiserich",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379284,
       "structure_id": null,
       "support_skills": {
@@ -90067,6 +90435,7 @@
       "player_name": "ˢˣ乄Daspim",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379456,
       "structure_id": null,
       "support_skills": {
@@ -90269,6 +90638,7 @@
       "player_name": "㋡Flickツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379305,
       "structure_id": null,
       "support_skills": {
@@ -90471,6 +90841,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -90673,6 +91044,7 @@
       "player_name": "Sir Relington",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -90875,6 +91247,7 @@
       "player_name": "Aldérik",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379345,
       "structure_id": null,
       "support_skills": {
@@ -91031,6 +91404,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -91233,6 +91607,7 @@
       "player_name": "iKoSenSei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379353,
       "structure_id": null,
       "support_skills": {
@@ -91427,6 +91802,7 @@
       "player_name": "DuckTheDuckTeen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -91608,6 +91984,7 @@
       "player_name": "Krawler12000",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -91810,6 +92187,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379360,
       "structure_id": null,
       "support_skills": {
@@ -92012,6 +92390,7 @@
       "player_name": "Zuckachu ヅ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -92214,6 +92593,7 @@
       "player_name": "KittySoftPaws",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379367,
       "structure_id": null,
       "support_skills": {
@@ -92412,6 +92792,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -92614,6 +92995,7 @@
       "player_name": "Nostrum33",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379375,
       "structure_id": null,
       "support_skills": {
@@ -92816,6 +93198,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -93014,6 +93397,7 @@
       "player_name": "Joey22587",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379469,
       "structure_id": null,
       "support_skills": {
@@ -93170,6 +93554,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379382,
       "structure_id": null,
       "support_skills": {
@@ -93351,6 +93736,7 @@
       "player_name": "YourLuck",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379390,
       "structure_id": null,
       "support_skills": {
@@ -93549,6 +93935,7 @@
       "player_name": "Basstma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379420,
       "structure_id": null,
       "support_skills": {
@@ -93747,6 +94134,7 @@
       "player_name": "Banna93",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379427,
       "structure_id": null,
       "support_skills": {
@@ -93949,6 +94337,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -94151,6 +94540,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -94349,6 +94739,7 @@
       "player_name": "Stop war ua",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379434,
       "structure_id": null,
       "support_skills": {
@@ -94551,6 +94942,7 @@
       "player_name": "ᵛᶯPaz Visla",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379442,
       "structure_id": null,
       "support_skills": {
@@ -94753,6 +95145,7 @@
       "player_name": "KittySoftPaws",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -94951,6 +95344,7 @@
       "player_name": "6sG 7oker",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -95671,6 +96065,7 @@
       "player_name": "箭ˢJian",
       "rally": true,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379485,
       "structure_id": null,
       "support_skills": {
@@ -95865,6 +96260,7 @@
       "player_name": "iKoSenSei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379458,
       "structure_id": null,
       "support_skills": {
@@ -96042,6 +96438,7 @@
       "player_name": "KastielX",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379476,
       "structure_id": null,
       "support_skills": {
@@ -96240,6 +96637,7 @@
       "player_name": "义 IIIVMINATI",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -96438,6 +96836,7 @@
       "player_name": "MaveK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379483,
       "structure_id": null,
       "support_skills": {
@@ -96640,6 +97039,7 @@
       "player_name": "Aachen 7",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -96842,6 +97242,7 @@
       "player_name": "Starr77",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379489,
       "structure_id": null,
       "support_skills": {
@@ -97036,6 +97437,7 @@
       "player_name": "Shazb0t",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -97192,6 +97594,7 @@
       "player_name": "Murphatlar",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379495,
       "structure_id": null,
       "support_skills": {
@@ -97390,6 +97793,7 @@
       "player_name": "SAH4RCOREJZ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -97596,6 +98000,7 @@
       "player_name": "Babel 03",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379501,
       "structure_id": null,
       "support_skills": {
@@ -97798,6 +98203,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -98000,6 +98406,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -98194,6 +98601,7 @@
       "player_name": "ᵛⁿSabu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379513,
       "structure_id": null,
       "support_skills": {
@@ -98396,6 +98804,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -98598,6 +99007,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379507,
       "structure_id": null,
       "support_skills": {
@@ -98796,6 +99206,7 @@
       "player_name": "SLIMEY KRAK869",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379722,
       "structure_id": null,
       "support_skills": {
@@ -98973,6 +99384,7 @@
       "player_name": "Judge Jonzement",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379519,
       "structure_id": null,
       "support_skills": {
@@ -99175,6 +99587,7 @@
       "player_name": "King Elma",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379691,
       "structure_id": null,
       "support_skills": {
@@ -99377,6 +99790,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379684,
       "structure_id": null,
       "support_skills": {
@@ -99575,6 +99989,7 @@
       "player_name": "٠Helmchen٠",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379710,
       "structure_id": null,
       "support_skills": {
@@ -99777,6 +100192,7 @@
       "player_name": "Allesauf0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379548,
       "structure_id": null,
       "support_skills": {
@@ -99979,6 +100395,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379598,
       "structure_id": null,
       "support_skills": {
@@ -100181,6 +100598,7 @@
       "player_name": "Sɪʀ Zucks",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379605,
       "structure_id": null,
       "support_skills": {
@@ -100379,6 +100797,7 @@
       "player_name": "iKoSenSei",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379637,
       "structure_id": null,
       "support_skills": {
@@ -100560,6 +100979,7 @@
       "player_name": "Tribun Ludwig",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379645,
       "structure_id": null,
       "support_skills": {
@@ -100762,6 +101182,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379651,
       "structure_id": null,
       "support_skills": {
@@ -100964,6 +101385,7 @@
       "player_name": "㋡Flickツ",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379658,
       "structure_id": null,
       "support_skills": {
@@ -101162,6 +101584,7 @@
       "player_name": "Henry Targaryen",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379666,
       "structure_id": null,
       "support_skills": {
@@ -101364,6 +101787,7 @@
       "player_name": "F4TF4LK",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379670,
       "structure_id": null,
       "support_skills": {
@@ -101541,6 +101965,7 @@
       "player_name": "Rummeltrupp",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379678,
       "structure_id": null,
       "support_skills": {
@@ -101722,6 +102147,7 @@
       "player_name": "xX亗Snake亗Xx",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379704,
       "structure_id": null,
       "support_skills": {
@@ -101924,6 +102350,7 @@
       "player_name": "Arck0",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379716,
       "structure_id": null,
       "support_skills": {
@@ -102126,6 +102553,7 @@
       "player_name": "I Dare",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379752,
       "structure_id": null,
       "support_skills": {
@@ -102315,6 +102743,7 @@
       "player_name": "ᵛⁿmoneybo",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379753,
       "structure_id": null,
       "support_skills": {
@@ -102509,6 +102938,7 @@
       "player_name": "ᵛⁿSabu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -102711,6 +103141,7 @@
       "player_name": "ᵀˢᵀEliza",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -102913,6 +103344,7 @@
       "player_name": "Nostrum33",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379766,
       "structure_id": null,
       "support_skills": {
@@ -103107,6 +103539,7 @@
       "player_name": "cpt pelle",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -103288,6 +103721,7 @@
       "player_name": "S0fieFlames",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379774,
       "structure_id": null,
       "support_skills": {
@@ -103490,6 +103924,7 @@
       "player_name": "Sancho0o",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379852,
       "structure_id": null,
       "support_skills": {
@@ -103692,6 +104127,7 @@
       "player_name": "Y A M A",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -103894,6 +104330,7 @@
       "player_name": "hangry",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379779,
       "structure_id": null,
       "support_skills": {
@@ -104100,6 +104537,7 @@
       "player_name": "Mangeer",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379785,
       "structure_id": null,
       "support_skills": {
@@ -104298,6 +104736,7 @@
       "player_name": "EDM LORD",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379806,
       "structure_id": null,
       "support_skills": {
@@ -104496,6 +104935,7 @@
       "player_name": "Nordsee 300",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379820,
       "structure_id": null,
       "support_skills": {
@@ -104698,6 +105138,7 @@
       "player_name": "Helly Jelly",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 2379845,
       "structure_id": null,
       "support_skills": {
@@ -116797,6 +117238,7 @@
     "player_name": "망치丶Black",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": 52,
     "support_skills": {
       "enable": false,

--- a/samples/Battle/Persistent.Mail.914085176607419831-processed.json
+++ b/samples/Battle/Persistent.Mail.914085176607419831-processed.json
@@ -197,6 +197,7 @@
       "player_name": "Benbu",
       "rally": null,
       "server_season": "100",
+      "session": null,
       "start_tick": 31439,
       "structure_id": null,
       "support_skills": {
@@ -340,6 +341,7 @@
     "player_name": "G Var",
     "rally": null,
     "server_season": "100",
+    "session": null,
     "structure_id": null,
     "support_skills": {
       "enable": false,


### PR DESCRIPTION
## What changed

- preserve the complete `Session` string from Battle mail player payloads
- expose it as `session` for both the sender and every opponent
- add fixture-backed coverage for both extraction paths and null handling

## Why

Ark match variants cannot be classified reliably from `AsBattleType`. The session string carries the mode and submode needed by the report filters, so it needs to survive mail processing unchanged.

## Impact

Newly processed and reprocessed Battle mails include `sender.session` and `opponents[].session`. Existing output remains otherwise compatible.

## Validation

- `cargo test -p mail-processor-battle --locked`
- `cargo clippy -p mail-processor-battle --all-targets --locked -- -D warnings`
- `cargo fmt --all`
- `git diff --check`
