### PR TITLE
perf(api): optimize battle report queries

### DIFF
--- a/crates/services/rokbattles-api/src/db/reports_store.rs
+++ b/crates/services/rokbattles-api/src/db/reports_store.rs
@@ -2,7 +2,7 @@
 
 use mongodb::{
     Collection, IndexModel,
-    bson::{Document, doc},
+    bson::{Bson, Document, doc},
     options::IndexOptions,
 };
 
@@ -122,6 +122,47 @@ impl ReportsStore {
                 .build(),
             IndexModel::builder()
                 .keys(doc! { "metadata.kvk": 1, "metadata.mail_time": -1 })
+                .build(),
+            IndexModel::builder()
+                .keys(doc! { "metadata.mail_time": -1, "metadata.kvk": 1 })
+                .options(
+                    IndexOptions::builder()
+                        .partial_filter_expression(doc! {
+                            "$and": [
+                                {
+                                    "opponents.player_id": { "$gt": 0 }
+                                },
+                                { "metadata.kvk": false },
+                                {
+                                    "$or": [
+                                        { "metadata.mail_role": { "$lt": "dungeon" } },
+                                        { "metadata.mail_role": { "$gt": "dungeon" } },
+                                    ]
+                                },
+                                {
+                                    "$or": [
+                                        { "sender.supreme_strife.battle_id": { "$in": [Bson::Null, Bson::String(String::new())] } },
+                                        { "sender.supreme_strife.team_id": { "$in": [Bson::Null, Bson::Int32(0), Bson::Int64(0)] } },
+                                    ]
+                                },
+                            ]
+                        })
+                        .build(),
+                )
+                .build(),
+            IndexModel::builder()
+                .keys(doc! {
+                    "metadata.mail_time": -1,
+                    "sender.supreme_strife.battle_id": 1,
+                })
+                .options(
+                    IndexOptions::builder()
+                        .partial_filter_expression(doc! {
+                            "sender.supreme_strife.battle_id": { "$gt": "" },
+                            "sender.supreme_strife.team_id": { "$gt": 0 },
+                        })
+                        .build(),
+                )
                 .build(),
             IndexModel::builder()
                 .keys(doc! {

--- a/crates/services/rokbattles-api/src/routes/governor/pairings/aggregate.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/aggregate.rs
@@ -199,7 +199,7 @@ fn for_each_pairing_entry(mail: &Document, mut push: impl FnMut(PairingEntry)) {
         .filter_map(Bson::as_document)
         .filter(|opponent| {
             let player_id = nested_i64(opponent, &["player_id"]).unwrap_or_default();
-            !matches!(player_id, -2 | 0)
+            player_id > 0
         })
         .collect::<Vec<_>>();
 

--- a/crates/services/rokbattles-api/src/routes/governor/pairings/store.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/store.rs
@@ -29,7 +29,7 @@ pub(crate) async fn fetch_pairings_mails(
 ) -> Result<Vec<Document>, ApiError> {
     let mut and_filters = vec![
         doc! { "sender.player_id": governor_id },
-        doc! { "opponents": { "$elemMatch": { "player_id": { "$nin": [-2, 0] } } } },
+        doc! { "opponents.player_id": { "$gt": 0 } },
         build_mail_time_match(range.start_millis, range.end_millis),
     ];
 

--- a/crates/services/rokbattles-api/src/routes/reports/battle/list_mapper.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/list_mapper.rs
@@ -8,8 +8,6 @@ use super::types::{
     ReportTimeline, TimelineSample,
 };
 
-const INVALID_OPPONENT_PLAYER_IDS: [i64; 2] = [-2, 0];
-
 pub(crate) fn build_battle_list_projection() -> Document {
     let mut projection = Document::new();
 
@@ -223,7 +221,7 @@ fn get_valid_sorted_opponents<'a>(opponents: &'a [&Document]) -> Vec<&'a Documen
 
 fn is_valid_opponent(opponent: &Document) -> bool {
     let player_id = nested_i64(opponent, &["player_id"]).unwrap_or(0);
-    !INVALID_OPPONENT_PLAYER_IDS.contains(&player_id)
+    player_id > 0
 }
 
 fn select_preferred_opponent<'a>(opponents: &'a [&Document]) -> Option<&'a Document> {

--- a/crates/services/rokbattles-api/src/routes/reports/battle/match_builder.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/match_builder.rs
@@ -7,11 +7,7 @@ use super::query::{
 
 /// Build the MongoDB `$match` object for battle report list queries.
 pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
-    let mut match_pipeline: Vec<Document> = vec![doc! {
-        "opponents": {
-            "$elemMatch": { "player_id": { "$nin": [-2, 0] } }
-        }
-    }];
+    let mut match_pipeline: Vec<Document> = vec![doc! { "opponents.player_id": { "$gt": 0 } }];
 
     if let Some(before_cursor) = request.before_cursor {
         match_pipeline.push(doc! { "metadata.mail_time": { "$gt": before_cursor } });
@@ -40,7 +36,7 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
         match_pipeline.push(doc! {
             "opponents": {
                 "$elemMatch": {
-                    "player_id": { "$nin": [-2, 0] },
+                    "player_id": { "$gt": 0 },
                     "commanders.primary.id": commander_id,
                 }
             }
@@ -51,7 +47,7 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
         match_pipeline.push(doc! {
             "opponents": {
                 "$elemMatch": {
-                    "player_id": { "$nin": [-2, 0] },
+                    "player_id": { "$gt": 0 },
                     "commanders.secondary.id": commander_id,
                 }
             }
@@ -69,8 +65,13 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
             ReportsFilterType::Home => {
                 match_pipeline.push(doc! {
                     "$and": [
-                        { "metadata.kvk": { "$ne": true } },
-                        { "metadata.mail_role": { "$ne": "dungeon" } },
+                        { "metadata.kvk": false },
+                        {
+                            "$or": [
+                                { "metadata.mail_role": { "$lt": "dungeon" } },
+                                { "metadata.mail_role": { "$gt": "dungeon" } },
+                            ]
+                        },
                         {
                             "$or": [
                                 { "sender.supreme_strife.battle_id": { "$in": [Bson::Null, Bson::String("".to_string())] } },
@@ -83,8 +84,8 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
             ReportsFilterType::Strife => {
                 match_pipeline.push(doc! {
                     "$and": [
-                        { "sender.supreme_strife.battle_id": { "$exists": true, "$nin": [Bson::Null, Bson::String("".to_string())] } },
-                        { "sender.supreme_strife.team_id": { "$exists": true, "$nin": [Bson::Null, Bson::Int32(0), Bson::Int64(0)] } },
+                        { "sender.supreme_strife.battle_id": { "$gt": "" } },
+                        { "sender.supreme_strife.team_id": { "$gt": 0 } },
                     ]
                 });
             }
@@ -125,7 +126,7 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
         rally_conditions.push(doc! {
             "opponents": {
                 "$elemMatch": {
-                    "player_id": { "$nin": [-2, 0] },
+                    "player_id": { "$gt": 0 },
                     "rally": { "$in": [Bson::Int32(1), Bson::Boolean(true)] },
                 }
             }
@@ -208,17 +209,17 @@ fn build_opponent_garrison_condition(
 ) -> Document {
     let elem_match = match garrison_type {
         Some(ReportsGarrisonBuildingType::Flag) => {
-            doc! { "player_id": { "$nin": [-2, 0] }, "alliance_building_id": 1 }
+            doc! { "player_id": { "$gt": 0 }, "alliance_building_id": 1 }
         }
         Some(ReportsGarrisonBuildingType::Fortress) => {
-            doc! { "player_id": { "$nin": [-2, 0] }, "alliance_building_id": 3 }
+            doc! { "player_id": { "$gt": 0 }, "alliance_building_id": 3 }
         }
         Some(ReportsGarrisonBuildingType::Other) => doc! {
-            "player_id": { "$nin": [-2, 0] },
+            "player_id": { "$gt": 0 },
             "alliance_building_id": { "$exists": true, "$nin": [Bson::Int32(1), Bson::Int32(3), Bson::Null] }
         },
         None => doc! {
-            "player_id": { "$nin": [-2, 0] },
+            "player_id": { "$gt": 0 },
             "alliance_building_id": { "$exists": true, "$ne": Bson::Null }
         },
     };
@@ -238,6 +239,65 @@ mod tests {
 
     use super::*;
     use crate::routes::reports::battle::query::parse_reports_request;
+
+    #[test]
+    fn home_filter_matches_non_kvk_non_dungeon_non_strife_reports() {
+        let request =
+            parse_reports_request(&HashMap::from([("type".to_string(), "home".to_string())]))
+                .expect("valid Home filter");
+
+        let filter = build_reports_match(&request);
+
+        assert_eq!(
+            filter,
+            doc! {
+                "$and": [
+                    { "opponents.player_id": { "$gt": 0 } },
+                    {
+                        "$and": [
+                            { "metadata.kvk": false },
+                            {
+                                "$or": [
+                                    { "metadata.mail_role": { "$lt": "dungeon" } },
+                                    { "metadata.mail_role": { "$gt": "dungeon" } },
+                                ]
+                            },
+                            {
+                                "$or": [
+                                    { "sender.supreme_strife.battle_id": { "$in": [Bson::Null, Bson::String(String::new())] } },
+                                    { "sender.supreme_strife.team_id": { "$in": [Bson::Null, Bson::Int32(0), Bson::Int64(0)] } },
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        );
+    }
+
+    #[test]
+    fn strife_filter_matches_active_supreme_strife_reports() {
+        let request =
+            parse_reports_request(&HashMap::from([("type".to_string(), "strife".to_string())]))
+                .expect("valid Strife filter");
+
+        let filter = build_reports_match(&request);
+
+        assert_eq!(
+            filter,
+            doc! {
+                "$and": [
+                    { "opponents.player_id": { "$gt": 0 } },
+                    {
+                        "$and": [
+                            { "sender.supreme_strife.battle_id": { "$gt": "" } },
+                            { "sender.supreme_strife.team_id": { "$gt": 0 } },
+                        ]
+                    }
+                ]
+            }
+        );
+    }
 
     #[test]
     fn kvk_subtype_matches_sender_server_season() {

--- a/crates/services/rokbattles-api/src/routes/reports/battle/mod.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/mod.rs
@@ -11,8 +11,8 @@ use axum::{
 };
 use futures::StreamExt;
 use mongodb::{
-    bson::doc,
-    options::{FindOneOptions, FindOptions},
+    bson::{Bson, doc},
+    options::{FindOneOptions, FindOptions, Hint},
 };
 
 use self::{
@@ -21,7 +21,7 @@ use self::{
     },
     list_mapper::{build_report_dedupe_key, map_battle_list_document},
     match_builder::build_reports_match,
-    query::parse_reports_request,
+    query::{ReportsFilterSide, ReportsFilterType, ReportsRequest, parse_reports_request},
     types::{ReportByIdResponse, ReportRowWithCursor, ReportsResponse},
 };
 use crate::{
@@ -47,10 +47,7 @@ pub async fn get(
     let request = parse_reports_request(&params)?;
     let final_match = build_reports_match(&request);
 
-    let options = FindOptions::builder()
-        .sort(doc! { "metadata.mail_time": request.sort_direction() })
-        .projection(self::list_mapper::build_battle_list_projection())
-        .build();
+    let options = build_battle_list_find_options(&request);
 
     let mut cursor = state
         .reports_store
@@ -95,6 +92,42 @@ pub async fn get(
     Ok((StatusCode::OK, [("Cache-Control", "no-store")], Json(response)))
 }
 
+fn build_battle_list_find_options(request: &ReportsRequest) -> FindOptions {
+    let hint_home_partial_index = should_hint_home_partial_index(request);
+    let hint = hint_home_partial_index
+        .then(|| Hint::Keys(doc! { "metadata.mail_time": -1, "metadata.kvk": 1 }));
+    let max = request.before_cursor.filter(|_| hint_home_partial_index).map(|before_cursor| {
+        doc! {
+            "metadata.mail_time": before_cursor,
+            "metadata.kvk": Bson::MinKey,
+        }
+    });
+    let min = request.after_cursor.filter(|_| hint_home_partial_index).map(|after_cursor| {
+        doc! {
+            "metadata.mail_time": after_cursor,
+            "metadata.kvk": Bson::MaxKey,
+        }
+    });
+
+    FindOptions::builder()
+        .sort(doc! { "metadata.mail_time": request.sort_direction() })
+        .projection(self::list_mapper::build_battle_list_projection())
+        .hint(hint)
+        .max(max)
+        .min(min)
+        .build()
+}
+
+fn should_hint_home_partial_index(request: &ReportsRequest) -> bool {
+    matches!(request.filter_type, Some(ReportsFilterType::Home))
+        && request.sender_primary_commander_id.is_none()
+        && request.sender_secondary_commander_id.is_none()
+        && request.opponent_primary_commander_id.is_none()
+        && request.opponent_secondary_commander_id.is_none()
+        && matches!(request.rally_side, ReportsFilterSide::None)
+        && matches!(request.garrison_side, ReportsFilterSide::None)
+}
+
 /// Look up a single battle report by mail ID.
 pub async fn get_by_id(
     State(state): State<Arc<AppState>>,
@@ -131,7 +164,87 @@ fn parse_report_id(raw_id: &str) -> Result<String, ApiError> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_report_id;
+    use std::collections::HashMap;
+
+    use mongodb::{
+        bson::{Bson, doc},
+        options::Hint,
+    };
+
+    use super::{build_battle_list_find_options, parse_report_id};
+    use crate::routes::reports::battle::query::parse_reports_request;
+
+    #[test]
+    fn home_list_options_hint_the_home_partial_index() {
+        let request =
+            parse_reports_request(&HashMap::from([("type".to_string(), "home".to_string())]))
+                .expect("valid Home filter");
+
+        let options = build_battle_list_find_options(&request);
+
+        assert!(matches!(
+            options.hint,
+            Some(Hint::Keys(keys))
+                if keys == doc! { "metadata.mail_time": -1, "metadata.kvk": 1 }
+        ));
+        assert!(options.max.is_none());
+        assert!(options.min.is_none());
+    }
+
+    #[test]
+    fn home_before_cursor_bounds_the_home_partial_index() {
+        let request = parse_reports_request(&HashMap::from([
+            ("type".to_string(), "home".to_string()),
+            ("before".to_string(), "123456".to_string()),
+        ]))
+        .expect("valid Home before cursor");
+
+        let options = build_battle_list_find_options(&request);
+
+        assert_eq!(
+            options.max,
+            Some(doc! {
+                "metadata.mail_time": 123456_i64,
+                "metadata.kvk": Bson::MinKey,
+            })
+        );
+        assert!(options.min.is_none());
+    }
+
+    #[test]
+    fn home_after_cursor_bounds_the_home_partial_index() {
+        let request = parse_reports_request(&HashMap::from([
+            ("type".to_string(), "home".to_string()),
+            ("after".to_string(), "123456".to_string()),
+        ]))
+        .expect("valid Home after cursor");
+
+        let options = build_battle_list_find_options(&request);
+
+        assert_eq!(
+            options.min,
+            Some(doc! {
+                "metadata.mail_time": 123456_i64,
+                "metadata.kvk": Bson::MaxKey,
+            })
+        );
+        assert!(options.max.is_none());
+    }
+
+    #[test]
+    fn home_list_options_allow_specialized_commander_index() {
+        let request = parse_reports_request(&HashMap::from([
+            ("type".to_string(), "home".to_string()),
+            ("ssc".to_string(), "618".to_string()),
+        ]))
+        .expect("valid Home commander filter");
+
+        let options = build_battle_list_find_options(&request);
+
+        assert!(options.hint.is_none());
+        assert!(options.max.is_none());
+        assert!(options.min.is_none());
+    }
 
     #[test]
     fn parses_non_empty_report_id() {


### PR DESCRIPTION
## Summary

- add targeted partial indexes for Home and Supreme Strife report lists
- simplify PvP opponent filtering to `player_id > 0` across report and governor pairing paths
- bound Home cursor scans and defer to specialized indexes for commander, rally, and garrison filters

## Why

Home and Supreme Strife report lists were scanning large portions of the battle-report collection. Supreme Strife took roughly 14 seconds in the representative live dataset, while Home took roughly 223 ms. The query predicates also prevented MongoDB from selecting compact, targeted indexes.

## Impact

Representative initial-page queries now complete in roughly 0–2 ms while examining about one document per returned row. Home cursor pagination remains constant-cost at deeper cursors, and specialized filter combinations can use their existing indexes.

The API-generated index set was audited against API and jobs consumers; no existing generated index was removed because every one still has an owner.

## Validation

- `cargo fmt --all --check`
- `cargo test -p rokbattles-api` (136 passed)
- `cargo clippy -p rokbattles-api --all-targets -- -D warnings`
- read-only MongoDB explain comparisons, including cursor result-equivalence checks at 100, 1,000, and 10,000 rows