### PR TITLE
refactor: update rally filters to match true only

### DIFF
--- a/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
+++ b/crates/services/rokbattles-api/src/routes/governor/pairings/query.rs
@@ -206,15 +206,11 @@ fn sender_garrison_field_conditions() -> Vec<Document> {
 }
 
 fn sender_rally_condition() -> Document {
-    doc! {
-        "sender.rally": { "$in": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] }
-    }
+    doc! { "sender.rally": true }
 }
 
 fn sender_not_rally_condition() -> Document {
-    doc! {
-        "sender.rally": { "$nin": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] }
-    }
+    doc! { "sender.rally": { "$ne": true } }
 }
 
 fn opponent_rally_or_garrison_condition() -> Document {
@@ -222,7 +218,7 @@ fn opponent_rally_or_garrison_condition() -> Document {
         "opponents": {
             "$elemMatch": {
                 "$or": [
-                    { "rally": { "$in": [Bson::Boolean(true), Bson::Int32(1), Bson::Int64(1)] } },
+                    { "rally": true },
                     { "alliance_building_id": { "$exists": true, "$ne": Bson::Null } },
                     { "structure_id": { "$exists": true, "$ne": Bson::Null } },
                 ]
@@ -435,6 +431,14 @@ mod tests {
                     sender_rally_condition(),
                 ]
             }
+        );
+    }
+
+    #[test]
+    fn sender_rally_conditions_use_boolean_schema() {
+        assert_eq!(
+            (sender_rally_condition(), sender_not_rally_condition()),
+            (doc! { "sender.rally": true }, doc! { "sender.rally": { "$ne": true } },)
         );
     }
 

--- a/crates/services/rokbattles-api/src/routes/reports/battle/match_builder.rs
+++ b/crates/services/rokbattles-api/src/routes/reports/battle/match_builder.rs
@@ -119,15 +119,14 @@ pub(crate) fn build_reports_match(request: &ReportsRequest) -> Document {
 
     let mut rally_conditions: Vec<Document> = Vec::new();
     if matches!(request.rally_side, ReportsFilterSide::Sender | ReportsFilterSide::Both) {
-        rally_conditions
-            .push(doc! { "sender.rally": { "$in": [Bson::Int32(1), Bson::Boolean(true)] } });
+        rally_conditions.push(doc! { "sender.rally": true });
     }
     if matches!(request.rally_side, ReportsFilterSide::Opponent | ReportsFilterSide::Both) {
         rally_conditions.push(doc! {
             "opponents": {
                 "$elemMatch": {
                     "player_id": { "$gt": 0 },
-                    "rally": { "$in": [Bson::Int32(1), Bson::Boolean(true)] },
+                    "rally": true,
                 }
             }
         });
@@ -381,6 +380,34 @@ mod tests {
                 ]
             },
         );
+    }
+
+    #[test]
+    fn sender_rally_filter_matches_boolean_true() {
+        let request =
+            parse_reports_request(&HashMap::from([("rs".to_string(), "sender".to_string())]))
+                .expect("valid sender rally filter");
+
+        assert!(
+            match_conditions(&build_reports_match(&request))
+                .contains(&Bson::Document(doc! { "sender.rally": true }))
+        );
+    }
+
+    #[test]
+    fn opponent_rally_filter_matches_boolean_true() {
+        let request =
+            parse_reports_request(&HashMap::from([("rs".to_string(), "opponent".to_string())]))
+                .expect("valid opponent rally filter");
+
+        assert!(match_conditions(&build_reports_match(&request)).contains(&Bson::Document(doc! {
+            "opponents": {
+                "$elemMatch": {
+                    "player_id": { "$gt": 0 },
+                    "rally": true,
+                }
+            }
+        })));
     }
 
     fn assert_ark_session_condition(subtype: &str, expected: Document) {


### PR DESCRIPTION
Early on we used to rallies to 1, but that has since been updated. This fixes the queries to only search for true. 