### PR TITLE
chore(docker): pin base images by digest

### DIFF
--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97.1-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 RUN apk add --no-cache \
@@ -9,7 +9,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY . .
 RUN cargo build --release --locked --target x86_64-unknown-linux-musl -p rokbattles-api
 
-FROM alpine:3.22 AS files
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS files
 RUN apk add --no-cache ca-certificates tzdata
 RUN addgroup --system --gid 10001 rokb && \
     adduser  --system --uid 10001 --ingroup rokb --home /nonexistent --shell /sbin/nologin rokb

--- a/infra/ingress.Dockerfile
+++ b/infra/ingress.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97.1-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 RUN apk add --no-cache \
@@ -9,7 +9,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY . .
 RUN cargo build --release --locked --target x86_64-unknown-linux-musl -p rokbattles-ingress
 
-FROM alpine:3.22 AS files
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS files
 RUN apk add --no-cache ca-certificates tzdata
 RUN addgroup --system --gid 10001 rokb && \
     adduser  --system --uid 10001 --ingroup rokb --home /nonexistent --shell /sbin/nologin rokb

--- a/infra/jobs.Dockerfile
+++ b/infra/jobs.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97.1-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 RUN apk add --no-cache \
@@ -9,7 +9,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY . .
 RUN cargo build --release --locked --target x86_64-unknown-linux-musl -p rokbattles-jobs
 
-FROM alpine:3.22 AS files
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS files
 RUN apk add --no-cache ca-certificates tzdata
 RUN addgroup --system --gid 10001 rokb && \
     adduser  --system --uid 10001 --ingroup rokb --home /nonexistent --shell /sbin/nologin rokb

--- a/infra/platform.Dockerfile
+++ b/infra/platform.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine AS base
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
 WORKDIR /app
 
 FROM base AS builder

--- a/infra/processor.Dockerfile
+++ b/infra/processor.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97-alpine AS builder
+FROM rust:1.97.1-alpine@sha256:3c38f3f82c2f3d73da3b38e18d279393a04cb43ddded0e35088a8c3324d40900 AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app
 RUN apk add --no-cache \
@@ -9,7 +9,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 COPY . .
 RUN cargo build --release --locked --target x86_64-unknown-linux-musl -p rokbattles-processor
 
-FROM alpine:3.22 AS files
+FROM alpine:3.22@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce AS files
 RUN apk add --no-cache ca-certificates tzdata
 RUN addgroup --system --gid 10001 rokb && \
     adduser  --system --uid 10001 --ingroup rokb --home /nonexistent --shell /sbin/nologin rokb


### PR DESCRIPTION
## Summary

- update the Rust builder images to Rust 1.97.1
- pin every registry-backed `FROM` reference in the five infrastructure Dockerfiles to an immutable multi-platform digest
- keep Node on the latest LTS line (Node 24) and Alpine on the supported 3.22 line

## Why

Rust 1.97.1 fixes an LLVM optimization miscompilation. Digest pinning makes image inputs reproducible while retaining readable release tags for maintenance.

## Impact

All service and site images now resolve deterministic base-image content. Internal stage aliases and `scratch` remain unchanged.

## Validation

- repository audit found 9 registry-backed `FROM` references and 0 unpinned references
- `docker build --platform linux/amd64 --file infra/api.Dockerfile .` (representative Rust service)
- `docker build --file infra/platform.Dockerfile .` (site image, native arm64)
