### PR TITLE
fix(mail): validate persistent mail decoding

### DIFF
--- a/crates/desktop/src/watcher/mail.rs
+++ b/crates/desktop/src/watcher/mail.rs
@@ -9,36 +9,6 @@ pub(crate) fn parse_rok_mail_id(filename: &str) -> Option<u128> {
     rest.parse::<u128>().ok()
 }
 
-/// Heuristic header validation to quickly skip non-mail buffers.
-pub(crate) fn has_rok_mail_header(buf: &[u8]) -> bool {
-    if buf.len() < 32 {
-        return false;
-    }
-    if buf[0] != 0xFF {
-        return false;
-    }
-    if buf[9] != 0x05 || buf[10] != 0x04 {
-        return false;
-    }
-    let len = {
-        let start = 11;
-        let end = start + 4;
-        let Some(bytes) = buf.get(start..end) else {
-            return false;
-        };
-        u32::from_le_bytes(bytes.try_into().unwrap_or([0; 4]))
-    };
-    if len != 9 {
-        return false;
-    }
-    let start = 15;
-    let end = start + 9;
-    let Some(bytes) = buf.get(start..end) else {
-        return false;
-    };
-    bytes == b"mailScene"
-}
-
 /// Extract a non-empty file name for API uploads.
 pub(crate) fn file_name_for_upload(path: &Path) -> Option<String> {
     path.file_name().and_then(|s| s.to_str()).filter(|name| !name.is_empty()).map(str::to_string)
@@ -64,21 +34,5 @@ mod tests {
             Some("Persistent.Mail.123".to_string())
         );
         assert_eq!(file_name_for_upload(Path::new("")), None);
-    }
-
-    #[test]
-    fn has_rok_mail_header_matches_expected_bytes() {
-        let mut buf = vec![0u8; 32];
-        buf[0] = 0xFF;
-        buf[9] = 0x05;
-        buf[10] = 0x04;
-        buf[11..15].copy_from_slice(9u32.to_le_bytes().as_slice());
-        buf[15..24].copy_from_slice(b"mailScene");
-
-        assert!(has_rok_mail_header(&buf));
-
-        let mut wrong = buf.clone();
-        wrong[0] = 0x00;
-        assert!(!has_rok_mail_header(&wrong));
     }
 }

--- a/crates/desktop/src/watcher/scan.rs
+++ b/crates/desktop/src/watcher/scan.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashSet,
     fs,
-    io::Read,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -306,7 +305,7 @@ pub(crate) async fn next_file(app: &AppHandle, state: &mut WatcherState) -> Opti
 
         let header = tauri::async_runtime::spawn_blocking({
             let path = path.clone();
-            move || has_rok_fileheader_from_file(&path)
+            move || has_valid_rok_mail_file(&path)
         })
         .await;
 
@@ -415,10 +414,35 @@ pub(crate) fn apply_fs_event(state: &mut WatcherState, path: PathBuf, now_ms: u1
     }
 }
 
-fn has_rok_fileheader_from_file(path: &PathBuf) -> anyhow::Result<bool> {
-    let mut f = fs::File::open(path)
-        .with_context(|| format!("Failed to open file for header check: {:?}", path))?;
-    let mut buf = [0u8; 32];
-    let _ = f.read(&mut buf)?;
-    Ok(super::mail::has_rok_mail_header(&buf))
+fn has_valid_rok_mail_file(path: &std::path::Path) -> anyhow::Result<bool> {
+    let buffer = fs::read(path)
+        .with_context(|| format!("Failed to read file for native validation: {:?}", path))?;
+    Ok(mail_decoder::validate_file(&buffer).is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_validation_accepts_checked_in_mail() {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../samples/Battle/Persistent.Mail.485440176891031331");
+
+        assert!(has_valid_rok_mail_file(&path).expect("validate sample"));
+    }
+
+    #[test]
+    fn native_validation_rejects_corrupt_mail() {
+        let sample = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../samples/Battle/Persistent.Mail.485440176891031331");
+        let mut buffer = fs::read(sample).expect("read sample");
+        let last = buffer.len() - 1;
+        buffer[last] ^= 1;
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("Persistent.Mail.1");
+        fs::write(&path, buffer).expect("write corrupt sample");
+
+        assert!(!has_valid_rok_mail_file(&path).expect("validate sample"));
+    }
 }

--- a/crates/mail/cli/src/run/mod.rs
+++ b/crates/mail/cli/src/run/mod.rs
@@ -42,13 +42,26 @@ mod tests {
         file.write_all(bytes).expect("write bytes");
     }
 
+    fn native_file(payload: &[u8]) -> Vec<u8> {
+        let mut buffer = vec![0xff];
+        buffer.extend_from_slice(&0_u64.to_le_bytes());
+        buffer.extend_from_slice(payload);
+        let checksum =
+            buffer.iter().copied().enumerate().fold(0x1505_u64, |hash, (index, byte)| {
+                let byte = if (1..9).contains(&index) { 0 } else { byte };
+                hash.wrapping_mul(33).wrapping_add(u64::from(byte))
+            });
+        buffer[1..9].copy_from_slice(&checksum.to_le_bytes());
+        buffer
+    }
+
     #[test]
     fn run_decodes_and_writes_pretty_json() {
         let input_dir = tempfile::tempdir().expect("input dir");
         let output_dir = tempfile::tempdir().expect("output dir");
         let input_path = input_dir.path().join("sample.mail");
 
-        let buffer = vec![0x05, 0x04, 0x01, 0, 0, 0, b'a', 0x01, 1, 0xff];
+        let buffer = native_file(&[0x05, 0x04, 0x01, 0, 0, 0, b'a', 0x01, 1, 0xff]);
         write_bytes(&input_path, &buffer);
 
         let config = Config {
@@ -70,7 +83,7 @@ mod tests {
         let output_dir = tempfile::tempdir().expect("output dir");
         let input_path = input_dir.path().join("sample.mail");
 
-        let buffer = vec![0x05, 0x04, 0x01, 0, 0, 0, b'a', 0x01, 1, 0xff];
+        let buffer = native_file(&[0x05, 0x04, 0x01, 0, 0, 0, b'a', 0x01, 1, 0xff]);
         write_bytes(&input_path, &buffer);
 
         let config = Config {

--- a/crates/mail/cli/src/run/process.rs
+++ b/crates/mail/cli/src/run/process.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use mail_registry::{detect_mail_type, process_mail};
+use mail_registry::{detect_mail_type, normalize_mail_root, process_mail};
 use serde_json::Value;
 
 use super::paths::processed_output_path;
@@ -12,15 +12,7 @@ pub(super) fn write_processed_json(
     value: &Value,
     pretty: bool,
 ) -> Result<(), MailCliError> {
-    let processed_input = match value {
-        Value::Object(_) => Some(value),
-        Value::Array(items) => match items.as_slice() {
-            [item] if item.is_object() => Some(item),
-            _ => None,
-        },
-        _ => None,
-    };
-    let Some(processed_input) = processed_input else {
+    let Some(processed_input) = normalize_mail_root(value) else {
         return Ok(());
     };
 
@@ -182,14 +174,14 @@ mod tests {
     }
 
     #[test]
-    fn write_processed_json_handles_singleton_array() {
+    fn write_processed_json_handles_corrected_preamble_fixture() {
         let temp = tempfile::tempdir().expect("temp dir");
         let input = temp.path().join("sample.mail");
         let sample_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../../samples/Battle/Persistent.Mail.33830971176980291131.json");
         let json = fs::read_to_string(sample_path).expect("read sample");
         let value: Value = serde_json::from_str(&json).expect("parse sample");
-        assert!(matches!(value, Value::Array(_)));
+        assert!(matches!(value, Value::Object(_)));
 
         write_processed_json(temp.path(), &input, &value, true).unwrap();
         let output = processed_output_path(temp.path(), &input).unwrap();

--- a/crates/mail/decoder/src/common.rs
+++ b/crates/mail/decoder/src/common.rs
@@ -3,16 +3,45 @@
 use thiserror::Error;
 
 pub(crate) const TAG_BOOL: u8 = 0x01;
-pub(crate) const TAG_F32: u8 = 0x02;
 pub(crate) const TAG_F64: u8 = 0x03;
 pub(crate) const TAG_STRING: u8 = 0x04;
-pub(crate) const TAG_OBJECT: u8 = 0x05;
+pub(crate) const TAG_TABLE: u8 = 0x05;
+pub(crate) const TABLE_END: u8 = 0xff;
+
+pub(crate) const FILE_MARKER: u8 = 0xff;
+pub(crate) const FILE_HEADER_LEN: usize = 9;
+pub(crate) const CHECKSUM_SEED: u64 = 0x1505;
 
 pub(crate) const MAX_DEPTH: usize = 128;
 
-/// Errors returned by [crate::decode].
-#[derive(Debug, Error)]
+/// Errors returned by [`crate::decode`], [`crate::decode_value`], and
+/// [`crate::validate_file`].
+#[derive(Debug, Error, PartialEq)]
 pub enum DecodeError {
+    /// The buffer is shorter than the fixed mail file header.
+    #[error("mail file header requires {required} bytes, found {actual}")]
+    HeaderTooShort {
+        /// Required fixed header size.
+        required: usize,
+        /// Actual buffer size.
+        actual: usize,
+    },
+    /// The required mail file marker was not present.
+    #[error("invalid mail file marker 0x{found:02x}; expected 0x{expected:02x}")]
+    InvalidFileMarker {
+        /// Required marker.
+        expected: u8,
+        /// Marker read from the file.
+        found: u8,
+    },
+    /// The stored mail file checksum did not match the file bytes.
+    #[error("mail file checksum mismatch (stored 0x{stored:016x}, computed 0x{computed:016x})")]
+    ChecksumMismatch {
+        /// Checksum stored in bytes 1 through 8.
+        stored: u64,
+        /// Checksum computed with those bytes treated as zero.
+        computed: u64,
+    },
     /// The buffer ended before all required bytes were available.
     #[error("unexpected EOF (needed {needed} bytes, had {remaining})")]
     UnexpectedEof {
@@ -53,23 +82,32 @@ pub enum DecodeError {
         /// The offending value.
         value: f64,
     },
-}
-
-pub(crate) fn is_known_tag(tag: u8) -> bool {
-    matches!(tag, TAG_BOOL | TAG_F32 | TAG_F64 | TAG_STRING | TAG_OBJECT)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn known_tags_match() {
-        assert!(is_known_tag(TAG_BOOL));
-        assert!(is_known_tag(TAG_F32));
-        assert!(is_known_tag(TAG_F64));
-        assert!(is_known_tag(TAG_STRING));
-        assert!(is_known_tag(TAG_OBJECT));
-        assert!(!is_known_tag(0xff));
-    }
+    /// A value tag is not supported by this decoder.
+    #[error("unsupported value tag 0x{tag:02x} at offset {offset}")]
+    UnsupportedTag {
+        /// Unsupported tag byte.
+        tag: u8,
+        /// Absolute offset within the decoded value buffer.
+        offset: usize,
+    },
+    /// A table ended before its explicit terminator.
+    #[error("table starting at offset {offset} is missing its 0xff terminator")]
+    MissingTableTerminator {
+        /// Offset of the table tag.
+        offset: usize,
+    },
+    /// A table mixed string and numeric keys, which JSON cannot preserve safely.
+    #[error("table at offset {offset} mixes string and numeric keys")]
+    MixedTableKeyTypes {
+        /// Offset of the table tag.
+        offset: usize,
+    },
+    /// A table repeated a key and would lose data in JSON.
+    #[error("table at offset {offset} contains duplicate key {key:?}")]
+    DuplicateTableKey {
+        /// Offset of the table tag.
+        offset: usize,
+        /// Duplicate key rendered using its JSON object representation.
+        key: String,
+    },
 }

--- a/crates/mail/decoder/src/decoder.rs
+++ b/crates/mail/decoder/src/decoder.rs
@@ -1,171 +1,147 @@
-//! Normalized decoder implementation.
+//! Strict `Persistent.Mail` decoder.
 
-use serde_json::{Map, Number, Value};
+use serde_json::{Number, Value};
 
 use crate::{
     common::{
-        DecodeError, MAX_DEPTH, TAG_BOOL, TAG_F32, TAG_F64, TAG_OBJECT, TAG_STRING, is_known_tag,
+        CHECKSUM_SEED, DecodeError, FILE_HEADER_LEN, FILE_MARKER, MAX_DEPTH, TABLE_END, TAG_BOOL,
+        TAG_F64, TAG_STRING, TAG_TABLE,
     },
-    value::numeric_keyed_container,
+    value::classify_table,
 };
 
-/// Largest header prefix scanned before the payload.
-const MAX_PREAMBLE_SCAN_BYTES: usize = 16;
-
-/// Decode a binary mail buffer into a JSON value.
+/// Validate the fixed file header and checksum without decoding its value.
 ///
-/// The decoder expects a single root value. If extra bytes remain after decoding,
-/// an error is returned. When the first parsed value is `null` and trailing bytes
-/// exist, the decoder assumes a leading preamble and retries decoding from a
-/// limited number of candidate offsets that yield a full, trailing-free decode.
-pub fn decode(buffer: &[u8]) -> Result<Value, DecodeError> {
-    if buffer.is_empty() {
-        return Err(DecodeError::UnexpectedEof { needed: 1, remaining: 0 });
+/// # Errors
+///
+/// Returns an error when the header is short, its marker is invalid, or its
+/// checksum does not match the complete file buffer.
+pub fn validate_file(buffer: &[u8]) -> Result<(), DecodeError> {
+    if buffer.len() < FILE_HEADER_LEN {
+        return Err(DecodeError::HeaderTooShort {
+            required: FILE_HEADER_LEN,
+            actual: buffer.len(),
+        });
+    }
+    if buffer[0] != FILE_MARKER {
+        return Err(DecodeError::InvalidFileMarker { expected: FILE_MARKER, found: buffer[0] });
     }
 
-    let mut decoder = Decoder::new(buffer);
-    let value = decoder.read_value()?;
-    if decoder.remaining() == 0 {
-        return Ok(value);
+    let stored = u64::from_le_bytes(bytes8(&buffer[1..FILE_HEADER_LEN])?);
+    let computed = file_checksum(buffer);
+    if stored != computed {
+        return Err(DecodeError::ChecksumMismatch { stored, computed });
     }
 
-    if !matches!(value, Value::Null) {
-        return Err(DecodeError::TrailingBytes { remaining: decoder.remaining() });
-    }
-
-    let remaining = decoder.remaining();
-    if let Some(value) = find_payload_value(buffer) {
-        return Ok(value);
-    }
-
-    Err(DecodeError::TrailingBytes { remaining })
+    Ok(())
 }
 
-fn find_payload_value(buffer: &[u8]) -> Option<Value> {
-    let mut fallback = None;
-    for (offset, tag) in buffer.iter().copied().enumerate() {
-        if offset > MAX_PREAMBLE_SCAN_BYTES {
-            break;
-        }
-        if !is_known_tag(tag) {
-            continue;
-        }
+/// Decode a complete `Persistent.Mail` file, including header validation.
+///
+/// # Errors
+///
+/// Returns an error for an invalid header/checksum, malformed values,
+/// unsupported tags, unterminated tables, or trailing bytes.
+pub fn decode(buffer: &[u8]) -> Result<Value, DecodeError> {
+    validate_file(buffer)?;
+    decode_value_at(&buffer[FILE_HEADER_LEN..], FILE_HEADER_LEN)
+}
 
-        let mut decoder = Decoder::with_offset(buffer, offset);
-        if let Ok(value) = decoder.read_value()
-            && decoder.remaining() == 0
-        {
-            if matches!(&value, Value::Object(_) | Value::Array(_)) {
-                return Some(value);
-            }
-            if fallback.is_none() {
-                fallback = Some(value);
-            }
-        }
+/// Decode exactly one headerless `Persistent.Mail` value.
+///
+/// This is intended for format tooling and focused tests. Production callers
+/// reading `Persistent.Mail` files should use [`decode`] so the file checksum
+/// is enforced.
+///
+/// # Errors
+///
+/// Returns an error for malformed values, unsupported tags, unterminated
+/// tables, or trailing bytes.
+pub fn decode_value(buffer: &[u8]) -> Result<Value, DecodeError> {
+    decode_value_at(buffer, 0)
+}
+
+fn decode_value_at(buffer: &[u8], base_offset: usize) -> Result<Value, DecodeError> {
+    let mut decoder = Decoder::new(buffer, base_offset);
+    let value = decoder.read_value()?;
+    if decoder.remaining() != 0 {
+        return Err(DecodeError::TrailingBytes { remaining: decoder.remaining() });
     }
+    Ok(value)
+}
 
-    fallback
+fn file_checksum(buffer: &[u8]) -> u64 {
+    buffer.iter().copied().enumerate().fold(CHECKSUM_SEED, |hash, (offset, byte)| {
+        let byte = if (1..FILE_HEADER_LEN).contains(&offset) { 0 } else { byte };
+        hash.wrapping_mul(33).wrapping_add(u64::from(byte))
+    })
 }
 
 struct Decoder<'a> {
     buffer: &'a [u8],
+    base_offset: usize,
     pos: usize,
     depth: usize,
 }
 
 impl<'a> Decoder<'a> {
-    fn new(buffer: &'a [u8]) -> Self {
-        Self { buffer, pos: 0, depth: 0 }
-    }
-
-    fn with_offset(buffer: &'a [u8], pos: usize) -> Self {
-        Self { buffer, pos, depth: 0 }
+    fn new(buffer: &'a [u8], base_offset: usize) -> Self {
+        Self { buffer, base_offset, pos: 0, depth: 0 }
     }
 
     fn remaining(&self) -> usize {
         self.buffer.len().saturating_sub(self.pos)
     }
 
+    fn absolute_offset(&self, relative: usize) -> usize {
+        self.base_offset.saturating_add(relative)
+    }
+
     fn read_value(&mut self) -> Result<Value, DecodeError> {
+        let tag_offset = self.absolute_offset(self.pos);
         let tag = self.read_u8()?;
         match tag {
-            TAG_BOOL => {
-                let value = self.read_u8()? != 0;
-                Ok(Value::Bool(value))
-            }
-            TAG_F32 => {
-                let raw = self.read_exact(4)?;
-                let value = f32::from_le_bytes(bytes4(raw)?);
-                number_value(f64::from(value))
-            }
+            TAG_BOOL => Ok(Value::Bool(self.read_u8()? != 0)),
             TAG_F64 => {
                 let raw = self.read_exact(8)?;
-                let value = f64::from_be_bytes(bytes8(raw)?);
-                number_value(value)
+                number_value(f64::from_be_bytes(bytes8(raw)?))
             }
-            TAG_STRING => {
-                let value = self.read_string()?;
-                Ok(Value::String(value))
-            }
-            TAG_OBJECT => self.read_container(),
-            _ => Ok(Value::Null),
+            TAG_STRING => Ok(Value::String(self.read_string()?)),
+            TAG_TABLE => self.read_table(tag_offset),
+            _ => Err(DecodeError::UnsupportedTag { tag, offset: tag_offset }),
         }
     }
 
-    fn read_container(&mut self) -> Result<Value, DecodeError> {
+    fn read_table(&mut self, table_offset: usize) -> Result<Value, DecodeError> {
         if self.depth >= MAX_DEPTH {
             return Err(DecodeError::DepthLimitExceeded { limit: MAX_DEPTH });
         }
 
         self.depth += 1;
-        // The container tag does not tell us whether this is a list or a map.
-        // A string child starts a normal object; numeric children are normalized
-        // after the complete container has been read.
-        let value = match self.peek_u8() {
-            Some(TAG_STRING) => Value::Object(self.read_object_entries()?),
-            Some(_) => self.read_numeric_or_sequential_container()?,
-            None => Value::Object(Map::new()),
-        };
+        let result = self.read_table_contents(table_offset);
         self.depth -= 1;
-        Ok(value)
+        result
     }
 
-    fn read_object_entries(&mut self) -> Result<Map<String, Value>, DecodeError> {
-        let mut map = Map::new();
-
-        while let Some(tag) = self.peek_u8() {
-            if tag == TAG_STRING {
-                let _ = self.read_u8()?;
-                let key = self.read_string()?;
-                let value = self.read_value()?;
-                map.insert(key, value);
-                continue;
-            }
-
-            // Non-string tags end the object; unknown tags act as explicit terminators.
-            if !is_known_tag(tag) {
-                let _ = self.read_u8()?;
-            }
-            break;
-        }
-
-        Ok(map)
-    }
-
-    fn read_numeric_or_sequential_container(&mut self) -> Result<Value, DecodeError> {
+    fn read_table_contents(&mut self, table_offset: usize) -> Result<Value, DecodeError> {
         let mut items = Vec::new();
-
-        while let Some(tag) = self.peek_u8() {
-            if !is_known_tag(tag) {
-                let _ = self.read_u8()?;
-                break;
+        let terminated = loop {
+            match self.peek_u8() {
+                Some(TABLE_END) => {
+                    self.read_u8()?;
+                    break true;
+                }
+                Some(_) => items.push(self.read_value()?),
+                None => break false,
             }
+        };
 
-            let value = self.read_value()?;
-            items.push(value);
+        let classified = classify_table(items, table_offset)?;
+        if !terminated {
+            return Err(DecodeError::MissingTableTerminator { offset: table_offset });
         }
 
-        Ok(numeric_keyed_container(&items).unwrap_or(Value::Array(items)))
+        Ok(classified.value)
     }
 
     fn read_string(&mut self) -> Result<String, DecodeError> {
@@ -175,7 +151,7 @@ impl<'a> Decoder<'a> {
             return Err(DecodeError::LengthOutOfBounds { length, remaining });
         }
 
-        let start = self.pos;
+        let start = self.absolute_offset(self.pos);
         let bytes = self.read_exact(length)?;
         std::str::from_utf8(bytes)
             .map(str::to_owned)
@@ -224,15 +200,13 @@ fn bytes8(bytes: &[u8]) -> Result<[u8; 8], DecodeError> {
 }
 
 fn number_value(value: f64) -> Result<Value, DecodeError> {
-    if value.is_finite() {
-        let normalized = normalize_integer(value);
-        Ok(Value::Number(normalized))
-    } else {
-        Err(DecodeError::NonFiniteNumber { value })
+    if !value.is_finite() {
+        return Err(DecodeError::NonFiniteNumber { value });
     }
+    Ok(Value::Number(normalize_number(value)))
 }
 
-fn normalize_integer(value: f64) -> Number {
+fn normalize_number(value: f64) -> Number {
     if value == 0.0 {
         return Number::from(0);
     }
@@ -247,16 +221,10 @@ fn normalize_integer(value: f64) -> Number {
         }
     }
 
-    number_from_f64(value)
-}
-
-fn number_from_f64(value: f64) -> Number {
-    if let Some(number) = Number::from_f64(value) {
-        number
-    } else {
-        // `number_value` rejects NaN and infinity before this helper is called.
-        Number::from(0)
-    }
+    let Some(number) = Number::from_f64(value) else {
+        unreachable!("finite f64 is a JSON number");
+    };
+    number
 }
 
 fn to_u64_exact(value: f64) -> Option<u64> {
@@ -264,7 +232,7 @@ fn to_u64_exact(value: f64) -> Option<u64> {
         return None;
     }
     let int = value as u64;
-    if (int as f64) == value { Some(int) } else { None }
+    ((int as f64) == value).then_some(int)
 }
 
 fn to_i64_exact(value: f64) -> Option<i64> {
@@ -272,41 +240,21 @@ fn to_i64_exact(value: f64) -> Option<i64> {
         return None;
     }
     let int = value as i64;
-    if (int as f64) == value { Some(int) } else { None }
+    ((int as f64) == value).then_some(int)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use serde_json::json;
 
     use super::*;
 
-    const TAG_OBJECT_END: u8 = 0xff;
-
     fn encode_string(value: &str) -> Vec<u8> {
-        let mut buffer = Vec::new();
-        buffer.push(TAG_STRING);
+        let mut buffer = vec![TAG_STRING];
         buffer.extend_from_slice(&(value.len() as u32).to_le_bytes());
         buffer.extend_from_slice(value.as_bytes());
-        buffer
-    }
-
-    fn encode_object(pairs: &[(&str, Vec<u8>)]) -> Vec<u8> {
-        let mut buffer = vec![TAG_OBJECT];
-        for (key, value) in pairs {
-            buffer.extend_from_slice(&encode_string(key));
-            buffer.extend_from_slice(value);
-        }
-        buffer.push(TAG_OBJECT_END);
-        buffer
-    }
-
-    fn encode_array(values: &[Vec<u8>]) -> Vec<u8> {
-        let mut buffer = vec![TAG_OBJECT];
-        for value in values {
-            buffer.extend_from_slice(value);
-        }
-        buffer.push(TAG_OBJECT_END);
         buffer
     }
 
@@ -316,231 +264,264 @@ mod tests {
         buffer
     }
 
-    #[test]
-    fn decode_bool_values() {
-        let value = decode(&[TAG_BOOL, 1]).unwrap();
-        assert_eq!(value, Value::Bool(true));
+    fn encode_table(values: &[Vec<u8>]) -> Vec<u8> {
+        let mut buffer = vec![TAG_TABLE];
+        for value in values {
+            buffer.extend_from_slice(value);
+        }
+        buffer.push(TABLE_END);
+        buffer
+    }
 
-        let value = decode(&[TAG_BOOL, 0]).unwrap();
-        assert_eq!(value, Value::Bool(false));
+    fn encode_object(pairs: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let values = pairs
+            .iter()
+            .flat_map(|(key, value)| [encode_string(key), value.clone()])
+            .collect::<Vec<_>>();
+        encode_table(&values)
+    }
+
+    fn encode_numeric_table(pairs: &[(f64, Vec<u8>)]) -> Vec<u8> {
+        let values = pairs
+            .iter()
+            .flat_map(|(key, value)| [encode_f64(*key), value.clone()])
+            .collect::<Vec<_>>();
+        encode_table(&values)
+    }
+
+    fn encode_file(value: &[u8]) -> Vec<u8> {
+        let mut buffer = vec![FILE_MARKER];
+        buffer.extend_from_slice(&0_u64.to_le_bytes());
+        buffer.extend_from_slice(value);
+        let checksum = file_checksum(&buffer);
+        buffer[1..FILE_HEADER_LEN].copy_from_slice(&checksum.to_le_bytes());
+        buffer
     }
 
     #[test]
-    fn decode_f32_value() {
-        let mut buffer = vec![TAG_F32];
-        buffer.extend_from_slice(&1.5_f32.to_le_bytes());
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Number(Number::from_f64(1.5).unwrap()));
+    fn decode_value_decodes_boolean() {
+        assert_eq!(decode_value(&[TAG_BOOL, 1]).expect("decode bool"), Value::Bool(true));
     }
 
     #[test]
-    fn decode_f64_value() {
-        let mut buffer = vec![TAG_F64];
-        buffer.extend_from_slice(&42.5_f64.to_be_bytes());
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Number(Number::from_f64(42.5).unwrap()));
+    fn decode_value_decodes_f64() {
+        assert_eq!(decode_value(&encode_f64(42.5)).expect("decode f64"), json!(42.5));
     }
 
     #[test]
-    fn normalize_float_whole_numbers() {
-        let mut buffer = vec![TAG_F32];
-        buffer.extend_from_slice(&1.0_f32.to_le_bytes());
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Number(Number::from(1)));
-
-        let mut buffer = vec![TAG_F64];
-        buffer.extend_from_slice(&0.0_f64.to_be_bytes());
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Number(Number::from(0)));
+    fn decode_value_normalizes_whole_f64() {
+        assert_eq!(decode_value(&encode_f64(1.0)).expect("decode f64"), json!(1));
     }
 
     #[test]
-    fn keep_float_fractional_numbers() {
-        let mut buffer = vec![TAG_F64];
-        buffer.extend_from_slice(&10.01_f64.to_be_bytes());
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Number(Number::from_f64(10.01).unwrap()));
+    fn decode_value_decodes_string() {
+        assert_eq!(decode_value(&encode_string("hello")).expect("decode string"), json!("hello"));
     }
 
     #[test]
-    fn decode_string_value() {
-        let buffer = encode_string("hello");
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::String("hello".to_string()));
+    fn decode_value_decodes_object_after_complete_table_read() {
+        let input = encode_object(&[("a", vec![TAG_BOOL, 1]), ("b", encode_string("ok"))]);
+
+        assert_eq!(decode_value(&input).expect("decode object"), json!({ "a": true, "b": "ok" }));
     }
 
     #[test]
-    fn decode_object_simple() {
-        let buffer = encode_object(&[("a", vec![TAG_BOOL, 1]), ("b", encode_string("ok"))]);
-        let value = decode(&buffer).unwrap();
+    fn decode_value_sorts_sequential_numeric_keys() {
+        let input =
+            encode_numeric_table(&[(2.0, encode_string("second")), (1.0, encode_string("first"))]);
 
-        let mut expected = Map::new();
-        expected.insert("a".to_string(), Value::Bool(true));
-        expected.insert("b".to_string(), Value::String("ok".to_string()));
-        assert_eq!(value, Value::Object(expected));
+        assert_eq!(decode_value(&input).expect("decode array"), json!(["first", "second"]));
     }
 
     #[test]
-    fn decode_nested_object() {
-        let inner = encode_object(&[("inner", vec![TAG_BOOL, 1])]);
-        let buffer = encode_object(&[("outer", inner)]);
-        let value = decode(&buffer).unwrap();
+    fn decode_value_preserves_non_sequential_numeric_keys() {
+        let input = encode_numeric_table(&[(42.0, encode_string("value"))]);
 
-        let mut inner_map = Map::new();
-        inner_map.insert("inner".to_string(), Value::Bool(true));
-        let mut outer_map = Map::new();
-        outer_map.insert("outer".to_string(), Value::Object(inner_map));
-        assert_eq!(value, Value::Object(outer_map));
+        assert_eq!(decode_value(&input).expect("decode numeric map"), json!({ "42": "value" }));
     }
 
     #[test]
-    fn decode_array_values() {
-        let buffer = encode_array(&[vec![TAG_BOOL, 1], encode_string("ok")]);
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Array(vec![Value::Bool(true), Value::String("ok".to_string())]));
+    fn decode_value_keeps_unkeyed_sequence() {
+        let input = encode_table(&[vec![TAG_BOOL, 1], encode_string("ok")]);
+
+        assert_eq!(decode_value(&input).expect("decode sequence"), json!([true, "ok"]));
     }
 
     #[test]
-    fn decode_empty_array() {
-        let buffer = vec![TAG_OBJECT, TAG_OBJECT_END];
-        let value = decode(&buffer).unwrap();
-        assert_eq!(value, Value::Array(Vec::new()));
+    fn decode_value_uses_array_for_empty_table() {
+        assert_eq!(decode_value(&[TAG_TABLE, TABLE_END]).expect("decode empty"), json!([]));
     }
 
     #[test]
-    fn decode_sequential_numeric_keyed_container_as_array() {
-        let buffer = encode_array(&[
-            encode_f64(1.0),
-            encode_string("first"),
+    fn decode_accepts_valid_native_header_and_checksum() {
+        let file = encode_file(&encode_object(&[("ok", vec![TAG_BOOL, 1])]));
+
+        assert_eq!(decode(&file).expect("decode file"), json!({ "ok": true }));
+    }
+
+    #[test]
+    fn decode_rejects_headerless_value() {
+        let error = decode(&[TAG_BOOL, 1]).expect_err("header should be required");
+
+        assert!(matches!(error, DecodeError::HeaderTooShort { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_invalid_file_marker() {
+        let mut file = encode_file(&encode_string("hello"));
+        file[0] = 0;
+
+        assert_eq!(
+            decode(&file).expect_err("marker should fail"),
+            DecodeError::InvalidFileMarker { expected: FILE_MARKER, found: 0 }
+        );
+    }
+
+    #[test]
+    fn decode_rejects_checksum_corruption() {
+        let mut file = encode_file(&encode_string("hello"));
+        let last = file.len() - 1;
+        file[last] ^= 1;
+
+        assert!(matches!(decode(&file), Err(DecodeError::ChecksumMismatch { .. })));
+    }
+
+    #[test]
+    fn decode_rejects_unsupported_tag() {
+        let file = encode_file(&[0x99]);
+
+        assert_eq!(
+            decode(&file).expect_err("unknown tag should fail"),
+            DecodeError::UnsupportedTag { tag: 0x99, offset: FILE_HEADER_LEN }
+        );
+    }
+
+    #[test]
+    fn decode_rejects_legacy_f32_tag() {
+        let file = encode_file(&[0x02, 0, 0, 0, 0]);
+
+        assert_eq!(
+            decode(&file).expect_err("f32 tag should fail"),
+            DecodeError::UnsupportedTag { tag: 0x02, offset: FILE_HEADER_LEN }
+        );
+    }
+
+    #[test]
+    fn decode_value_rejects_unknown_tag_inside_table() {
+        let input = encode_table(&[vec![0x99]]);
+
+        assert_eq!(
+            decode_value(&input).expect_err("unknown tag should fail"),
+            DecodeError::UnsupportedTag { tag: 0x99, offset: 1 }
+        );
+    }
+
+    #[test]
+    fn decode_value_rejects_unterminated_keyed_table() {
+        let mut input = encode_object(&[("ok", vec![TAG_BOOL, 1])]);
+        input.pop();
+
+        assert_eq!(
+            decode_value(&input).expect_err("terminator should be required"),
+            DecodeError::MissingTableTerminator { offset: 0 }
+        );
+    }
+
+    #[test]
+    fn decode_value_rejects_unterminated_unkeyed_table() {
+        let nested = encode_object(&[("type", encode_string("Battle"))]);
+        let mut input = vec![TAG_TABLE];
+        input.extend_from_slice(&nested);
+
+        assert_eq!(
+            decode_value(&input).expect_err("outer table terminator should be required"),
+            DecodeError::MissingTableTerminator { offset: 0 }
+        );
+    }
+
+    #[test]
+    fn decode_value_rejects_mixed_table_keys() {
+        let input = encode_table(&[
+            encode_string("one"),
+            vec![TAG_BOOL, 1],
             encode_f64(2.0),
-            encode_string("second"),
+            vec![TAG_BOOL, 0],
         ]);
 
-        assert_eq!(decode(&buffer).unwrap(), json!(["first", "second"]));
+        assert_eq!(
+            decode_value(&input).expect_err("mixed keys should fail"),
+            DecodeError::MixedTableKeyTypes { offset: 0 }
+        );
     }
 
     #[test]
-    fn decode_non_sequential_numeric_keyed_container_as_object() {
-        let buffer = encode_array(&[encode_f64(42.0), encode_string("value")]);
+    fn decode_value_rejects_duplicate_table_keys() {
+        let input = encode_object(&[("same", vec![TAG_BOOL, 1]), ("same", vec![TAG_BOOL, 0])]);
 
-        assert_eq!(decode(&buffer).unwrap(), json!({ "42": "value" }));
+        assert_eq!(
+            decode_value(&input).expect_err("duplicate should fail"),
+            DecodeError::DuplicateTableKey { offset: 0, key: "same".to_string() }
+        );
     }
 
     #[test]
-    fn decode_sequential_numeric_scalar_container_as_array() {
-        let buffer =
-            encode_array(&[encode_f64(1.0), encode_f64(24.0), encode_f64(2.0), encode_f64(1.0)]);
+    fn decode_value_rejects_trailing_bytes() {
+        let mut input = encode_object(&[("ok", vec![TAG_BOOL, 1])]);
+        input.extend_from_slice(&[TAG_BOOL, 0]);
 
-        assert_eq!(decode(&buffer).unwrap(), json!([24, 1]));
+        assert_eq!(
+            decode_value(&input).expect_err("trailing value should fail"),
+            DecodeError::TrailingBytes { remaining: 2 }
+        );
     }
 
     #[test]
-    fn decode_unknown_tag_as_null() {
-        let value = decode(&[0x99]).unwrap();
-        assert_eq!(value, Value::Null);
+    fn validate_file_accepts_checked_in_sample() {
+        let sample = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../../samples/Battle/Persistent.Mail.485440176891031331"
+        ));
+
+        assert_eq!(validate_file(sample), Ok(()));
     }
 
     #[test]
-    fn decode_skips_preamble_to_valid_payload() {
-        let mut buffer = vec![0xff, TAG_BOOL, 0];
-        buffer.extend_from_slice(&encode_object(&[("ok", vec![TAG_BOOL, 1])]));
-        let value = decode(&buffer).unwrap();
-
-        let mut expected = Map::new();
-        expected.insert("ok".to_string(), Value::Bool(true));
-        assert_eq!(value, Value::Object(expected));
-    }
-
-    #[test]
-    fn decode_preamble_without_payload_is_error() {
-        let err = decode(&[0x99, 0x88]).unwrap_err();
-        assert!(matches!(err, DecodeError::TrailingBytes { .. }));
-    }
-
-    #[test]
-    fn decode_preamble_scan_is_bounded() {
-        let mut buffer = vec![0x99; MAX_PREAMBLE_SCAN_BYTES + 1];
-        buffer.extend_from_slice(&encode_object(&[("ok", vec![TAG_BOOL, 1])]));
-
-        let err = decode(&buffer).unwrap_err();
-        assert!(matches!(err, DecodeError::TrailingBytes { .. }));
-    }
-
-    #[test]
-    fn decode_preamble_scan_includes_limit_boundary() {
-        let mut buffer = vec![0x99; MAX_PREAMBLE_SCAN_BYTES];
-        buffer.extend_from_slice(&encode_object(&[("ok", vec![TAG_BOOL, 1])]));
-
-        let value = decode(&buffer).unwrap();
-
-        let mut expected = Map::new();
-        expected.insert("ok".to_string(), Value::Bool(true));
-        assert_eq!(value, Value::Object(expected));
-    }
-
-    #[test]
-    fn decode_invalid_utf8_is_error() {
-        let mut buffer = vec![TAG_STRING];
-        buffer.extend_from_slice(&2_u32.to_le_bytes());
-        buffer.extend_from_slice(&[0xff, 0xff]);
-        let err = decode(&buffer).unwrap_err();
-        assert!(matches!(err, DecodeError::InvalidUtf8 { .. }));
-    }
-
-    #[test]
-    fn decode_trailing_bytes_is_error() {
-        let mut buffer = encode_object(&[("ok", vec![TAG_BOOL, 1])]);
-        buffer.push(TAG_BOOL);
-        buffer.push(0);
-        let err = decode(&buffer).unwrap_err();
-        assert!(matches!(err, DecodeError::TrailingBytes { .. }));
-    }
-
-    #[test]
-    fn decode_sample_mail_files() {
-        let samples = [
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../../samples/Battle/Persistent.Mail.485440176891031331"
-            ))
-            .as_slice(),
-            include_bytes!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/../../../samples/Battle/Persistent.Mail.1409019176893142331"
-            ))
-            .as_slice(),
-        ];
-
-        for sample in samples {
-            let value = decode(sample).expect("decode sample");
-            assert!(matches!(value, Value::Object(_)));
-        }
-    }
-
-    #[test]
-    fn decode_all_checked_in_mail_samples() {
-        let samples_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../samples");
+    fn decode_all_checked_in_mail_samples_matches_raw_json() {
+        let samples_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../samples");
         let samples = collect_mail_samples(&samples_dir);
 
         for input in &samples {
             let buffer = std::fs::read(input)
                 .unwrap_or_else(|error| panic!("failed to read {}: {error}", input.display()));
-            if let Err(error) = decode(&buffer) {
-                panic!("failed to decode {}: {error}", input.display());
-            }
+            let actual = decode(&buffer)
+                .unwrap_or_else(|error| panic!("failed to decode {}: {error}", input.display()));
+            let expected_path = PathBuf::from(format!("{}.json", input.display()));
+            let expected_buffer = std::fs::read(&expected_path).unwrap_or_else(|error| {
+                panic!("failed to read {}: {error}", expected_path.display())
+            });
+            let expected: Value =
+                serde_json::from_slice(&expected_buffer).unwrap_or_else(|error| {
+                    panic!("failed to parse {}: {error}", expected_path.display())
+                });
+            assert!(
+                json_equivalent(&actual, &expected),
+                "decoded output differs for {}: {}",
+                input.display(),
+                first_json_difference(&actual, &expected, "$"),
+            );
         }
 
         assert_eq!(samples.len(), 132);
     }
 
-    fn collect_mail_samples(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    fn collect_mail_samples(dir: &Path) -> Vec<PathBuf> {
         let mut samples = Vec::new();
         collect_mail_samples_inner(dir, &mut samples);
         samples.sort();
         samples
     }
 
-    fn collect_mail_samples_inner(dir: &std::path::Path, samples: &mut Vec<std::path::PathBuf>) {
+    fn collect_mail_samples_inner(dir: &Path, samples: &mut Vec<PathBuf>) {
         let entries = std::fs::read_dir(dir)
             .unwrap_or_else(|error| panic!("failed to read {}: {error}", dir.display()));
 
@@ -551,19 +532,89 @@ mod tests {
                 })
                 .path();
             if path.is_dir() {
-                collect_mail_samples_inner(&path, samples);
+                if path.file_name().and_then(|name| name.to_str()) != Some("game") {
+                    collect_mail_samples_inner(&path, samples);
+                }
             } else if is_binary_mail_sample(&path) {
                 samples.push(path);
             }
         }
     }
 
-    fn is_binary_mail_sample(path: &std::path::Path) -> bool {
+    fn is_binary_mail_sample(path: &Path) -> bool {
         let Some(file_name) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
             return false;
         };
-        file_name.starts_with("Persistent.Mail.")
-            && !file_name.ends_with(".json")
-            && !file_name.ends_with("-processed.json")
+        file_name.starts_with("Persistent.Mail.") && !file_name.ends_with(".json")
+    }
+
+    fn json_equivalent(actual: &Value, expected: &Value) -> bool {
+        match (actual, expected) {
+            (Value::Array(actual), Value::Array(expected)) => {
+                actual.len() == expected.len()
+                    && actual.iter().zip(expected).all(|(a, b)| json_equivalent(a, b))
+            }
+            (Value::Object(actual), Value::Object(expected)) => {
+                actual.len() == expected.len()
+                    && actual.iter().all(|(key, value)| {
+                        expected.get(key).is_some_and(|other| json_equivalent(value, other))
+                    })
+            }
+            (Value::Number(actual), Value::Number(expected)) => {
+                match (actual.as_i64(), expected.as_i64()) {
+                    (Some(actual), Some(expected)) => actual == expected,
+                    _ => match (actual.as_u64(), expected.as_u64()) {
+                        (Some(actual), Some(expected)) => actual == expected,
+                        _ => match (actual.as_f64(), expected.as_f64()) {
+                            (Some(actual), Some(expected)) => {
+                                ordered_float_bits(actual).abs_diff(ordered_float_bits(expected))
+                                    <= 1
+                            }
+                            _ => false,
+                        },
+                    },
+                }
+            }
+            _ => actual == expected,
+        }
+    }
+
+    fn ordered_float_bits(value: f64) -> u64 {
+        let bits = value.to_bits();
+        if bits & (1_u64 << 63) == 0 { bits | (1_u64 << 63) } else { !bits }
+    }
+
+    fn first_json_difference(actual: &Value, expected: &Value, path: &str) -> String {
+        match (actual, expected) {
+            (Value::Array(actual), Value::Array(expected)) => {
+                if actual.len() != expected.len() {
+                    return format!("{path} array length {} != {}", actual.len(), expected.len());
+                }
+                for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+                    if !json_equivalent(actual, expected) {
+                        return first_json_difference(
+                            actual,
+                            expected,
+                            &format!("{path}[{index}]"),
+                        );
+                    }
+                }
+            }
+            (Value::Object(actual), Value::Object(expected)) => {
+                if actual.len() != expected.len() {
+                    return format!("{path} object length {} != {}", actual.len(), expected.len());
+                }
+                for (key, actual) in actual {
+                    let Some(expected) = expected.get(key) else {
+                        return format!("{path}.{key} is missing from expected output");
+                    };
+                    if !json_equivalent(actual, expected) {
+                        return first_json_difference(actual, expected, &format!("{path}.{key}"));
+                    }
+                }
+            }
+            _ => return format!("{path}: actual {actual:?}, expected {expected:?}"),
+        }
+        "no structural difference found".to_string()
     }
 }

--- a/crates/mail/decoder/src/lib.rs
+++ b/crates/mail/decoder/src/lib.rs
@@ -1,32 +1,28 @@
 #![forbid(unsafe_code)]
 
-//! Mail binary decoder.
+//! Decoder for `Persistent.Mail` files.
 //!
-//! # Format
-//! Each value starts with a one-byte tag:
-//! - `0x01` -> bool (`u8`, non-zero is `true`)
-//! - `0x02` -> `f32` (little-endian)
-//! - `0x03` -> `f64` (big-endian)
-//! - `0x04` -> UTF-8 string (`u32` length, little-endian, then bytes)
-//! - `0x05` -> container (object or array)
-//! - Anything else -> `null`
+//! A complete file contains a fixed nine-byte header followed by one tagged
+//! value. The header starts with `0xff` and stores a little-endian
+//! 64-bit checksum in bytes 1 through 8. The checksum uses a wrapping DJB2
+//! recurrence over the complete file while treating its checksum bytes as zero.
 //!
-//! Objects are sequences of `key -> value` pairs where keys are encoded as
-//! strings (tag `0x04`). Objects end when the next tag is not a string tag.
-//! In the sample files, an unknown tag (`0xff`) is used as an explicit
-//! terminator; the decoder consumes that byte as the end marker.
+//! Supported value tags are:
 //!
-//! Arrays use the same `0x05` tag. If the first element is not a string tag,
-//! the decoder treats the container as an array of values until the terminator.
+//! - `0x01`: boolean (`u8`)
+//! - `0x03`: big-endian IEEE-754 `f64`
+//! - `0x04`: UTF-8 string with a little-endian `u32` byte length
+//! - `0x05`: table contents ending with the explicit `0xff` terminator
 //!
-//! The files in `samples/` also contain a small leading header. If the first
-//! parsed value is `null` and trailing bytes remain, the decoder treats the
-//! leading bytes as a preamble and scans for the first offset that yields a
-//! complete decode without trailing bytes.
+//! Tables are read completely before classification. String-keyed tables become
+//! JSON objects, numeric keys `1..N` become JSON arrays, other numeric keys
+//! become decimal JSON object keys, and unkeyed sequences remain arrays. Empty
+//! tables are represented as `[]`. Mixed or duplicate keys are rejected to avoid
+//! silently losing information in JSON.
 
 mod common;
 mod decoder;
 mod value;
 
 pub use common::DecodeError;
-pub use decoder::decode;
+pub use decoder::{decode, decode_value, validate_file};

--- a/crates/mail/decoder/src/value.rs
+++ b/crates/mail/decoder/src/value.rs
@@ -1,36 +1,124 @@
-//! Helpers for normalizing numeric-keyed containers.
+//! Helpers for classifying `Persistent.Mail` table contents.
 
-use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 
-pub(crate) fn numeric_keyed_container(items: &[Value]) -> Option<Value> {
+use serde_json::{Map, Value, map::Entry};
+
+use crate::common::DecodeError;
+
+#[derive(Debug)]
+pub(crate) struct ClassifiedTable {
+    pub(crate) value: Value,
+}
+
+pub(crate) fn classify_table(
+    items: Vec<Value>,
+    table_offset: usize,
+) -> Result<ClassifiedTable, DecodeError> {
     if items.is_empty() || !items.len().is_multiple_of(2) {
-        return None;
+        return Ok(sequential(items));
     }
 
-    let mut pairs = Vec::with_capacity(items.len() / 2);
-    for (index, pair) in items.as_chunks::<2>().0.iter().enumerate() {
-        let key = integer_key(&pair[0])?;
-        pairs.push((key, index + 1, pair[1].clone()));
-    }
-
-    if pairs.iter().all(|(key, expected, _)| key == expected) {
-        return Some(Value::Array(pairs.into_iter().map(|(_, _, value)| value).collect()));
-    }
-
-    let mut map = Map::new();
-    for (key, _, value) in pairs {
-        // Non-sequential numeric keys are semantic ids. JSON object keys are
-        // strings, so preserve those ids using their decimal representation.
-        if map.insert(key.to_string(), value).is_some() {
-            return None;
+    let mut has_string_keys = false;
+    let mut has_number_keys = false;
+    for pair in items.as_chunks::<2>().0 {
+        match &pair[0] {
+            Value::String(_) => has_string_keys = true,
+            Value::Number(_) => has_number_keys = true,
+            _ => return Ok(sequential(items)),
         }
     }
 
-    Some(Value::Object(map))
+    if has_string_keys && has_number_keys {
+        return Err(DecodeError::MixedTableKeyTypes { offset: table_offset });
+    }
+
+    let value = if has_string_keys {
+        string_keyed_table(items, table_offset)?
+    } else {
+        numeric_keyed_table(items, table_offset)?
+    };
+    Ok(ClassifiedTable { value })
 }
 
-fn integer_key(value: &Value) -> Option<usize> {
-    usize::try_from(value.as_u64()?).ok()
+fn sequential(items: Vec<Value>) -> ClassifiedTable {
+    ClassifiedTable { value: Value::Array(items) }
+}
+
+fn string_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, DecodeError> {
+    let mut map = Map::with_capacity(items.len() / 2);
+    for (key, value) in owned_pairs(items) {
+        let Value::String(key) = key else {
+            unreachable!("table key types were classified before conversion");
+        };
+        match map.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            Entry::Occupied(entry) => {
+                return Err(DecodeError::DuplicateTableKey {
+                    offset: table_offset,
+                    key: entry.key().clone(),
+                });
+            }
+        }
+    }
+    Ok(Value::Object(map))
+}
+
+fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, DecodeError> {
+    let pair_count = items.len() / 2;
+    let is_sequential = {
+        let mut keys = vec![false; pair_count];
+        items.as_chunks::<2>().0.iter().all(|pair| {
+            let Some(key) = pair[0].as_u64().and_then(|key| usize::try_from(key).ok()) else {
+                return false;
+            };
+            key > 0 && key <= pair_count && !std::mem::replace(&mut keys[key - 1], true)
+        })
+    };
+
+    if is_sequential {
+        let mut values = BTreeMap::new();
+        for (key, value) in owned_pairs(items) {
+            let Some(key) = key.as_u64().and_then(|key| usize::try_from(key).ok()) else {
+                unreachable!("sequential numeric keys were validated before conversion");
+            };
+            values.insert(key, value);
+        }
+        return Ok(Value::Array(values.into_values().collect()));
+    }
+
+    let mut map = Map::with_capacity(pair_count);
+    for (key, value) in owned_pairs(items) {
+        let Value::Number(key) = key else {
+            unreachable!("table key types were classified before conversion");
+        };
+        let key = key.to_string();
+        match map.entry(key) {
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            Entry::Occupied(entry) => {
+                return Err(DecodeError::DuplicateTableKey {
+                    offset: table_offset,
+                    key: entry.key().clone(),
+                });
+            }
+        }
+    }
+    Ok(Value::Object(map))
+}
+
+fn owned_pairs(items: Vec<Value>) -> impl Iterator<Item = (Value, Value)> {
+    let mut items = items.into_iter();
+    std::iter::from_fn(move || {
+        let key = items.next()?;
+        let Some(value) = items.next() else {
+            unreachable!("pair iterator requires an even item count");
+        };
+        Some((key, value))
+    })
 }
 
 #[cfg(test)]
@@ -40,18 +128,38 @@ mod tests {
     use super::*;
 
     #[test]
-    fn duplicate_numeric_keys_remain_an_array() {
-        let values = json!([2, "first", 2, "second"]);
-        let values = values.as_array().expect("array");
+    fn sequential_numeric_keys_are_sorted_into_an_array() {
+        let values = json!([2, "second", 1, "first"]);
+        let classified =
+            classify_table(values.as_array().expect("array").clone(), 0).expect("classify table");
 
-        assert_eq!(numeric_keyed_container(values), None);
+        assert_eq!(classified.value, json!(["first", "second"]));
     }
 
     #[test]
-    fn mixed_values_remain_an_array() {
-        let values = json!([1, "first", "key", "second"]);
-        let values = values.as_array().expect("array");
+    fn duplicate_numeric_keys_are_rejected() {
+        let values = json!([2, "first", 2, "second"]);
+        let error = classify_table(values.as_array().expect("array").clone(), 7)
+            .expect_err("duplicate should fail");
 
-        assert_eq!(numeric_keyed_container(values), None);
+        assert_eq!(error, DecodeError::DuplicateTableKey { offset: 7, key: "2".to_string() });
+    }
+
+    #[test]
+    fn mixed_key_types_are_rejected() {
+        let values = json!([1, "first", "key", "second"]);
+        let error = classify_table(values.as_array().expect("array").clone(), 11)
+            .expect_err("mixed keys should fail");
+
+        assert_eq!(error, DecodeError::MixedTableKeyTypes { offset: 11 });
+    }
+
+    #[test]
+    fn non_key_values_remain_a_sequence() {
+        let values = json!([true, "first", false, "second"]);
+        let classified =
+            classify_table(values.as_array().expect("array").clone(), 0).expect("classify table");
+
+        assert_eq!(classified.value, values);
     }
 }

--- a/crates/mail/processors/system-barbarianfort/src/templates.rs
+++ b/crates/mail/processors/system-barbarianfort/src/templates.rs
@@ -1,4 +1,4 @@
-//! Localized mail body templates from `samples/game/mail`.
+//! Localized system barbarian fort mail body templates.
 
 pub(crate) const BODY_TEMPLATES: &[&str] = &[
     // BARBARIAN_CONTENT_2

--- a/crates/mail/registry/src/lib.rs
+++ b/crates/mail/registry/src/lib.rs
@@ -133,15 +133,14 @@ impl fmt::Display for MailType {
     }
 }
 
-/// Normalize a decoded mail payload to a single root object.
+/// Normalize a decoded mail payload to the object value processors should use.
+///
+/// A valid decoded mail payload has an object root. Other shapes are rejected
+/// so malformed data cannot enter processor code.
 #[must_use]
-pub fn normalize_mail_root(value: &Value) -> Option<&Map<String, Value>> {
+pub fn normalize_mail_root(value: &Value) -> Option<&Value> {
     match value {
-        Value::Object(map) => Some(map),
-        Value::Array(items) => match items.as_slice() {
-            [Value::Object(map)] => Some(map),
-            _ => None,
-        },
+        Value::Object(_) => Some(value),
         _ => None,
     }
 }
@@ -188,7 +187,7 @@ pub fn detect_mail_type_from_root(root: &Map<String, Value>) -> Option<MailType>
 /// Detect the processable mail type for a decoded mail payload.
 #[must_use]
 pub fn detect_mail_type(value: &Value) -> Option<MailType> {
-    let root = normalize_mail_root(value)?;
+    let root = normalize_mail_root(value)?.as_object()?;
     detect_mail_type_from_root(root)
 }
 
@@ -303,15 +302,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalize_mail_root_accepts_object_and_singleton_array() {
+    fn normalize_mail_root_accepts_object() {
         let object = json!({ "type": "Battle" });
-        assert!(normalize_mail_root(&object).is_some());
+        assert_eq!(normalize_mail_root(&object), Some(&object));
+    }
 
+    #[test]
+    fn normalize_mail_root_rejects_singleton_array() {
         let singleton = json!([{ "type": "Battle" }]);
-        assert!(normalize_mail_root(&singleton).is_some());
-
-        let multiple = json!([{ "type": "Battle" }, { "type": "Battle" }]);
-        assert!(normalize_mail_root(&multiple).is_none());
+        assert_eq!(normalize_mail_root(&singleton), None);
     }
 
     #[test]

--- a/crates/services/rokbattles-ingress/src/handlers.rs
+++ b/crates/services/rokbattles-ingress/src/handlers.rs
@@ -226,7 +226,7 @@ fn update_status_for_mail_type(mail_type: &str) -> &'static str {
 }
 
 fn extract_mail_id(decoded: &Value) -> Option<String> {
-    let root = normalize_root(decoded)?;
+    let root = mail_registry::normalize_mail_root(decoded)?;
     root.get("id")
         .and_then(value_to_string)
         .or_else(|| root.get("mail_id").and_then(value_to_string))
@@ -239,21 +239,6 @@ fn value_to_string(value: &Value) -> Option<String> {
     match value {
         Value::String(value) => Some(value.clone()),
         Value::Number(value) => Some(value.to_string()),
-        _ => None,
-    }
-}
-
-/// Turn a decoded mail payload into the root object we store.
-///
-/// Some mail samples decode as a one-item array. In that case the item is the
-/// root object. Other shapes are rejected.
-fn normalize_root(value: &Value) -> Option<&Value> {
-    match value {
-        Value::Object(_) => Some(value),
-        Value::Array(items) => match items.as_slice() {
-            [item] if item.is_object() => Some(item),
-            _ => None,
-        },
         _ => None,
     }
 }
@@ -358,9 +343,9 @@ mod tests {
     }
 
     #[test]
-    fn extracts_mail_type_from_singleton_array() {
+    fn rejects_mail_type_from_singleton_array() {
         let decoded = json!([{ "type": "Battle" }]);
-        assert_eq!(extract_mail_type(&decoded).unwrap(), "Battle");
+        assert!(extract_mail_type(&decoded).is_err());
     }
 
     #[test]
@@ -584,9 +569,9 @@ mod tests {
     }
 
     #[test]
-    fn extracts_mail_id_from_singleton_array() {
+    fn rejects_mail_id_from_singleton_array() {
         let decoded = json!([{ "id": "12345" }]);
-        assert_eq!(extract_mail_id(&decoded).as_deref(), Some("12345"));
+        assert_eq!(extract_mail_id(&decoded), None);
     }
 
     #[test]

--- a/crates/services/rokbattles-ingress/src/raw_mail.rs
+++ b/crates/services/rokbattles-ingress/src/raw_mail.rs
@@ -60,7 +60,8 @@ pub struct RawMailDocumentInput<'a> {
 
 /// Extract the fields required by the V2 `mail` subdocument.
 pub fn extract_raw_mail_metadata(decoded: &Value) -> Result<RawMailMetadata, ApiError> {
-    let root = normalize_root(decoded).ok_or_else(|| ApiError::bad_request("invalid mail root"))?;
+    let root = mail_registry::normalize_mail_root(decoded)
+        .ok_or_else(|| ApiError::bad_request("invalid mail root"))?;
     let object = root.as_object().ok_or_else(|| ApiError::bad_request("invalid mail root"))?;
 
     let id = object
@@ -103,17 +104,6 @@ fn extract_receiver_identity(object: &serde_json::Map<String, Value>) -> Result<
         .filter(|value| value.starts_with("player_"))
         .map(str::to_string)
         .ok_or_else(|| ApiError::bad_request("missing mail receiver"))
-}
-
-fn normalize_root(value: &Value) -> Option<&Value> {
-    match value {
-        Value::Object(_) => Some(value),
-        Value::Array(items) => match items.as_slice() {
-            [item] if item.is_object() => Some(item),
-            _ => None,
-        },
-        _ => None,
-    }
 }
 
 fn value_to_string(value: &Value) -> Option<String> {
@@ -181,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn extracts_v2_metadata_from_singleton_array() {
+    fn rejects_v2_metadata_from_singleton_array() {
         let decoded = json!([{
             "id": "12345",
             "time": 1772127772844751_u64,
@@ -189,9 +179,7 @@ mod tests {
             "receiver": "player_22"
         }]);
 
-        let metadata = extract_raw_mail_metadata(&decoded).expect("metadata");
-
-        assert_eq!(metadata.receiver, "player_22");
+        assert!(extract_raw_mail_metadata(&decoded).is_err());
     }
 
     #[test]

--- a/crates/services/rokbattles-processor/src/processing.rs
+++ b/crates/services/rokbattles-processor/src/processing.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use futures::stream::TryStreamExt;
-use mail_registry::{MailType, process_mail};
+use mail_registry::{MailType, normalize_mail_root, process_mail};
 use mongodb::bson::{Bson, DateTime, Document, oid::ObjectId};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -144,7 +144,7 @@ async fn process_document(
 
 fn prepare_processed_document(raw: &RawMail) -> Result<(MailType, Document), ProcessorError> {
     let decoded = decode_mail_binary(raw)?;
-    let root = normalize_root(&decoded).ok_or_else(|| {
+    let root = normalize_mail_root(&decoded).ok_or_else(|| {
         ProcessorError::InvalidMailPayload("mail payload must be an object".to_string())
     })?;
     let mail_type = extract_mail_type(root)?;
@@ -239,17 +239,6 @@ fn observed_version(doc: &Document) -> ObservedVersion {
     }
 }
 
-fn normalize_root(value: &Value) -> Option<&Value> {
-    match value {
-        Value::Object(_) => Some(value),
-        Value::Array(items) => match items.as_slice() {
-            [item] if item.is_object() => Some(item),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 fn extract_mail_type(root: &Value) -> Result<MailType, ProcessorError> {
     if let Some(mail_type) = mail_registry::detect_mail_type(root) {
         return Ok(mail_type);
@@ -269,24 +258,6 @@ mod tests {
 
     use super::*;
     use crate::storage::STATUS_PENDING;
-
-    #[test]
-    fn normalize_root_accepts_object() {
-        let value = json!({ "type": "Battle" });
-        assert!(normalize_root(&value).is_some());
-    }
-
-    #[test]
-    fn normalize_root_accepts_singleton_array() {
-        let value = json!([{ "type": "Battle" }]);
-        assert!(normalize_root(&value).is_some());
-    }
-
-    #[test]
-    fn normalize_root_rejects_other_shapes() {
-        let value = json!([1, 2, 3]);
-        assert!(normalize_root(&value).is_none());
-    }
 
     #[test]
     fn extract_mail_type_parses_known_types() {
@@ -525,6 +496,19 @@ mod tests {
         }
     }
 
+    fn native_file(payload: &[u8]) -> Vec<u8> {
+        let mut buffer = vec![0xff];
+        buffer.extend_from_slice(&0_u64.to_le_bytes());
+        buffer.extend_from_slice(payload);
+        let checksum =
+            buffer.iter().copied().enumerate().fold(0x1505_u64, |hash, (index, byte)| {
+                let byte = if (1..9).contains(&index) { 0 } else { byte };
+                hash.wrapping_mul(33).wrapping_add(u64::from(byte))
+            });
+        buffer[1..9].copy_from_slice(&checksum.to_le_bytes());
+        buffer
+    }
+
     fn raw_document() -> Document {
         doc! {
             "_id": ObjectId::new(),
@@ -659,6 +643,110 @@ mod tests {
     }
 
     #[test]
+    fn all_processable_binary_samples_match_processed_fixtures() {
+        let samples_root =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../samples");
+        let mut samples = Vec::new();
+        collect_binary_mail_samples(&samples_root, &mut samples);
+        samples.sort();
+        let mut processed_count = 0;
+
+        for input in samples {
+            let bytes = std::fs::read(&input)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", input.display()));
+            let decoded = mail_decoder::decode(&bytes)
+                .unwrap_or_else(|error| panic!("failed to decode {}: {error}", input.display()));
+            let Some(root) = normalize_mail_root(&decoded) else {
+                panic!("non-object root for {}", input.display());
+            };
+            let Some(mail_type) = mail_registry::detect_mail_type(root) else {
+                continue;
+            };
+            let processed = process_mail(mail_type, root)
+                .unwrap_or_else(|error| panic!("failed to process {}: {error}", input.display()));
+            let actual = serde_json::to_value(processed).expect("serialize processed mail");
+            let expected_path =
+                std::path::PathBuf::from(format!("{}-processed.json", input.display()));
+            let expected: Value =
+                serde_json::from_slice(&std::fs::read(&expected_path).unwrap_or_else(|error| {
+                    panic!("failed to read {}: {error}", expected_path.display())
+                }))
+                .unwrap_or_else(|error| {
+                    panic!("failed to parse {}: {error}", expected_path.display())
+                });
+
+            assert!(
+                json_equivalent(&actual, &expected),
+                "processed output differs for {}",
+                input.display()
+            );
+            processed_count += 1;
+        }
+
+        assert_eq!(processed_count, 132);
+    }
+
+    fn collect_binary_mail_samples(root: &std::path::Path, samples: &mut Vec<std::path::PathBuf>) {
+        for entry in std::fs::read_dir(root)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", root.display()))
+        {
+            let path = entry
+                .unwrap_or_else(|error| {
+                    panic!("failed to read entry in {}: {error}", root.display())
+                })
+                .path();
+            if path.is_dir() {
+                if path.file_name().and_then(|name| name.to_str()) != Some("game") {
+                    collect_binary_mail_samples(&path, samples);
+                }
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name.starts_with("Persistent.Mail.") && !name.ends_with(".json") {
+                samples.push(path);
+            }
+        }
+    }
+
+    fn json_equivalent(actual: &Value, expected: &Value) -> bool {
+        match (actual, expected) {
+            (Value::Array(actual), Value::Array(expected)) => {
+                actual.len() == expected.len()
+                    && actual.iter().zip(expected).all(|(a, b)| json_equivalent(a, b))
+            }
+            (Value::Object(actual), Value::Object(expected)) => {
+                actual.len() == expected.len()
+                    && actual.iter().all(|(key, value)| {
+                        expected.get(key).is_some_and(|other| json_equivalent(value, other))
+                    })
+            }
+            (Value::Number(actual), Value::Number(expected)) => {
+                match (actual.as_i64(), expected.as_i64()) {
+                    (Some(actual), Some(expected)) => actual == expected,
+                    _ => match (actual.as_u64(), expected.as_u64()) {
+                        (Some(actual), Some(expected)) => actual == expected,
+                        _ => match (actual.as_f64(), expected.as_f64()) {
+                            (Some(actual), Some(expected)) => {
+                                ordered_float_bits(actual).abs_diff(ordered_float_bits(expected))
+                                    <= 1
+                            }
+                            _ => false,
+                        },
+                    },
+                }
+            }
+            _ => actual == expected,
+        }
+    }
+
+    fn ordered_float_bits(value: f64) -> u64 {
+        let bits = value.to_bits();
+        if bits & (1_u64 << 63) == 0 { bits | (1_u64 << 63) } else { !bits }
+    }
+
+    #[test]
     fn decode_mail_binary_rejects_unsupported_algorithm() {
         let mut raw = raw_mail_from_bytes(b"anything");
         raw.algorithm = "gzip".to_string();
@@ -709,7 +797,8 @@ mod tests {
 
     #[test]
     fn prepare_processed_document_rejects_non_object_root() {
-        let raw = raw_mail_from_bytes(&[0x01, 1]);
+        let bytes = native_file(&[0x01, 1]);
+        let raw = raw_mail_from_bytes(&bytes);
         let error = prepare_processed_document(&raw).unwrap_err();
         assert!(matches!(error, ProcessorError::InvalidMailPayload(_)));
     }

--- a/samples/Battle/Persistent.Mail.33830971176980291131.json
+++ b/samples/Battle/Persistent.Mail.33830971176980291131.json
@@ -1,515 +1,513 @@
-[
-  {
-    "addition": "",
-    "attachments": [],
-    "body": {
-      "content": {
-        "Attacks": {
-          "186643701": {
-            "Bts": 906332,
-            "CIdt": {
-              "AId": 0,
-              "AName": "",
+{
+  "addition": "",
+  "attachments": [],
+  "body": {
+    "content": {
+      "Attacks": {
+        "186643701": {
+          "Bts": 906332,
+          "CIdt": {
+            "AId": 0,
+            "AName": "",
+            "Abbr": "",
+            "Avatar": "",
+            "CAHAH": [],
+            "CASS": {
+              "Ban": false,
+              "ENABLE": false
+            },
+            "CId": 186643701,
+            "COSId": 0,
+            "CT": 1,
+            "CTK": "-2_1769789566_85",
+            "CastleLevel": 0,
+            "CastlePos": {
+              "X": 3748.8755,
+              "Y": 4147.133
+            },
+            "CtId": 1605906,
+            "DisappearTick": 914117,
+            "HAw": false,
+            "HAw2": false,
+            "HEq": "{}",
+            "HId": 85,
+            "HId2": 0,
+            "HLv": 34,
+            "HLv2": 0,
+            "HSS": [
+              {
+                "SkillId": 110,
+                "SkillLevel": 5
+              }
+            ],
+            "HSt": 5,
+            "HSt2": 0,
+            "HTE": 0,
+            "HTJ": 0,
+            "HTJ2": 0,
+            "Idt": "186643701",
+            "IfAI": 0,
+            "IsAuto": 0,
+            "KVKMorale": {
+              "CampX": 0,
+              "CampY": 0,
+              "Distance": 0,
+              "Morale": 0
+            },
+            "NpcBType": 1,
+            "NpcType": 34,
+            "PId": -2,
+            "PName": "",
+            "SerSeason": "",
+            "Titan": {
+              "BattleId": "",
+              "Pioneer": false,
+              "Round": 0,
+              "TeamId": 0
+            }
+          },
+          "Damage": {
+            "AddCnt": 0,
+            "AtkPower": -518,
+            "BadHurt": 76,
+            "BadReduceCnt": 0,
+            "Cnt": 270640,
+            "Contribute": 0,
+            "DeadReduceCnt": 0,
+            "Death": 0,
+            "Gt": 0,
+            "GtMax": 0,
+            "Healing": 0,
+            "Hurt": 3261,
+            "HurtCntEnd": 116050,
+            "InitMax": 388000,
+            "KillScore": 0,
+            "Max": 363575,
+            "Power": -532,
+            "RetreatCnt": 0,
+            "SkillPower": -14,
+            "UnitStifleBadHurtReduceCnt": 0,
+            "WarExploits": 0
+          },
+          "Def": 2,
+          "Ets": 906369,
+          "Kill": {
+            "AddCnt": 0,
+            "AtkPower": -224176,
+            "BadHurt": 0,
+            "BadReduceCnt": 0,
+            "Cnt": 0,
+            "Contribute": 0,
+            "DeadReduceCnt": 0,
+            "Death": 165000,
+            "Gt": 0,
+            "GtMax": 0,
+            "Healing": 0,
+            "Hurt": 0,
+            "HurtCntEnd": 0,
+            "InitMax": 165000,
+            "KillScore": 0,
+            "Max": 165000,
+            "Power": -660000,
+            "RetreatCnt": 0,
+            "SkillPower": -435824,
+            "UnitStifleBadHurtReduceCnt": 0,
+            "WarExploits": 0
+          },
+          "NpcAtkExp": 4760,
+          "NpcKillLoot": [
+            {
+              "SubType": 143,
+              "Type": 2,
+              "Value": 59
+            },
+            {
+              "SubType": 71,
+              "Type": 2,
+              "Value": 8
+            },
+            {
+              "SubType": 128,
+              "Type": 2,
+              "Value": 34
+            }
+          ],
+          "OTs": {
+            "1605906": {
               "Abbr": "",
-              "Avatar": "",
-              "CAHAH": [],
-              "CASS": {
-                "Ban": false,
-                "ENABLE": false
-              },
-              "CId": 186643701,
-              "COSId": 0,
-              "CT": 1,
-              "CTK": "-2_1769789566_85",
-              "CastleLevel": 0,
-              "CastlePos": {
-                "X": 3748.8755,
-                "Y": 4147.133
-              },
-              "CtId": 1605906,
-              "DisappearTick": 914117,
-              "HAw": false,
-              "HAw2": false,
-              "HEq": "{}",
               "HId": 85,
               "HId2": 0,
               "HLv": 34,
               "HLv2": 0,
-              "HSS": [
-                {
-                  "SkillId": 110,
-                  "SkillLevel": 5
-                }
-              ],
-              "HSt": 5,
-              "HSt2": 0,
-              "HTE": 0,
-              "HTJ": 0,
-              "HTJ2": 0,
-              "Idt": "186643701",
-              "IfAI": 0,
-              "IsAuto": 0,
-              "KVKMorale": {
-                "CampX": 0,
-                "CampY": 0,
-                "Distance": 0,
-                "Morale": 0
-              },
-              "NpcBType": 1,
-              "NpcType": 34,
               "PId": -2,
-              "PName": "",
-              "SerSeason": "",
-              "Titan": {
-                "BattleId": "",
-                "Pioneer": false,
-                "Round": 0,
-                "TeamId": 0
-              }
+              "PName": ""
+            }
+          },
+          "OppositeDu": {
+            "DuCnt": 0,
+            "DuMax": 0
+          },
+          "OpsKvkModBuffIds": [],
+          "Pos": {
+            "X": 3754.0183,
+            "Y": 4147.5947
+          },
+          "ReportShowType": 0,
+          "RewardLimited": false,
+          "SelfDu": {
+            "DuCnt": 0,
+            "DuMax": 0
+          },
+          "SelfKvkModBuffIds": [],
+          "StatShowType": 1,
+          "Tick": 38,
+          "TickStart": 906332
+        },
+        "189076501": {
+          "Bts": 906321,
+          "CIdt": {
+            "AId": 0,
+            "AName": "",
+            "Abbr": "",
+            "Avatar": "",
+            "CAHAH": [],
+            "CASS": {
+              "Ban": false,
+              "ENABLE": false
             },
-            "Damage": {
-              "AddCnt": 0,
-              "AtkPower": -518,
-              "BadHurt": 76,
-              "BadReduceCnt": 0,
-              "Cnt": 270640,
-              "Contribute": 0,
-              "DeadReduceCnt": 0,
-              "Death": 0,
-              "Gt": 0,
-              "GtMax": 0,
-              "Healing": 0,
-              "Hurt": 3261,
-              "HurtCntEnd": 116050,
-              "InitMax": 388000,
-              "KillScore": 0,
-              "Max": 363575,
-              "Power": -532,
-              "RetreatCnt": 0,
-              "SkillPower": -14,
-              "UnitStifleBadHurtReduceCnt": 0,
-              "WarExploits": 0
+            "CId": 189076501,
+            "COSId": 0,
+            "CT": 1,
+            "CTK": "-2_1769801604_204",
+            "CastleLevel": 0,
+            "CastlePos": {
+              "X": 3754.0183,
+              "Y": 4152.67
             },
-            "Def": 2,
-            "Ets": 906369,
-            "Kill": {
-              "AddCnt": 0,
-              "AtkPower": -224176,
-              "BadHurt": 0,
-              "BadReduceCnt": 0,
-              "Cnt": 0,
-              "Contribute": 0,
-              "DeadReduceCnt": 0,
-              "Death": 165000,
-              "Gt": 0,
-              "GtMax": 0,
-              "Healing": 0,
-              "Hurt": 0,
-              "HurtCntEnd": 0,
-              "InitMax": 165000,
-              "KillScore": 0,
-              "Max": 165000,
-              "Power": -660000,
-              "RetreatCnt": 0,
-              "SkillPower": -435824,
-              "UnitStifleBadHurtReduceCnt": 0,
-              "WarExploits": 0
-            },
-            "NpcAtkExp": 4760,
-            "NpcKillLoot": [
+            "CtId": 1626958,
+            "DisappearTick": 990254,
+            "HAw": false,
+            "HAw2": false,
+            "HEq": "{}",
+            "HId": 204,
+            "HId2": 0,
+            "HLv": 60,
+            "HLv2": 0,
+            "HSS": [
               {
-                "SubType": 143,
-                "Type": 2,
-                "Value": 59
-              },
-              {
-                "SubType": 71,
-                "Type": 2,
-                "Value": 8
-              },
-              {
-                "SubType": 128,
-                "Type": 2,
-                "Value": 34
+                "SkillId": 127,
+                "SkillLevel": 5
               }
             ],
-            "OTs": {
-              "1605906": {
-                "Abbr": "",
-                "HId": 85,
-                "HId2": 0,
-                "HLv": 34,
-                "HLv2": 0,
-                "PId": -2,
-                "PName": ""
-              }
+            "HSt": 6,
+            "HSt2": 0,
+            "HTE": 0,
+            "HTJ": 0,
+            "HTJ2": 0,
+            "Idt": "189076501",
+            "IfAI": 0,
+            "IsAuto": 0,
+            "IsFort": true,
+            "KVKMorale": {
+              "CampX": 0,
+              "CampY": 0,
+              "Distance": 0,
+              "Morale": 0
             },
-            "OppositeDu": {
-              "DuCnt": 0,
-              "DuMax": 0
-            },
-            "OpsKvkModBuffIds": [],
-            "Pos": {
-              "X": 3754.0183,
-              "Y": 4147.5947
-            },
-            "ReportShowType": 0,
-            "RewardLimited": false,
-            "SelfDu": {
-              "DuCnt": 0,
-              "DuMax": 0
-            },
-            "SelfKvkModBuffIds": [],
-            "StatShowType": 1,
-            "Tick": 38,
-            "TickStart": 906332
+            "NpcBType": 2,
+            "NpcType": 110,
+            "PId": -2,
+            "PName": "",
+            "SerSeason": "",
+            "Titan": {
+              "BattleId": "",
+              "Pioneer": false,
+              "Round": 0,
+              "TeamId": 0
+            }
           },
-          "189076501": {
-            "Bts": 906321,
-            "CIdt": {
-              "AId": 0,
-              "AName": "",
+          "Damage": {
+            "AddCnt": 0,
+            "AtkPower": -25184,
+            "BadHurt": 3898,
+            "BadReduceCnt": 0,
+            "Cnt": 41294,
+            "Contribute": 0,
+            "DeadReduceCnt": 0,
+            "Death": 0,
+            "Gt": 0,
+            "GtMax": 0,
+            "Healing": 0,
+            "Hurt": 339471,
+            "HurtCntEnd": 342732,
+            "InitMax": 388000,
+            "KillScore": 0,
+            "Max": 388000,
+            "Power": -29068,
+            "RetreatCnt": 0,
+            "SkillPower": -3884,
+            "UnitStifleBadHurtReduceCnt": 0,
+            "WarExploits": 0
+          },
+          "Def": 2,
+          "Ets": 906557,
+          "Kill": {
+            "AddCnt": 0,
+            "AtkPower": -2234508,
+            "BadHurt": 0,
+            "BadReduceCnt": 0,
+            "Cnt": 0,
+            "Contribute": 0,
+            "DeadReduceCnt": 0,
+            "Death": 2000000,
+            "Gt": 0,
+            "GtMax": 0,
+            "Healing": 0,
+            "Hurt": 0,
+            "HurtCntEnd": 0,
+            "InitMax": 2000000,
+            "KillScore": 0,
+            "Max": 2000000,
+            "Power": -8000000,
+            "RetreatCnt": 0,
+            "SkillPower": -5765492,
+            "UnitStifleBadHurtReduceCnt": 0,
+            "WarExploits": 0
+          },
+          "NpcAtkExp": 0,
+          "OTs": {
+            "1626958": {
               "Abbr": "",
-              "Avatar": "",
-              "CAHAH": [],
-              "CASS": {
-                "Ban": false,
-                "ENABLE": false
-              },
-              "CId": 189076501,
-              "COSId": 0,
-              "CT": 1,
-              "CTK": "-2_1769801604_204",
-              "CastleLevel": 0,
-              "CastlePos": {
-                "X": 3754.0183,
-                "Y": 4152.67
-              },
-              "CtId": 1626958,
-              "DisappearTick": 990254,
-              "HAw": false,
-              "HAw2": false,
-              "HEq": "{}",
               "HId": 204,
               "HId2": 0,
               "HLv": 60,
               "HLv2": 0,
-              "HSS": [
-                {
-                  "SkillId": 127,
-                  "SkillLevel": 5
-                }
-              ],
-              "HSt": 6,
-              "HSt2": 0,
-              "HTE": 0,
-              "HTJ": 0,
-              "HTJ2": 0,
-              "Idt": "189076501",
-              "IfAI": 0,
-              "IsAuto": 0,
-              "IsFort": true,
-              "KVKMorale": {
-                "CampX": 0,
-                "CampY": 0,
-                "Distance": 0,
-                "Morale": 0
-              },
-              "NpcBType": 2,
-              "NpcType": 110,
               "PId": -2,
-              "PName": "",
-              "SerSeason": "",
-              "Titan": {
-                "BattleId": "",
-                "Pioneer": false,
-                "Round": 0,
-                "TeamId": 0
-              }
-            },
-            "Damage": {
-              "AddCnt": 0,
-              "AtkPower": -25184,
-              "BadHurt": 3898,
-              "BadReduceCnt": 0,
-              "Cnt": 41294,
-              "Contribute": 0,
-              "DeadReduceCnt": 0,
-              "Death": 0,
-              "Gt": 0,
-              "GtMax": 0,
-              "Healing": 0,
-              "Hurt": 339471,
-              "HurtCntEnd": 342732,
-              "InitMax": 388000,
-              "KillScore": 0,
-              "Max": 388000,
-              "Power": -29068,
-              "RetreatCnt": 0,
-              "SkillPower": -3884,
-              "UnitStifleBadHurtReduceCnt": 0,
-              "WarExploits": 0
-            },
-            "Def": 2,
-            "Ets": 906557,
-            "Kill": {
-              "AddCnt": 0,
-              "AtkPower": -2234508,
-              "BadHurt": 0,
-              "BadReduceCnt": 0,
-              "Cnt": 0,
-              "Contribute": 0,
-              "DeadReduceCnt": 0,
-              "Death": 2000000,
-              "Gt": 0,
-              "GtMax": 0,
-              "Healing": 0,
-              "Hurt": 0,
-              "HurtCntEnd": 0,
-              "InitMax": 2000000,
-              "KillScore": 0,
-              "Max": 2000000,
-              "Power": -8000000,
-              "RetreatCnt": 0,
-              "SkillPower": -5765492,
-              "UnitStifleBadHurtReduceCnt": 0,
-              "WarExploits": 0
-            },
-            "NpcAtkExp": 0,
-            "OTs": {
-              "1626958": {
-                "Abbr": "",
-                "HId": 204,
-                "HId2": 0,
-                "HLv": 60,
-                "HLv2": 0,
-                "PId": -2,
-                "PName": ""
-              }
-            },
-            "OppositeDu": {
-              "DuCnt": 0,
-              "DuMax": 0
-            },
-            "OpsKvkModBuffIds": [],
-            "Pos": {
-              "X": 3754.5127,
-              "Y": 4146.154
-            },
-            "ReportShowType": 0,
-            "RewardLimited": false,
-            "SelfDu": {
-              "DuCnt": 0,
-              "DuMax": 0
-            },
-            "SelfKvkModBuffIds": [],
-            "StatShowType": 1,
-            "Tick": 237,
-            "TickStart": 906321
-          }
-        },
-        "Btk": 906321,
-        "Bts": 1769802676,
-        "DataOmit": false,
-        "Ets": 1769802911,
-        "Events": [],
-        "GsId": 1804,
-        "Id": 6301574,
-        "LLScriptSchema": 320,
-        "LoadSource": "oss",
-        "Role": "gsmp",
-        "RoomId": 0,
-        "STs": {
-          "1628577": {
-            "Abbr": "SO4L",
-            "HId": 540,
-            "HId2": 575,
-            "HLv": 60,
-            "HLv2": 60,
-            "PId": 71738515,
-            "PName": "Grigvar"
+              "PName": ""
+            }
           },
-          "1628608": {
-            "Abbr": "SO4L",
-            "HId": 61,
-            "HId2": 15,
-            "HLv": 40,
-            "HLv2": 40,
-            "PId": 159922529,
-            "PName": "GメKnight 2"
-          }
-        },
-        "Samples": [
-          {
-            "Cnt": 388000,
-            "T": 906321
+          "OppositeDu": {
+            "DuCnt": 0,
+            "DuMax": 0
           },
-          {
-            "Cnt": 363575,
-            "T": 906332
+          "OpsKvkModBuffIds": [],
+          "Pos": {
+            "X": 3754.5127,
+            "Y": 4146.154
           },
-          {
-            "Cnt": 270640,
-            "T": 906369
+          "ReportShowType": 0,
+          "RewardLimited": false,
+          "SelfDu": {
+            "DuCnt": 0,
+            "DuMax": 0
           },
-          {
-            "Cnt": 41294,
-            "T": 906557
-          }
-        ],
-        "Schema": 10,
-        "SelfChar": {
-          "AId": 4805441,
-          "AName": "魂社会SoulReapers",
+          "SelfKvkModBuffIds": [],
+          "StatShowType": 1,
+          "Tick": 237,
+          "TickStart": 906321
+        }
+      },
+      "Btk": 906321,
+      "Bts": 1769802676,
+      "DataOmit": false,
+      "Ets": 1769802911,
+      "Events": [],
+      "GsId": 1804,
+      "Id": 6301574,
+      "LLScriptSchema": 320,
+      "LoadSource": "oss",
+      "Role": "gsmp",
+      "RoomId": 0,
+      "STs": {
+        "1628577": {
           "Abbr": "SO4L",
-          "AppUid": "32624247",
-          "Avatar": "{\"avatarFrame\":\"http://imimg.lilithcdn.com/roc/img_AvatarFrame_189.png\",\"avatar\":\"https://plat-fau-global.lilithgame.com/p/astc/IM/10043/0/32624247/2026-01-15/1822754B851EA438ECFE0FF4994C2FA6_250x250.jpg\"}",
-          "CAHAH": [],
-          "CASS": {
-            "Ban": false,
-            "ENABLE": false
-          },
-          "CId": 189336301,
-          "COSId": 1804,
-          "CT": 1,
-          "CTK": "71738515_1769802374_540_575_SquareRally",
-          "CastleLevel": 25,
-          "CastlePos": {
-            "X": 3815.7598,
-            "Y": 3977.461
-          },
-          "CtId": 1628577,
-          "HAw": true,
-          "HAw2": true,
-          "HEq": "{1:20007_400:2,2:20008_260:2,3:20009_381:2,4:20028_378:2,5:20033_382:2,6:20012_383:2,7:20040_394:1,8:20037_338:1}",
-          "HEq2": "{1:20001_380:2,2:20004_379:32,3:20009_190:2,4:20028_265:33,5:20033_261:32,6:20012_266:3,7:20040_264:1,8:20037_398:31}",
-          "HFMs": 13,
-          "HFMs2": 13,
           "HId": 540,
           "HId2": 575,
           "HLv": 60,
           "HLv2": 60,
-          "HSS": [
-            {
-              "SkillId": 389,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1735,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1736,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1737,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1738,
-              "SkillLevel": 1
-            }
-          ],
-          "HSS2": [
-            {
-              "SkillId": 1790,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1789,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 411,
-              "SkillLevel": 5
-            },
-            {
-              "SkillId": 1787,
-              "SkillLevel": 5
-            }
-          ],
-          "HSt": 6,
-          "HSt2": 6,
-          "HTE": -1,
-          "HTJ": 0,
-          "HTJ2": 0,
-          "HWBs": {
-            "1": {
-              "Affix": "107",
-              "Buffs": "3002_0.019000;4002_0.027000;10002_0.018000",
-              "Id": "75113011_18860"
-            },
-            "2": {
-              "Affix": "13202",
-              "Buffs": "3002_0.026000;4002_0.033000;10002_0.015000",
-              "Id": "75213010_16122"
-            },
-            "3": {
-              "Affix": "13302",
-              "Buffs": "3002_0.028000;4002_0.017000;5002_0.018000",
-              "Id": "75313011_18861"
-            },
-            "4": {
-              "Affix": "407;418",
-              "Buffs": "6002_0.022000;4002_0.020000;5002_0.020000",
-              "Id": "75413012_18004"
-            }
-          },
-          "HWBs2": {
-            "1": "75113012_8250",
-            "2": "75213011_11529",
-            "3": "75313010_11530",
-            "4": "75413011_18189"
-          },
-          "Idt": "189336301",
-          "IfAI": 0,
-          "IsAuto": 0,
-          "IsRally": true,
-          "KVKMorale": {
-            "CampX": 0,
-            "CampY": 0,
-            "Distance": 0,
-            "Morale": 0
-          },
           "PId": 71738515,
-          "PName": "Grigvar",
-          "PkgNameNew": "com.lilithgames.rok.pc.int",
-          "SerSeason": "100",
-          "Titan": {
-            "BattleId": "",
-            "Pioneer": false,
-            "Round": 0,
-            "TeamId": 0
-          },
-          "Udid": "489044729533721131"
+          "PName": "Grigvar"
         },
-        "TickSkip": 100
-      }
-    },
-    "box": "Report",
-    "flaglist": [],
-    "holdTag": 0,
-    "id": "33830971176980291131",
-    "mailScene": 0,
-    "preMailId": "",
-    "receiver": "player_71738515",
-    "receiverInfo": {
-      "Abbr": "",
-      "Name": ""
-    },
-    "reportMerge": 0,
-    "sender": "system",
-    "senderInfo": {
-      "Abbr": "",
-      "Name": "system"
-    },
-    "senderTradeTime": 0,
-    "serverId": 1804,
-    "starMark": 0,
-    "time": 1769802911843205,
-    "title": "",
-    "type": "Battle",
-    "unread": false
-  }
-]
+        "1628608": {
+          "Abbr": "SO4L",
+          "HId": 61,
+          "HId2": 15,
+          "HLv": 40,
+          "HLv2": 40,
+          "PId": 159922529,
+          "PName": "GメKnight 2"
+        }
+      },
+      "Samples": [
+        {
+          "Cnt": 388000,
+          "T": 906321
+        },
+        {
+          "Cnt": 363575,
+          "T": 906332
+        },
+        {
+          "Cnt": 270640,
+          "T": 906369
+        },
+        {
+          "Cnt": 41294,
+          "T": 906557
+        }
+      ],
+      "Schema": 10,
+      "SelfChar": {
+        "AId": 4805441,
+        "AName": "魂社会SoulReapers",
+        "Abbr": "SO4L",
+        "AppUid": "32624247",
+        "Avatar": "{\"avatarFrame\":\"http://imimg.lilithcdn.com/roc/img_AvatarFrame_189.png\",\"avatar\":\"https://plat-fau-global.lilithgame.com/p/astc/IM/10043/0/32624247/2026-01-15/1822754B851EA438ECFE0FF4994C2FA6_250x250.jpg\"}",
+        "CAHAH": [],
+        "CASS": {
+          "Ban": false,
+          "ENABLE": false
+        },
+        "CId": 189336301,
+        "COSId": 1804,
+        "CT": 1,
+        "CTK": "71738515_1769802374_540_575_SquareRally",
+        "CastleLevel": 25,
+        "CastlePos": {
+          "X": 3815.7598,
+          "Y": 3977.461
+        },
+        "CtId": 1628577,
+        "HAw": true,
+        "HAw2": true,
+        "HEq": "{1:20007_400:2,2:20008_260:2,3:20009_381:2,4:20028_378:2,5:20033_382:2,6:20012_383:2,7:20040_394:1,8:20037_338:1}",
+        "HEq2": "{1:20001_380:2,2:20004_379:32,3:20009_190:2,4:20028_265:33,5:20033_261:32,6:20012_266:3,7:20040_264:1,8:20037_398:31}",
+        "HFMs": 13,
+        "HFMs2": 13,
+        "HId": 540,
+        "HId2": 575,
+        "HLv": 60,
+        "HLv2": 60,
+        "HSS": [
+          {
+            "SkillId": 389,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1735,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1736,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1737,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1738,
+            "SkillLevel": 1
+          }
+        ],
+        "HSS2": [
+          {
+            "SkillId": 1790,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1789,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 411,
+            "SkillLevel": 5
+          },
+          {
+            "SkillId": 1787,
+            "SkillLevel": 5
+          }
+        ],
+        "HSt": 6,
+        "HSt2": 6,
+        "HTE": -1,
+        "HTJ": 0,
+        "HTJ2": 0,
+        "HWBs": {
+          "1": {
+            "Affix": "107",
+            "Buffs": "3002_0.019000;4002_0.027000;10002_0.018000",
+            "Id": "75113011_18860"
+          },
+          "2": {
+            "Affix": "13202",
+            "Buffs": "3002_0.026000;4002_0.033000;10002_0.015000",
+            "Id": "75213010_16122"
+          },
+          "3": {
+            "Affix": "13302",
+            "Buffs": "3002_0.028000;4002_0.017000;5002_0.018000",
+            "Id": "75313011_18861"
+          },
+          "4": {
+            "Affix": "407;418",
+            "Buffs": "6002_0.022000;4002_0.020000;5002_0.020000",
+            "Id": "75413012_18004"
+          }
+        },
+        "HWBs2": {
+          "1": "75113012_8250",
+          "2": "75213011_11529",
+          "3": "75313010_11530",
+          "4": "75413011_18189"
+        },
+        "Idt": "189336301",
+        "IfAI": 0,
+        "IsAuto": 0,
+        "IsRally": true,
+        "KVKMorale": {
+          "CampX": 0,
+          "CampY": 0,
+          "Distance": 0,
+          "Morale": 0
+        },
+        "PId": 71738515,
+        "PName": "Grigvar",
+        "PkgNameNew": "com.lilithgames.rok.pc.int",
+        "SerSeason": "100",
+        "Titan": {
+          "BattleId": "",
+          "Pioneer": false,
+          "Round": 0,
+          "TeamId": 0
+        },
+        "Udid": "489044729533721131"
+      },
+      "TickSkip": 100
+    }
+  },
+  "box": "Report",
+  "flaglist": [],
+  "holdTag": 0,
+  "id": "33830971176980291131",
+  "mailScene": 0,
+  "preMailId": "",
+  "receiver": "player_71738515",
+  "receiverInfo": {
+    "Abbr": "",
+    "Name": ""
+  },
+  "reportMerge": 0,
+  "sender": "system",
+  "senderInfo": {
+    "Abbr": "",
+    "Name": "system"
+  },
+  "senderTradeTime": 0,
+  "serverId": 1804,
+  "starMark": 0,
+  "time": 1769802911843205,
+  "title": "",
+  "type": "Battle",
+  "unread": false
+}


### PR DESCRIPTION
## Summary

- validate `Persistent.Mail` headers and checksums before decoding
- classify table values consistently and return typed errors for malformed or ambiguous input
- centralize strict object-root handling across the registry, CLI, desktop watcher, ingress service, and processor
- add full-corpus regression coverage for raw decoding and processed output

## Why

The decoder previously searched the initial bytes for a plausible value tag. When a checksum byte matched a table tag, decoding could begin one byte before the payload and produce an incorrect root shape. Validating the header and starting at the fixed payload offset resolves the underlying issue.

## Impact

Raw JSON now reflects the actual payload shape, while processed documents remain unchanged. Corrupt headers, checksum mismatches, unsupported tags, unterminated tables, duplicate keys, and mixed key types are rejected explicitly.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p mail-decoder -p mail-registry -p mail-cli -p rokbattles-ingress -p rokbattles-processor -p rokbattles-desktop --all-targets --all-features --locked -- -D warnings`
- `cargo test -p 'mail-*'`
- `cargo test -p rokbattles-ingress -p rokbattles-processor -p rokbattles-desktop`