### PR TITLE
perf(mail): accelerate checksum validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,9 +2943,14 @@ dependencies = [
 name = "mail-decoder"
 version = "1.6.0"
 dependencies = [
+ "mail-decoder-simd",
  "serde_json",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "mail-decoder-simd"
+version = "1.6.0"
 
 [[package]]
 name = "mail-processor-alliance-aoo-battle-info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/core/drastc",
     "crates/mail/cli",
     "crates/mail/decoder",
+    "crates/mail/decoder-simd",
     "crates/mail/registry",
     "crates/mail/processors/alliance-aoo-battle-info",
     "crates/mail/processors/alliance-aoo-battle-results",

--- a/crates/desktop/src/watcher/mod.rs
+++ b/crates/desktop/src/watcher/mod.rs
@@ -163,7 +163,7 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
             }
 
             while state.upload_queue.len() < state.config.upload_prefetch_target {
-                if let Some(item) = next_file(&app, &mut state).await {
+                if let Some(item) = next_file(&app, &mut state) {
                     state.enqueue_upload(item);
                 } else {
                     break;

--- a/crates/desktop/src/watcher/scan.rs
+++ b/crates/desktop/src/watcher/scan.rs
@@ -276,7 +276,7 @@ pub(crate) async fn refresh_scans_if_needed(app: &AppHandle, state: &mut Watcher
     did_refresh
 }
 
-pub(crate) async fn next_file(app: &AppHandle, state: &mut WatcherState) -> Option<QueuedUpload> {
+pub(crate) fn next_file(app: &AppHandle, state: &mut WatcherState) -> Option<QueuedUpload> {
     for _ in 0..state.config.scan_budget_per_tick {
         let (scan_idx, _best_id) = state
             .scans
@@ -303,36 +303,17 @@ pub(crate) async fn next_file(app: &AppHandle, state: &mut WatcherState) -> Opti
             Err(_) => continue,
         };
 
-        let header = tauri::async_runtime::spawn_blocking({
-            let path = path.clone();
-            move || has_valid_rok_mail_file(&path)
-        })
-        .await;
-
-        match header {
-            Ok(Ok(true)) => {
-                state.store.entries.insert(key, sig.clone());
-                state.store_dirty_updates += 1;
-                state.maybe_flush_store(app);
-                return Some(QueuedUpload {
-                    path: path.to_string_lossy().to_string(),
-                    sig,
-                    attempts: 0,
-                    not_before_ms: None,
-                });
-            }
-            Ok(Ok(false)) => {
-                state.store.entries.insert(key, sig);
-                state.store_dirty_updates += 1;
-                state.maybe_flush_store(app);
-            }
-            Ok(Err(e)) => {
-                emit_log(app, format!("Header check failed for {:?}: {}", path, e));
-            }
-            Err(e) => {
-                emit_log(app, format!("Header check task failed for {:?}: {}", path, e));
-            }
-        }
+        // The upload stage reads and decodes file contents; discovery records only metadata so
+        // newly found files are not read twice.
+        state.store.entries.insert(key, sig.clone());
+        state.store_dirty_updates += 1;
+        state.maybe_flush_store(app);
+        return Some(QueuedUpload {
+            path: path.to_string_lossy().to_string(),
+            sig,
+            attempts: 0,
+            not_before_ms: None,
+        });
     }
 
     state.maybe_flush_store(app);
@@ -411,38 +392,5 @@ pub(crate) fn apply_fs_event(state: &mut WatcherState, path: PathBuf, now_ms: u1
     {
         let _ = scan.known_ids.insert(id);
         scan.max_id = Some(scan.max_id.map_or(id, |m| m.max(id)));
-    }
-}
-
-fn has_valid_rok_mail_file(path: &std::path::Path) -> anyhow::Result<bool> {
-    let buffer = fs::read(path)
-        .with_context(|| format!("Failed to read file for native validation: {:?}", path))?;
-    Ok(mail_decoder::validate_file(&buffer).is_ok())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn native_validation_accepts_checked_in_mail() {
-        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../samples/Battle/Persistent.Mail.485440176891031331");
-
-        assert!(has_valid_rok_mail_file(&path).expect("validate sample"));
-    }
-
-    #[test]
-    fn native_validation_rejects_corrupt_mail() {
-        let sample = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../samples/Battle/Persistent.Mail.485440176891031331");
-        let mut buffer = fs::read(sample).expect("read sample");
-        let last = buffer.len() - 1;
-        buffer[last] ^= 1;
-        let temp = tempfile::tempdir().expect("temp dir");
-        let path = temp.path().join("Persistent.Mail.1");
-        fs::write(&path, buffer).expect("write corrupt sample");
-
-        assert!(!has_valid_rok_mail_file(&path).expect("validate sample"));
     }
 }

--- a/crates/mail/decoder-simd/Cargo.toml
+++ b/crates/mail/decoder-simd/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mail-decoder-simd"
+version = "1.6.0"
+edition = "2024"
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/mail/decoder-simd/src/lib.rs
+++ b/crates/mail/decoder-simd/src/lib.rs
@@ -1,0 +1,179 @@
+//! Runtime-dispatched SIMD and portable scalar checksum implementations for the mail decoder.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+const MULTIPLIER: u64 = 33;
+const MULTIPLIER_2: u64 = MULTIPLIER * MULTIPLIER;
+const MULTIPLIER_3: u64 = MULTIPLIER_2 * MULTIPLIER;
+const MULTIPLIER_4: u64 = MULTIPLIER_3 * MULTIPLIER;
+
+/// Extend a wrapping DJB2 checksum with `bytes`, using an available SIMD implementation or the
+/// equivalent scalar fallback.
+#[must_use]
+pub fn checksum(hash: u64, bytes: &[u8]) -> u64 {
+    platform::checksum(hash, bytes)
+}
+
+fn checksum_scalar(mut hash: u64, bytes: &[u8]) -> u64 {
+    let mut chunks = bytes.chunks_exact(4);
+    for chunk in &mut chunks {
+        if let &[byte_0, byte_1, byte_2, byte_3] = chunk {
+            let contribution = u64::from(byte_0) * MULTIPLIER_3
+                + u64::from(byte_1) * MULTIPLIER_2
+                + u64::from(byte_2) * MULTIPLIER
+                + u64::from(byte_3);
+            hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(contribution);
+        }
+    }
+    for &byte in chunks.remainder() {
+        hash = hash.wrapping_mul(MULTIPLIER).wrapping_add(u64::from(byte));
+    }
+    hash
+}
+
+#[cfg(target_arch = "aarch64")]
+mod platform {
+    use std::arch::aarch64::{
+        uint16x4_t, vget_high_u8, vget_high_u16, vget_low_u8, vget_low_u16, vld1_u16, vld1q_u8,
+        vmovl_u8, vmull_u16, vpaddq_u32, vst1q_u32,
+    };
+
+    use super::{MULTIPLIER_4, checksum_scalar};
+
+    const WEIGHTS: [u16; 4] = [35_937, 1_089, 33, 1];
+
+    pub(super) fn checksum(hash: u64, bytes: &[u8]) -> u64 {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: Runtime detection guarantees NEON is available. The implementation only
+            // performs unaligned reads within `bytes` and writes to a local array.
+            unsafe { checksum_neon(hash, bytes) }
+        } else {
+            checksum_scalar(hash, bytes)
+        }
+    }
+
+    #[target_feature(enable = "neon")]
+    unsafe fn checksum_neon(mut hash: u64, bytes: &[u8]) -> u64 {
+        // SAFETY: `WEIGHTS.as_ptr()` points to four contiguous initialized `u16` values, matching
+        // the load width.
+        let weights: uint16x4_t = unsafe { vld1_u16(WEIGHTS.as_ptr()) };
+        let mut chunks = bytes.chunks_exact(16);
+        for chunk in &mut chunks {
+            // SAFETY: `chunks_exact(16)` guarantees 16 readable bytes.
+            let input = unsafe { vld1q_u8(chunk.as_ptr()) };
+            let low = vmovl_u8(vget_low_u8(input));
+            let high = vmovl_u8(vget_high_u8(input));
+            let products_0 = vmull_u16(vget_low_u16(low), weights);
+            let products_1 = vmull_u16(vget_high_u16(low), weights);
+            let products_2 = vmull_u16(vget_low_u16(high), weights);
+            let products_3 = vmull_u16(vget_high_u16(high), weights);
+            let pairs_01 = vpaddq_u32(products_0, products_1);
+            let pairs_23 = vpaddq_u32(products_2, products_3);
+            let sums = vpaddq_u32(pairs_01, pairs_23);
+            let mut contributions = [0_u32; 4];
+            // SAFETY: `contributions` has space for all four lanes.
+            unsafe { vst1q_u32(contributions.as_mut_ptr(), sums) };
+
+            for contribution in contributions {
+                hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(u64::from(contribution));
+            }
+        }
+
+        checksum_scalar(hash, chunks.remainder())
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod platform {
+    use std::arch::x86_64::{
+        __m128i, __m256i, _mm_loadu_si128, _mm_srli_si128, _mm256_cvtepu8_epi32, _mm256_hadd_epi32,
+        _mm256_mullo_epi32, _mm256_setr_epi32, _mm256_storeu_si256,
+    };
+
+    use super::{MULTIPLIER_4, checksum_scalar};
+
+    pub(super) fn checksum(hash: u64, bytes: &[u8]) -> u64 {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            // SAFETY: Runtime detection guarantees AVX2 is available. The implementation only
+            // performs unaligned reads within `bytes` and writes to a local array.
+            unsafe { checksum_avx2(hash, bytes) }
+        } else {
+            checksum_scalar(hash, bytes)
+        }
+    }
+
+    #[target_feature(enable = "avx2")]
+    unsafe fn checksum_avx2(mut hash: u64, bytes: &[u8]) -> u64 {
+        let weights = _mm256_setr_epi32(35_937, 1_089, 33, 1, 35_937, 1_089, 33, 1);
+        let mut chunks = bytes.chunks_exact(16);
+        for chunk in &mut chunks {
+            // SAFETY: `chunks_exact(16)` guarantees 16 readable bytes.
+            let input = unsafe { _mm_loadu_si128(chunk.as_ptr().cast::<__m128i>()) };
+            let low = _mm256_cvtepu8_epi32(input);
+            let high = _mm256_cvtepu8_epi32(_mm_srli_si128::<8>(input));
+            let products_low = _mm256_mullo_epi32(low, weights);
+            let products_high = _mm256_mullo_epi32(high, weights);
+            let pairs = _mm256_hadd_epi32(products_low, products_high);
+            let sums = _mm256_hadd_epi32(pairs, pairs);
+            let mut lanes = [0_u32; 8];
+            // SAFETY: `lanes` has space for all eight lanes.
+            unsafe { _mm256_storeu_si256(lanes.as_mut_ptr().cast::<__m256i>(), sums) };
+
+            let [sum_0, sum_2, _, _, sum_1, sum_3, _, _] = lanes;
+            for contribution in [sum_0, sum_1, sum_2, sum_3] {
+                hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(u64::from(contribution));
+            }
+        }
+
+        checksum_scalar(hash, chunks.remainder())
+    }
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+mod platform {
+    pub(super) fn checksum(hash: u64, bytes: &[u8]) -> u64 {
+        super::checksum_scalar(hash, bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn checksum_reference(mut hash: u64, bytes: &[u8]) -> u64 {
+        for &byte in bytes {
+            hash = hash.wrapping_mul(MULTIPLIER).wrapping_add(u64::from(byte));
+        }
+        hash
+    }
+
+    #[test]
+    fn checksum_matches_reference_for_varied_lengths_and_values() {
+        let bytes = (0..=u16::MAX)
+            .map(|value| (value.wrapping_mul(197).wrapping_add(101) & 0xff) as u8)
+            .collect::<Vec<_>>();
+
+        let lengths = (0..=4096).chain([8191, 8192, 8193, 32_767, 65_535, 65_536]);
+        for length in lengths {
+            assert_eq!(
+                checksum(0x1505, &bytes[..length]),
+                checksum_reference(0x1505, &bytes[..length])
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_checksum_matches_reference_for_varied_lengths_and_values() {
+        let bytes = (0..=u16::MAX)
+            .map(|value| (value.wrapping_mul(197).wrapping_add(101) & 0xff) as u8)
+            .collect::<Vec<_>>();
+
+        let lengths = (0..=4096).chain([8191, 8192, 8193, 32_767, 65_535, 65_536]);
+        for length in lengths {
+            assert_eq!(
+                checksum_scalar(0x1505, &bytes[..length]),
+                checksum_reference(0x1505, &bytes[..length])
+            );
+        }
+    }
+}

--- a/crates/mail/decoder/Cargo.toml
+++ b/crates/mail/decoder/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.6.0"
 edition = "2024"
 
 [dependencies]
+mail-decoder-simd = { path = "../decoder-simd" }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/mail/decoder/src/decoder.rs
+++ b/crates/mail/decoder/src/decoder.rs
@@ -71,10 +71,26 @@ fn decode_value_at(buffer: &[u8], base_offset: usize) -> Result<Value, DecodeErr
 }
 
 fn file_checksum(buffer: &[u8]) -> u64 {
-    buffer.iter().copied().enumerate().fold(CHECKSUM_SEED, |hash, (offset, byte)| {
-        let byte = if (1..FILE_HEADER_LEN).contains(&offset) { 0 } else { byte };
-        hash.wrapping_mul(33).wrapping_add(u64::from(byte))
-    })
+    const CHECKSUM_MULTIPLIER: u64 = 33;
+    const ZEROED_CHECKSUM_BYTES_FACTOR: u64 = CHECKSUM_MULTIPLIER.pow(8);
+
+    let Some((&marker, rest)) = buffer.split_first() else {
+        return CHECKSUM_SEED;
+    };
+    let Some(payload) = rest.get(FILE_HEADER_LEN - 1..) else {
+        return rest.iter().fold(
+            CHECKSUM_SEED.wrapping_mul(CHECKSUM_MULTIPLIER).wrapping_add(u64::from(marker)),
+            |hash, _| hash.wrapping_mul(CHECKSUM_MULTIPLIER),
+        );
+    };
+
+    // The checksum treats header bytes 1 through 8 as zero, so consuming that field is equivalent
+    // to multiplying the current hash by 33^8.
+    let header_hash = CHECKSUM_SEED
+        .wrapping_mul(CHECKSUM_MULTIPLIER)
+        .wrapping_add(u64::from(marker))
+        .wrapping_mul(ZEROED_CHECKSUM_BYTES_FACTOR);
+    mail_decoder_simd::checksum(header_hash, payload)
 }
 
 struct Decoder<'a> {


### PR DESCRIPTION
## Summary

- add a stable-Rust checksum backend with runtime-dispatched ARM64 NEON and x86-64 AVX2 implementations
- retain an algebraically equivalent scalar fallback for unsupported CPUs and architectures
- keep unsafe code isolated to the checksum backend with documented safety invariants
- remove the desktop discovery-stage file read so new mail is read and decoded only once by the upload stage

## Why

Checksum validation previously processed one byte at a time, limiting instruction-level parallelism. Desktop discovery also read and validated each new file before the upload stage read and decoded the same file again.

This keeps the checksum and decoded output unchanged while reducing CPU work and eliminating the duplicate local file read.

## Local performance

Measured with seven-run stable release medians using the existing `opt-level = "z"` profile.

### Round 1 — initial local cache

| Workload | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Checksum validation across 2,012 files (20.70 MB) | 15.439 ms | 5.115 ms | 66.9% |
| Full decode across 2,012 files | 108.955 ms | 96.422 ms | 11.5% |

The cache contained 1,989 files at or below 100 KB. On that subset, SIMD reduced median full-decode time by another 2.3% compared with the optimized scalar fallback, with no small-file regression.

### Round 2 — expanded local cache

The expanded workload contained 18,262 decodable files (45.12 MB), including 18,239 files at or below 100 KB.

| Workload | Original | Optimized scalar | SIMD | Original → SIMD |
| --- | ---: | ---: | ---: | ---: |
| Checksum validation | 30.905 ms | 14.986 ms | 9.989 ms | 67.7% |
| Full decode | 213.338 ms | 197.369 ms | 191.281 ms | 10.3% |

On this ARM64 system, runtime-dispatched NEON improved checksum validation by another 33.3% over the optimized scalar fallback and improved full decoding by another 3.1%.

### Round 3 — additional local cache

The third workload contained 7,247 decodable files (15.50 MB), including 7,241 files at or below 100 KB.

| Workload | Original | Optimized scalar | SIMD | Original → SIMD |
| --- | ---: | ---: | ---: | ---: |
| Checksum validation | 10.460 ms | 5.138 ms | 3.448 ms | 67.0% |
| Full decode | 69.236 ms | 64.001 ms | 62.133 ms | 10.3% |

On the same ARM64 system, runtime-dispatched NEON improved checksum validation by another 32.9% over the optimized scalar fallback and improved full decoding by another 2.9%. Across all three datasets, the optimized implementation consistently reduces checksum time by about 67% and full-decode time by about 10–12%.

## Compatibility

- ARM64 uses NEON after runtime feature detection.
- x86-64 uses AVX2 after runtime feature detection.
- Other targets and CPUs use the portable scalar implementation.
- The primary decoder crate continues to forbid unsafe code.
- Decoded and processed document output is unchanged.

## Validation

- `cargo +stable test --workspace --all-features --locked`
- stable Clippy with warnings denied for the affected crates
- stable optimized builds for the decoder, desktop, CLI, and processor
- cross-compilation checks for Windows x86-64, Windows ARM64, and 32-bit Windows
- checksum equivalence tests across varied input lengths and values
- existing decoded-output fixture comparisons
