### PR TITLE
feat(combat-lab): aggregate power loss

### DIFF
--- a/crates/apps/rokbattles-api/src/routes/combat_lab/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab/mod.rs
@@ -146,9 +146,22 @@ struct CombatLabStrategies {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all(deserialize = "snake_case", serialize = "camelCase"))]
 struct CombatLabStrategySummary {
     #[serde(flatten)]
     summary: CombatLabSummary,
+    #[serde(default)]
+    power_loss_inflicted: i64,
+    #[serde(default)]
+    power_loss_taken: i64,
+    #[serde(default)]
+    atk_power_loss_inflicted: i64,
+    #[serde(default)]
+    atk_power_loss_taken: i64,
+    #[serde(default)]
+    skill_power_loss_inflicted: i64,
+    #[serde(default)]
+    skill_power_loss_taken: i64,
     formations: Vec<CombatLabFormation>,
 }
 
@@ -219,7 +232,7 @@ mod tests {
         }
     }
 
-    fn stored_strategy(total_battles: i64, formation_id: i64) -> Document {
+    fn stored_legacy_strategy(total_battles: i64, formation_id: i64) -> Document {
         let mut strategy = stored_summary(total_battles);
         strategy.insert(
             "formations",
@@ -228,6 +241,17 @@ mod tests {
                 "count": total_battles,
             })]),
         );
+        strategy
+    }
+
+    fn stored_strategy(total_battles: i64, formation_id: i64) -> Document {
+        let mut strategy = stored_legacy_strategy(total_battles, formation_id);
+        strategy.insert("power_loss_inflicted", 1_200_i64);
+        strategy.insert("power_loss_taken", 900_i64);
+        strategy.insert("atk_power_loss_inflicted", 500_i64);
+        strategy.insert("atk_power_loss_taken", 400_i64);
+        strategy.insert("skill_power_loss_inflicted", 700_i64);
+        strategy.insert("skill_power_loss_taken", 500_i64);
         strategy
     }
 
@@ -294,6 +318,13 @@ mod tests {
         );
         assert_eq!(open_field.get_i64("totalBattles"), Ok(10));
         assert!(open_field.get("total_battles").is_none());
+        assert_eq!(open_field.get_i64("powerLossInflicted"), Ok(1_200));
+        assert_eq!(open_field.get_i64("powerLossTaken"), Ok(900));
+        assert_eq!(open_field.get_i64("atkPowerLossInflicted"), Ok(500));
+        assert_eq!(open_field.get_i64("atkPowerLossTaken"), Ok(400));
+        assert_eq!(open_field.get_i64("skillPowerLossInflicted"), Ok(700));
+        assert_eq!(open_field.get_i64("skillPowerLossTaken"), Ok(500));
+        assert!(open_field.get("power_loss_inflicted").is_none());
         assert_eq!(
             open_field.get_array("formations"),
             Ok(&vec![Bson::Document(doc! { "id": 2_i64, "count": 10_i64 })])
@@ -377,5 +408,32 @@ mod tests {
         .expect_err("confidence is required");
 
         assert!(error.to_string().contains("missing field `confidence`"));
+    }
+
+    #[test]
+    fn map_pairing_document_defaults_new_power_losses_for_legacy_strategy_documents() {
+        let legacy_strategy = stored_legacy_strategy(1, 0);
+        let response = map_pairing_document(doc! {
+            "primary_commander_id": 509_i64,
+            "secondary_commander_id": 6_i64,
+            "strategies": {
+                "all": legacy_strategy.clone(),
+                "open_field": legacy_strategy.clone(),
+                "swarming": legacy_strategy.clone(),
+                "rally": legacy_strategy.clone(),
+                "garrison": legacy_strategy,
+            },
+            "drastc": Bson::Null,
+            "refreshed_at": DateTime::from_millis(0),
+        })
+        .expect("mapped legacy response");
+        let response = to_document(&response).expect("serialized response");
+        let all = response
+            .get_document("strategies")
+            .and_then(|strategies| strategies.get_document("all"))
+            .expect("all strategy");
+
+        assert_eq!(all.get_i64("powerLossInflicted"), Ok(0));
+        assert_eq!(all.get_i64("skillPowerLossTaken"), Ok(0));
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
@@ -40,6 +40,14 @@ fn map_raw_totals_document(document: &Document) -> PairingRawTotals {
         severely_wounded_inflicted: direct_i64(document, "severely_wounded_inflicted")
             .unwrap_or_default(),
         severely_wounded_taken: direct_i64(document, "severely_wounded_taken").unwrap_or_default(),
+        power_loss_inflicted: direct_i64(document, "power_loss_inflicted").unwrap_or_default(),
+        power_loss_taken: direct_i64(document, "power_loss_taken").unwrap_or_default(),
+        atk_power_loss_inflicted: direct_i64(document, "atk_power_loss_inflicted")
+            .unwrap_or_default(),
+        atk_power_loss_taken: direct_i64(document, "atk_power_loss_taken").unwrap_or_default(),
+        skill_power_loss_inflicted: direct_i64(document, "skill_power_loss_inflicted")
+            .unwrap_or_default(),
+        skill_power_loss_taken: direct_i64(document, "skill_power_loss_taken").unwrap_or_default(),
         damage_total: direct_i64(document, "damage_total").unwrap_or_default(),
         sps_total: direct_i64(document, "sps_total").unwrap_or_default(),
         tps_total: direct_i64(document, "tps_total").unwrap_or_default(),
@@ -214,6 +222,12 @@ mod tests {
             "battle_duration_total": 10_000_i64,
             "severely_wounded_inflicted": 20_i64,
             "severely_wounded_taken": 10_i64,
+            "power_loss_inflicted": 1_200_i64,
+            "power_loss_taken": 900_i64,
+            "atk_power_loss_inflicted": 500_i64,
+            "atk_power_loss_taken": 400_i64,
+            "skill_power_loss_inflicted": 700_i64,
+            "skill_power_loss_taken": 500_i64,
             "damage_total": 50_i64,
             "sps_total": 20_i64,
             "tps_total": 10_i64,
@@ -230,6 +244,12 @@ mod tests {
 
         let totals = map_raw_totals_document(&document);
         assert_eq!(totals.total_battles, 2);
+        assert_eq!(totals.power_loss_inflicted, 1_200);
+        assert_eq!(totals.power_loss_taken, 900);
+        assert_eq!(totals.atk_power_loss_inflicted, 500);
+        assert_eq!(totals.atk_power_loss_taken, 400);
+        assert_eq!(totals.skill_power_loss_inflicted, 700);
+        assert_eq!(totals.skill_power_loss_taken, 500);
         assert_eq!(totals.damage_total, 50);
         assert_eq!(totals.opponent_dead, 5);
         assert_eq!(totals.normalized_duration_seconds_total, 10.0);

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/model.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/model.rs
@@ -17,6 +17,12 @@ pub(super) struct PairingRawTotals {
     pub(super) battle_duration_total: i64,
     pub(super) severely_wounded_inflicted: i64,
     pub(super) severely_wounded_taken: i64,
+    pub(super) power_loss_inflicted: i64,
+    pub(super) power_loss_taken: i64,
+    pub(super) atk_power_loss_inflicted: i64,
+    pub(super) atk_power_loss_taken: i64,
+    pub(super) skill_power_loss_inflicted: i64,
+    pub(super) skill_power_loss_taken: i64,
     pub(super) damage_total: i64,
     pub(super) sps_total: i64,
     pub(super) tps_total: i64,
@@ -40,6 +46,12 @@ impl PairingRawTotals {
         self.battle_duration_total += other.battle_duration_total;
         self.severely_wounded_inflicted += other.severely_wounded_inflicted;
         self.severely_wounded_taken += other.severely_wounded_taken;
+        self.power_loss_inflicted += other.power_loss_inflicted;
+        self.power_loss_taken += other.power_loss_taken;
+        self.atk_power_loss_inflicted += other.atk_power_loss_inflicted;
+        self.atk_power_loss_taken += other.atk_power_loss_taken;
+        self.skill_power_loss_inflicted += other.skill_power_loss_inflicted;
+        self.skill_power_loss_taken += other.skill_power_loss_taken;
         self.damage_total += other.damage_total;
         self.sps_total += other.sps_total;
         self.tps_total += other.tps_total;
@@ -209,6 +221,12 @@ mod tests {
                         battle_duration_total: value * 1_000,
                         severely_wounded_inflicted: value * 3,
                         severely_wounded_taken: value * 2,
+                        power_loss_inflicted: value * 12,
+                        power_loss_taken: value * 9,
+                        atk_power_loss_inflicted: value * 5,
+                        atk_power_loss_taken: value * 4,
+                        skill_power_loss_inflicted: value * 7,
+                        skill_power_loss_taken: value * 5,
                         damage_total: value * 4,
                         sps_total: value * 3,
                         tps_total: value * 2,
@@ -239,6 +257,12 @@ mod tests {
                     battle_duration_total: 10_000,
                     severely_wounded_inflicted: 30,
                     severely_wounded_taken: 20,
+                    power_loss_inflicted: 120,
+                    power_loss_taken: 90,
+                    atk_power_loss_inflicted: 50,
+                    atk_power_loss_taken: 40,
+                    skill_power_loss_inflicted: 70,
+                    skill_power_loss_taken: 50,
                     damage_total: 40,
                     sps_total: 30,
                     tps_total: 20,

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/output.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/output.rs
@@ -74,6 +74,12 @@ pub(super) fn build_precomputed_document(
 
 fn strategy_summary_document(raw: &StrategyRawTotals) -> Document {
     let mut summary = summary_document(finalize_summary(raw.totals));
+    summary.insert("power_loss_inflicted", raw.totals.power_loss_inflicted);
+    summary.insert("power_loss_taken", raw.totals.power_loss_taken);
+    summary.insert("atk_power_loss_inflicted", raw.totals.atk_power_loss_inflicted);
+    summary.insert("atk_power_loss_taken", raw.totals.atk_power_loss_taken);
+    summary.insert("skill_power_loss_inflicted", raw.totals.skill_power_loss_inflicted);
+    summary.insert("skill_power_loss_taken", raw.totals.skill_power_loss_taken);
     summary.insert(
         "formations",
         raw.formations
@@ -198,6 +204,12 @@ mod tests {
             "hps": 0.0,
         };
         let mut zero_strategy = zero_summary.clone();
+        zero_strategy.insert("power_loss_inflicted", 0_i64);
+        zero_strategy.insert("power_loss_taken", 0_i64);
+        zero_strategy.insert("atk_power_loss_inflicted", 0_i64);
+        zero_strategy.insert("atk_power_loss_taken", 0_i64);
+        zero_strategy.insert("skill_power_loss_inflicted", 0_i64);
+        zero_strategy.insert("skill_power_loss_taken", 0_i64);
         zero_strategy.insert("formations", Bson::Array(Vec::new()));
 
         assert_eq!(
@@ -285,6 +297,12 @@ mod tests {
                     kill_points_lost: 100,
                     trade_percentage_total: 300.0,
                     battle_duration_total: 10_000,
+                    power_loss_inflicted: 1_200,
+                    power_loss_taken: 900,
+                    atk_power_loss_inflicted: 500,
+                    atk_power_loss_taken: 400,
+                    skill_power_loss_inflicted: 700,
+                    skill_power_loss_taken: 500,
                     ..PairingRawTotals::default()
                 },
                 formations: BTreeMap::from([(0, 1), (1, 1)]),
@@ -299,6 +317,12 @@ mod tests {
                     kill_points_lost: 200,
                     trade_percentage_total: 450.0,
                     battle_duration_total: 15_000,
+                    power_loss_inflicted: 1_800,
+                    power_loss_taken: 1_500,
+                    atk_power_loss_inflicted: 800,
+                    atk_power_loss_taken: 600,
+                    skill_power_loss_inflicted: 1_000,
+                    skill_power_loss_taken: 900,
                     ..PairingRawTotals::default()
                 },
                 formations: BTreeMap::from([(1, 2), (2, 1)]),
@@ -315,6 +339,12 @@ mod tests {
         let all = strategy_documents.get_document("all").expect("all");
 
         assert_eq!(all.get_i64("total_battles"), Ok(5));
+        assert_eq!(all.get_i64("power_loss_inflicted"), Ok(3_000));
+        assert_eq!(all.get_i64("power_loss_taken"), Ok(2_400));
+        assert_eq!(all.get_i64("atk_power_loss_inflicted"), Ok(1_300));
+        assert_eq!(all.get_i64("atk_power_loss_taken"), Ok(1_000));
+        assert_eq!(all.get_i64("skill_power_loss_inflicted"), Ok(1_700));
+        assert_eq!(all.get_i64("skill_power_loss_taken"), Ok(1_400));
         for strategy in ["open_field", "swarming", "rally", "garrison"] {
             assert!(strategy_documents.get_document(strategy).is_ok());
         }

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
@@ -302,6 +302,12 @@ fn raw_totals_group_stage(id: Document) -> Document {
             "battle_duration_total": { "$sum": "$battle_duration" },
             "severely_wounded_inflicted": { "$sum": "$severely_wounded_inflicted" },
             "severely_wounded_taken": { "$sum": "$severely_wounded_taken" },
+            "power_loss_inflicted": { "$sum": "$power_loss_inflicted" },
+            "power_loss_taken": { "$sum": "$power_loss_taken" },
+            "atk_power_loss_inflicted": { "$sum": "$atk_power_loss_inflicted" },
+            "atk_power_loss_taken": { "$sum": "$atk_power_loss_taken" },
+            "skill_power_loss_inflicted": { "$sum": "$skill_power_loss_inflicted" },
+            "skill_power_loss_taken": { "$sum": "$skill_power_loss_taken" },
             "damage_total": { "$sum": "$damage_total" },
             "sps_total": { "$sum": "$sps_total" },
             "tps_total": { "$sum": "$tps_total" },
@@ -333,6 +339,12 @@ fn strategy_totals_group_stage() -> Document {
             "battle_duration_total": { "$sum": "$battle_duration_total" },
             "severely_wounded_inflicted": { "$sum": "$severely_wounded_inflicted" },
             "severely_wounded_taken": { "$sum": "$severely_wounded_taken" },
+            "power_loss_inflicted": { "$sum": "$power_loss_inflicted" },
+            "power_loss_taken": { "$sum": "$power_loss_taken" },
+            "atk_power_loss_inflicted": { "$sum": "$atk_power_loss_inflicted" },
+            "atk_power_loss_taken": { "$sum": "$atk_power_loss_taken" },
+            "skill_power_loss_inflicted": { "$sum": "$skill_power_loss_inflicted" },
+            "skill_power_loss_taken": { "$sum": "$skill_power_loss_taken" },
             "damage_total": { "$sum": "$damage_total" },
             "sps_total": { "$sum": "$sps_total" },
             "tps_total": { "$sum": "$tps_total" },
@@ -524,6 +536,12 @@ fn raw_totals_aggregate_document() -> Document {
         "battle_duration_total": "$battle_duration_total",
         "severely_wounded_inflicted": "$severely_wounded_inflicted",
         "severely_wounded_taken": "$severely_wounded_taken",
+        "power_loss_inflicted": "$power_loss_inflicted",
+        "power_loss_taken": "$power_loss_taken",
+        "atk_power_loss_inflicted": "$atk_power_loss_inflicted",
+        "atk_power_loss_taken": "$atk_power_loss_taken",
+        "skill_power_loss_inflicted": "$skill_power_loss_inflicted",
+        "skill_power_loss_taken": "$skill_power_loss_taken",
         "damage_total": "$damage_total",
         "sps_total": "$sps_total",
         "tps_total": "$tps_total",
@@ -654,6 +672,12 @@ fn perspective_entry(
         "battle_duration": battle_duration.clone(),
         "severely_wounded_inflicted": opponent_severely_wounded.clone(),
         "severely_wounded_taken": sender_severely_wounded.clone(),
+        "power_loss_inflicted": power_loss_field(enemy_results_path, "power"),
+        "power_loss_taken": power_loss_field(self_results_path, "power"),
+        "atk_power_loss_inflicted": power_loss_field(enemy_results_path, "attack_power"),
+        "atk_power_loss_taken": power_loss_field(self_results_path, "attack_power"),
+        "skill_power_loss_inflicted": power_loss_field(enemy_results_path, "skill_power"),
+        "skill_power_loss_taken": power_loss_field(self_results_path, "skill_power"),
         "damage_total": {
             "$add": [
                 opponent_slightly_wounded.clone(),
@@ -703,6 +727,15 @@ fn perspective_entry(
 
 fn numeric_field(path: &str, field: &str) -> Document {
     doc! { "$ifNull": [format!("${path}.{field}"), 0] }
+}
+
+fn power_loss_field(path: &str, field: &str) -> Document {
+    doc! {
+        "$max": [
+            { "$multiply": [numeric_field(path, field), -1_i64] },
+            0_i64,
+        ]
+    }
 }
 
 fn trade_percentage_expr(kill_points_gained: Document, kill_points_lost: Document) -> Document {
@@ -1069,5 +1102,34 @@ mod tests {
         );
 
         assert_eq!(entry.get_document("formation"), Ok(&doc! { "$ifNull": ["$formation", 0_i64] }));
+    }
+
+    #[test]
+    fn perspective_entry_orients_and_normalizes_power_losses() {
+        let entry = perspective_entry(
+            "$primary",
+            "$secondary",
+            "$formation",
+            "$strategy",
+            "self_results",
+            "enemy_results",
+        );
+
+        assert_eq!(
+            entry.get_document("power_loss_inflicted"),
+            Ok(&power_loss_field("enemy_results", "power"))
+        );
+        assert_eq!(
+            entry.get_document("power_loss_taken"),
+            Ok(&power_loss_field("self_results", "power"))
+        );
+        assert_eq!(
+            entry.get_document("atk_power_loss_inflicted"),
+            Ok(&power_loss_field("enemy_results", "attack_power"))
+        );
+        assert_eq!(
+            entry.get_document("skill_power_loss_taken"),
+            Ok(&power_loss_field("self_results", "skill_power"))
+        );
     }
 }

--- a/packages/site/src/lib/combat-lab/api.ts
+++ b/packages/site/src/lib/combat-lab/api.ts
@@ -47,6 +47,12 @@ export type CombatLabFormation = {
 };
 
 export type CombatLabStrategySummary = CombatLabSummary & {
+  powerLossInflicted: number;
+  powerLossTaken: number;
+  atkPowerLossInflicted: number;
+  atkPowerLossTaken: number;
+  skillPowerLossInflicted: number;
+  skillPowerLossTaken: number;
   formations: CombatLabFormation[];
 };
 


### PR DESCRIPTION
## Summary

- aggregate total, attack, and skill power loss inflicted and taken for each precomputed commander-pairing strategy
- expose the new values through the Combat Lab API and site types
- default the new fields to zero when reading legacy precomputed strategy documents

## Why

Combat Lab needs power-loss metrics alongside its existing pairing strategy summaries so consumers can compare actual power traded by each commander pairing.

## Impact

The precompute job writes six additional strategy fields, and the Combat Lab API serializes them in camelCase. This PR no longer contains any My Pairings changes; those were split into independent PR #804.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rokbattles-api -p rokbattles-jobs` (237 tests passed)
- `pnpm install --frozen-lockfile`
- `pnpm -F @rokbattles/site typecheck`
- verified the branch is a single commit directly on current `main`