### PR TITLE
feat(combat-lab): add rolling one-year ranking cutoff

### DIFF
--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/confidence.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/confidence.rs
@@ -17,8 +17,9 @@ use crate::error::JobsError;
 pub(super) async fn read_pairing_confidences(
     source: &Collection<Document>,
     supported_pairings: &[PairingKey],
+    cutoff_mail_time: i64,
 ) -> Result<BTreeMap<PairingKey, DrastcConfidence>, JobsError> {
-    let pipeline = build_confidence_pipeline(supported_pairings);
+    let pipeline = build_confidence_pipeline(supported_pairings, cutoff_mail_time);
     let mut cursor = source.aggregate(pipeline).allow_disk_use(true).await?;
     let mut confidences = BTreeMap::new();
 
@@ -31,8 +32,12 @@ pub(super) async fn read_pairing_confidences(
     Ok(confidences)
 }
 
-pub(super) fn build_confidence_pipeline(supported_pairings: &[PairingKey]) -> Vec<Document> {
-    let mut pipeline = build_supported_pairing_entries_pipeline(supported_pairings);
+pub(super) fn build_confidence_pipeline(
+    supported_pairings: &[PairingKey],
+    cutoff_mail_time: i64,
+) -> Vec<Document> {
+    let mut pipeline =
+        build_supported_pairing_entries_pipeline(supported_pairings, cutoff_mail_time);
     pipeline.extend([
         doc! {
             "$match": {
@@ -111,7 +116,8 @@ mod tests {
     #[test]
     fn confidence_pipeline_groups_open_field_battles_by_governor_then_pairing() {
         let pairing = PairingKey { primary_commander_id: 595, secondary_commander_id: 596 };
-        let pipeline = build_confidence_pipeline(&[pairing]);
+        let cutoff_mail_time = 1_755_000_000_000_000_i64;
+        let pipeline = build_confidence_pipeline(&[pairing], cutoff_mail_time);
         let group_count = pipeline.iter().filter(|stage| stage.contains_key("$group")).count();
         let pairing_match = pipeline
             .iter()
@@ -123,6 +129,12 @@ mod tests {
         assert_eq!(pairing_match.get_str("strategy"), Ok("open_field"));
         let leading_match = pipeline[0].get_document("$match").expect("leading match");
         assert_eq!(leading_match.get_array("$or").map(Vec::len), Ok(2));
+        assert_eq!(
+            leading_match
+                .get_document("metadata.mail_time")
+                .and_then(|mail_time| mail_time.get_i64("$gte")),
+            Ok(cutoff_mail_time)
+        );
         assert!(!format!("{pipeline:?}").contains("kill_points_gained"));
     }
 

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
@@ -18,8 +18,9 @@ use crate::error::JobsError;
 pub(super) async fn read_pairings_and_reference_ranges(
     source: &Collection<Document>,
     legendary_ids: &[i64],
+    cutoff_mail_time: i64,
 ) -> Result<PairingsAggregation, JobsError> {
-    let pipeline = build_pairings_pipeline(legendary_ids);
+    let pipeline = build_pairings_pipeline(legendary_ids, cutoff_mail_time);
     let mut cursor = source.aggregate(pipeline).allow_disk_use(true).await?;
     let mut aggregation = PairingsAggregation::default();
 

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
@@ -27,6 +27,8 @@ use crate::error::JobsError;
 
 const COMMANDERS_YAML: &str = include_str!("../../../../../datasets/commanders.yaml");
 const BULK_WRITE_BATCH_SIZE: usize = 1_000;
+const RANKING_WINDOW_DAYS: i64 = 365;
+const MILLIS_PER_DAY: i64 = 24 * 60 * 60 * 1_000;
 
 /// Counts from one commander pairing precompute run.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -44,21 +46,28 @@ pub struct CommanderPairingsPrecomputeStats {
 pub async fn precompute_commander_pairings_data(
     reports_store: &ReportsStore,
 ) -> Result<CommanderPairingsPrecomputeStats, JobsError> {
+    let refreshed_at = DateTime::now();
+    let cutoff_mail_time = ranking_cutoff_mail_time(refreshed_at);
     let legendary_ids = legendary_commander_ids()?;
-    let aggregation =
-        read_pairings_and_reference_ranges(reports_store.battle_collection(), &legendary_ids)
-            .await?;
+    let aggregation = read_pairings_and_reference_ranges(
+        reports_store.battle_collection(),
+        &legendary_ids,
+        cutoff_mail_time,
+    )
+    .await?;
     let supported_drastc_pairings = supported_drastc_pairings(&legendary_ids);
     let drastc_scores = build_drastc_scores_from_aggregates(
         &aggregation.drastc_observed,
         &supported_drastc_pairings,
         aggregation.reference_ranges,
     );
-    let confidences =
-        read_pairing_confidences(reports_store.battle_collection(), &supported_drastc_pairings)
-            .await?;
+    let confidences = read_pairing_confidences(
+        reports_store.battle_collection(),
+        &supported_drastc_pairings,
+        cutoff_mail_time,
+    )
+    .await?;
 
-    let refreshed_at = DateTime::now();
     let all_pairings = ordered_pairing_keys(&legendary_ids);
     let battle_entries_counted = all_pairings
         .iter()
@@ -87,6 +96,13 @@ pub async fn precompute_commander_pairings_data(
         battle_entries_counted,
         documents_written,
     })
+}
+
+fn ranking_cutoff_mail_time(run_at: DateTime) -> i64 {
+    run_at
+        .timestamp_millis()
+        .saturating_sub(RANKING_WINDOW_DAYS * MILLIS_PER_DAY)
+        .saturating_mul(1_000)
 }
 
 fn build_pairing_documents(
@@ -229,6 +245,17 @@ mod tests {
         let keys = ordered_pairing_keys(&[1, 2, 3]);
         assert_eq!(keys.len(), 6);
         assert!(!keys.contains(&PairingKey { primary_commander_id: 1, secondary_commander_id: 1 }));
+    }
+
+    #[test]
+    fn ranking_cutoff_preserves_the_utc_run_time() {
+        let run_at = DateTime::parse_rfc3339_str("2026-08-12T08:00:00Z").expect("run timestamp");
+        let expected = DateTime::parse_rfc3339_str("2025-08-12T08:00:00Z")
+            .expect("cutoff timestamp")
+            .timestamp_millis()
+            * 1_000;
+
+        assert_eq!(ranking_cutoff_mail_time(run_at), expected);
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
@@ -6,8 +6,11 @@ use super::model::{PairingKey, Strategy};
 
 const MIN_REFERENCE_RANGE_PAIRING_BATTLES: i64 = 5_000;
 
-pub(super) fn build_pairings_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
-    let mut pipeline = build_pairing_entries_pipeline(legendary_ids);
+pub(super) fn build_pairings_pipeline(
+    legendary_ids: &[i64],
+    cutoff_mail_time: i64,
+) -> Vec<Document> {
+    let mut pipeline = build_pairing_entries_pipeline(legendary_ids, cutoff_mail_time);
     pipeline.extend([
         raw_totals_group_stage(doc! {
             "primary_commander_id": "$primary_commander_id",
@@ -25,7 +28,7 @@ pub(super) fn build_pairings_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
     pipeline
 }
 
-fn build_pairing_entries_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
+fn build_pairing_entries_pipeline(legendary_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
     let legendary_id_values = legendary_id_bson_array(legendary_ids);
     let sender_condition = ids_match_condition(
         "$sender.commanders.primary.id",
@@ -76,11 +79,12 @@ fn build_pairing_entries_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
         ),
     );
 
-    build_entries_pipeline(sender_entry, opponent_entry, pair_filters)
+    build_entries_pipeline(sender_entry, opponent_entry, pair_filters, cutoff_mail_time)
 }
 
 pub(super) fn build_supported_pairing_entries_pipeline(
     supported_pairings: &[PairingKey],
+    cutoff_mail_time: i64,
 ) -> Vec<Document> {
     let sender_condition = exact_pairing_condition(
         "$sender.commanders.primary.id",
@@ -141,18 +145,20 @@ pub(super) fn build_supported_pairing_entries_pipeline(
         ),
     );
 
-    build_entries_pipeline(sender_entry, opponent_entry, pair_filters)
+    build_entries_pipeline(sender_entry, opponent_entry, pair_filters, cutoff_mail_time)
 }
 
 fn build_entries_pipeline(
     sender_entry: Document,
     opponent_entry: Document,
     pair_filters: Vec<Bson>,
+    cutoff_mail_time: i64,
 ) -> Vec<Document> {
     vec![
         doc! {
             "$match": {
                 "metadata.kvk": true,
+                "metadata.mail_time": { "$gte": cutoff_mail_time },
                 "opponents": { "$elemMatch": { "player_id": { "$gt": 0 } } },
                 "$or": pair_filters,
             }
@@ -818,20 +824,27 @@ mod tests {
 
     #[test]
     fn build_pairings_pipeline_starts_with_indexable_kvk_filter() {
-        let pipeline = build_pairings_pipeline(&[509, 6]);
+        let cutoff_mail_time = 1_755_000_000_000_000_i64;
+        let pipeline = build_pairings_pipeline(&[509, 6], cutoff_mail_time);
         let matcher = pipeline
             .first()
             .and_then(|stage| stage.get_document("$match").ok())
             .expect("leading match");
 
         assert_eq!(matcher.get_bool("metadata.kvk"), Ok(true));
+        assert_eq!(
+            matcher
+                .get_document("metadata.mail_time")
+                .and_then(|mail_time| mail_time.get_i64("$gte")),
+            Ok(cutoff_mail_time)
+        );
         assert!(matcher.get_document("opponents").is_ok());
         assert!(matcher.get_array("$or").is_ok());
     }
 
     #[test]
     fn build_pairings_pipeline_streams_pairing_documents_without_facets() {
-        let pipeline = build_pairings_pipeline(&[509, 6]);
+        let pipeline = build_pairings_pipeline(&[509, 6], 1_755_000_000_000_000_i64);
         let group_count = pipeline.iter().filter(|stage| stage.contains_key("$group")).count();
 
         assert_eq!(group_count, 3);


### PR DESCRIPTION
## What changed

- capture one UTC timestamp at the start of each commander-pairings precompute run
- calculate an exact rolling cutoff of 365 × 24 hours, preserving the run time of day
- apply the inclusive `metadata.mail_time >= cutoff` predicate to Combat Lab totals, DRASTC scoring/reference ranges, and DRASTC confidence
- add boundary and pipeline coverage for both aggregation paths

## Why

Combat Lab and DRASTC rankings previously aggregated all historical KvK battle data. This bounds every scheduled refresh to the trailing 365 days, so a run at `2026-08-12T08:00:00Z` starts at `2025-08-12T08:00:00Z`.

## Performance

The cutoff is part of the first MongoDB `$match`, before unwind, projection, grouping, or percentile stages. It is a direct range predicate compatible with the existing compound `{ metadata.kvk: 1, metadata.mail_time: -1 }` index, so stale documents are excluded at the database scan rather than filtered in memory.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p rokbattles-jobs` (65 passed)
- `cargo clippy -p rokbattles-jobs --all-targets --all-features --locked -- -D warnings -D clippy::perf`