### PR TITLE
feat(combat-lab): generate rankings for all pairings

### DIFF
--- a/crates/apps/rokbattles-jobs/src/error.rs
+++ b/crates/apps/rokbattles-jobs/src/error.rs
@@ -15,6 +15,8 @@ pub enum JobsError {
     Io(#[from] std::io::Error),
     #[error("MONGODB_URI must include a default database")]
     MissingDatabase,
+    #[error("Commander dataset contains no commanders")]
+    MissingCommanders,
     #[error("Commander dataset contains no legendary commanders")]
     MissingLegendaryCommanders,
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mapper.rs
@@ -17,9 +17,12 @@ use crate::error::JobsError;
 
 pub(super) async fn read_pairings_and_reference_ranges(
     source: &Collection<Document>,
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
+    drastc_reference_ids: &[i64],
+    supported_drastc_pairings: &[PairingKey],
 ) -> Result<PairingsAggregation, JobsError> {
-    let pipeline = build_pairings_pipeline(legendary_ids);
+    let pipeline =
+        build_pairings_pipeline(commander_ids, drastc_reference_ids, supported_drastc_pairings);
     let mut cursor = source.aggregate(pipeline).allow_disk_use(true).await?;
     let mut aggregation = PairingsAggregation::default();
 

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
@@ -1,4 +1,4 @@
-//! Precompute global legendary commander pairing battle data.
+//! Precompute global commander pairing battle data.
 
 mod confidence;
 mod mapper;
@@ -31,7 +31,7 @@ const BULK_WRITE_BATCH_SIZE: usize = 1_000;
 /// Counts from one commander pairing precompute run.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CommanderPairingsPrecomputeStats {
-    pub legendary_commanders: usize,
+    pub commanders: usize,
     pub observed_pairings: usize,
     pub supported_drastc_pairings: usize,
     pub scored_drastc_pairings: usize,
@@ -40,15 +40,19 @@ pub struct CommanderPairingsPrecomputeStats {
     pub documents_written: usize,
 }
 
-/// Refresh global legendary commander pairing data.
+/// Refresh global commander pairing data.
 pub async fn precompute_commander_pairings_data(
     reports_store: &ReportsStore,
 ) -> Result<CommanderPairingsPrecomputeStats, JobsError> {
-    let legendary_ids = legendary_commander_ids()?;
-    let aggregation =
-        read_pairings_and_reference_ranges(reports_store.battle_collection(), &legendary_ids)
-            .await?;
-    let supported_drastc_pairings = supported_drastc_pairings(&legendary_ids);
+    let commander_catalog = commander_catalog()?;
+    let supported_drastc_pairings = supported_drastc_pairings(&commander_catalog.all);
+    let aggregation = read_pairings_and_reference_ranges(
+        reports_store.battle_collection(),
+        &commander_catalog.all,
+        &commander_catalog.legendary,
+        &supported_drastc_pairings,
+    )
+    .await?;
     let drastc_scores = build_drastc_scores_from_aggregates(
         &aggregation.drastc_observed,
         &supported_drastc_pairings,
@@ -59,7 +63,7 @@ pub async fn precompute_commander_pairings_data(
             .await?;
 
     let refreshed_at = DateTime::now();
-    let all_pairings = ordered_pairing_keys(&legendary_ids);
+    let all_pairings = ordered_pairing_keys(&commander_catalog.all);
     let battle_entries_counted = all_pairings
         .iter()
         .filter_map(|key| aggregation.strategies.get(key))
@@ -79,7 +83,7 @@ pub async fn precompute_commander_pairings_data(
     .await?;
 
     Ok(CommanderPairingsPrecomputeStats {
-        legendary_commanders: legendary_ids.len(),
+        commanders: commander_catalog.all.len(),
         observed_pairings: aggregation.strategies.len(),
         supported_drastc_pairings: supported_drastc_pairings.len(),
         scored_drastc_pairings: drastc_scores.len(),
@@ -140,17 +144,24 @@ async fn write_pairing_documents(
     Ok(documents_written)
 }
 
-fn legendary_commander_ids() -> Result<Vec<i64>, JobsError> {
-    let mut ids = BTreeSet::new();
+struct CommanderCatalog {
+    all: Vec<i64>,
+    legendary: Vec<i64>,
+}
+
+fn commander_catalog() -> Result<CommanderCatalog, JobsError> {
+    let mut all = BTreeSet::new();
+    let mut legendary = BTreeSet::new();
     let mut current_id = None;
     let mut current_is_legendary = false;
 
     for line in COMMANDERS_YAML.lines() {
         if let Some(id) = parse_top_level_commander_id(line) {
             if current_is_legendary && let Some(previous_id) = current_id {
-                ids.insert(previous_id);
+                legendary.insert(previous_id);
             }
 
+            all.insert(id);
             current_id = Some(id);
             current_is_legendary = false;
             continue;
@@ -162,14 +173,20 @@ fn legendary_commander_ids() -> Result<Vec<i64>, JobsError> {
     }
 
     if current_is_legendary && let Some(previous_id) = current_id {
-        ids.insert(previous_id);
+        legendary.insert(previous_id);
     }
 
-    if ids.is_empty() {
+    if all.is_empty() {
+        return Err(JobsError::MissingCommanders);
+    }
+    if legendary.is_empty() {
         return Err(JobsError::MissingLegendaryCommanders);
     }
 
-    Ok(ids.into_iter().collect())
+    Ok(CommanderCatalog {
+        all: all.into_iter().collect(),
+        legendary: legendary.into_iter().collect(),
+    })
 }
 
 fn parse_top_level_commander_id(line: &str) -> Option<i64> {
@@ -182,11 +199,13 @@ fn parse_top_level_commander_id(line: &str) -> Option<i64> {
     id.parse::<i64>().ok()
 }
 
-fn ordered_pairing_keys(legendary_ids: &[i64]) -> Vec<PairingKey> {
-    let mut keys = Vec::with_capacity(legendary_ids.len().saturating_mul(legendary_ids.len()));
+fn ordered_pairing_keys(commander_ids: &[i64]) -> Vec<PairingKey> {
+    let mut keys = Vec::with_capacity(
+        commander_ids.len().saturating_mul(commander_ids.len().saturating_sub(1)),
+    );
 
-    for primary_commander_id in legendary_ids {
-        for secondary_commander_id in legendary_ids {
+    for primary_commander_id in commander_ids {
+        for secondary_commander_id in commander_ids {
             if primary_commander_id == secondary_commander_id {
                 continue;
             }
@@ -215,20 +234,42 @@ mod tests {
     use super::*;
 
     #[test]
-    fn legendary_commander_ids_reads_expected_dataset_values() {
-        let ids = legendary_commander_ids().expect("legendary ids");
-        assert!(ids.contains(&509));
-        assert!(ids.contains(&6));
-        assert!(ids.contains(&179));
-        assert!(ids.contains(&187));
-        assert!(!ids.contains(&12));
+    fn commander_catalog_reads_every_top_level_dataset_entry() {
+        let catalog = commander_catalog().expect("commander catalog");
+
+        assert_eq!(catalog.all.len(), 141);
     }
 
     #[test]
-    fn ordered_pairing_keys_excludes_self_pairings() {
-        let keys = ordered_pairing_keys(&[1, 2, 3]);
-        assert_eq!(keys.len(), 6);
-        assert!(!keys.contains(&PairingKey { primary_commander_id: 1, secondary_commander_id: 1 }));
+    fn commander_catalog_includes_non_legendary_commanders() {
+        let catalog = commander_catalog().expect("commander catalog");
+
+        assert!([12, 22, 33].iter().all(|id| catalog.all.contains(id)));
+    }
+
+    #[test]
+    fn commander_catalog_preserves_legendary_drastc_reference_population() {
+        let catalog = commander_catalog().expect("commander catalog");
+
+        assert_eq!(catalog.legendary.len(), 110);
+    }
+
+    #[test]
+    fn full_catalog_does_not_expand_supported_drastc_pairings() {
+        let catalog = commander_catalog().expect("commander catalog");
+
+        assert_eq!(
+            supported_drastc_pairings(&catalog.all),
+            supported_drastc_pairings(&catalog.legendary)
+        );
+    }
+
+    #[test]
+    fn ordered_pairing_keys_generates_every_ordered_non_self_pairing() {
+        let catalog = commander_catalog().expect("commander catalog");
+        let keys = ordered_pairing_keys(&catalog.all);
+
+        assert_eq!(keys.len(), 141 * 140);
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/pipeline.rs
@@ -6,8 +6,12 @@ use super::model::{PairingKey, Strategy};
 
 const MIN_REFERENCE_RANGE_PAIRING_BATTLES: i64 = 5_000;
 
-pub(super) fn build_pairings_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
-    let mut pipeline = build_pairing_entries_pipeline(legendary_ids);
+pub(super) fn build_pairings_pipeline(
+    commander_ids: &[i64],
+    drastc_reference_ids: &[i64],
+    supported_drastc_pairings: &[PairingKey],
+) -> Vec<Document> {
+    let mut pipeline = build_pairing_entries_pipeline(commander_ids);
     pipeline.extend([
         raw_totals_group_stage(doc! {
             "primary_commander_id": "$primary_commander_id",
@@ -16,38 +20,38 @@ pub(super) fn build_pairings_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
             "formation": "$formation",
         }),
         strategy_totals_group_stage(),
-        reference_eligibility_stage(),
+        reference_eligibility_stage(drastc_reference_ids),
         reference_metric_stage(),
         reference_window_stage(),
-        pairing_output_group_stage(),
+        pairing_output_group_stage(supported_drastc_pairings),
         pairing_output_project_stage(),
     ]);
     pipeline
 }
 
-fn build_pairing_entries_pipeline(legendary_ids: &[i64]) -> Vec<Document> {
-    let legendary_id_values = legendary_id_bson_array(legendary_ids);
+fn build_pairing_entries_pipeline(commander_ids: &[i64]) -> Vec<Document> {
+    let commander_id_values = commander_id_bson_array(commander_ids);
     let sender_condition = ids_match_condition(
         "$sender.commanders.primary.id",
         "$sender.commanders.secondary.id",
-        &legendary_id_values,
+        &commander_id_values,
     );
     let opponent_condition = ids_match_condition(
         "$opponents.commanders.primary.id",
         "$opponents.commanders.secondary.id",
-        &legendary_id_values,
+        &commander_id_values,
     );
     let pair_filters = vec![
         Bson::Document(doc! {
-            "sender.commanders.primary.id": { "$in": legendary_id_values.clone() },
-            "sender.commanders.secondary.id": { "$in": legendary_id_values.clone() },
+            "sender.commanders.primary.id": { "$in": commander_id_values.clone() },
+            "sender.commanders.secondary.id": { "$in": commander_id_values.clone() },
         }),
         Bson::Document(doc! {
             "opponents": {
                 "$elemMatch": {
                     "player_id": { "$gt": 0 },
-                    "commanders.primary.id": { "$in": legendary_id_values.clone() },
-                    "commanders.secondary.id": { "$in": legendary_id_values },
+                    "commanders.primary.id": { "$in": commander_id_values.clone() },
+                    "commanders.secondary.id": { "$in": commander_id_values },
                 }
             }
         }),
@@ -357,13 +361,17 @@ fn strategy_totals_group_stage() -> Document {
     }
 }
 
-fn reference_eligibility_stage() -> Document {
+fn reference_eligibility_stage(drastc_reference_ids: &[i64]) -> Document {
+    let reference_ids = commander_id_bson_array(drastc_reference_ids);
+
     doc! {
         "$set": {
             "_reference_eligible": {
                 "$and": [
                     { "$eq": ["$_id.strategy", Strategy::OpenField.as_str()] },
                     { "$gte": ["$total_battles", MIN_REFERENCE_RANGE_PAIRING_BATTLES] },
+                    { "$in": ["$_id.primary_commander_id", reference_ids.clone()] },
+                    { "$in": ["$_id.secondary_commander_id", reference_ids] },
                 ]
             }
         }
@@ -478,7 +486,13 @@ fn reference_window_stage() -> Document {
     }
 }
 
-fn pairing_output_group_stage() -> Document {
+fn pairing_output_group_stage(supported_drastc_pairings: &[PairingKey]) -> Document {
+    let supported_pairing_condition = exact_pairing_condition(
+        "$_id.primary_commander_id",
+        "$_id.secondary_commander_id",
+        supported_drastc_pairings,
+    );
+
     doc! {
         "$group": {
             "_id": {
@@ -491,7 +505,12 @@ fn pairing_output_group_stage() -> Document {
             "drastc_observed": {
                 "$max": {
                     "$cond": [
-                        { "$eq": ["$_id.strategy", Strategy::OpenField.as_str()] },
+                        {
+                            "$and": [
+                                { "$eq": ["$_id.strategy", Strategy::OpenField.as_str()] },
+                                supported_pairing_condition,
+                            ]
+                        },
                         raw_totals_aggregate_document(),
                         Bson::Null,
                     ]
@@ -594,19 +613,19 @@ fn aggregate_consistency_rate_expr() -> Document {
     }
 }
 
-fn legendary_id_bson_array(legendary_ids: &[i64]) -> Vec<Bson> {
-    legendary_ids.iter().map(|id| Bson::Int64(*id)).collect()
+fn commander_id_bson_array(commander_ids: &[i64]) -> Vec<Bson> {
+    commander_ids.iter().map(|id| Bson::Int64(*id)).collect()
 }
 
 fn ids_match_condition(
     primary_expr: &'static str,
     secondary_expr: &'static str,
-    legendary_ids: &[Bson],
+    commander_ids: &[Bson],
 ) -> Document {
     doc! {
         "$and": [
-            { "$in": [primary_expr, legendary_ids.to_vec()] },
-            { "$in": [secondary_expr, legendary_ids.to_vec()] },
+            { "$in": [primary_expr, commander_ids.to_vec()] },
+            { "$in": [secondary_expr, commander_ids.to_vec()] },
             { "$ne": [primary_expr, secondary_expr] },
         ]
     }
@@ -800,15 +819,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn reference_eligibility_requires_large_open_field_pairings() {
+    fn reference_eligibility_requires_large_open_field_reference_pairings() {
         assert_eq!(
-            reference_eligibility_stage(),
+            reference_eligibility_stage(&[509, 6]),
             doc! {
                 "$set": {
                     "_reference_eligible": {
                         "$and": [
                             { "$eq": ["$_id.strategy", "open_field"] },
                             { "$gte": ["$total_battles", MIN_REFERENCE_RANGE_PAIRING_BATTLES] },
+                            { "$in": ["$_id.primary_commander_id", [509_i64, 6_i64]] },
+                            { "$in": ["$_id.secondary_commander_id", [509_i64, 6_i64]] },
                         ]
                     }
                 }
@@ -818,7 +839,7 @@ mod tests {
 
     #[test]
     fn build_pairings_pipeline_starts_with_indexable_kvk_filter() {
-        let pipeline = build_pairings_pipeline(&[509, 6]);
+        let pipeline = build_pairings_pipeline(&[509, 6, 12], &[509, 6], &[]);
         let matcher = pipeline
             .first()
             .and_then(|stage| stage.get_document("$match").ok())
@@ -831,7 +852,7 @@ mod tests {
 
     #[test]
     fn build_pairings_pipeline_streams_pairing_documents_without_facets() {
-        let pipeline = build_pairings_pipeline(&[509, 6]);
+        let pipeline = build_pairings_pipeline(&[509, 6, 12], &[509, 6], &[]);
         let group_count = pipeline.iter().filter(|stage| stage.contains_key("$group")).count();
 
         assert_eq!(group_count, 3);
@@ -884,7 +905,13 @@ mod tests {
         ] {
             assert!(output.get_document(field).is_ok());
         }
-        let group = pairing_output_group_stage();
+    }
+
+    #[test]
+    fn pairing_output_limits_drastc_observations_to_supported_pairings() {
+        let supported_pairing =
+            PairingKey { primary_commander_id: 579, secondary_commander_id: 575 };
+        let group = pairing_output_group_stage(&[supported_pairing]);
         let condition = group
             .get_document("$group")
             .and_then(|group| group.get_document("drastc_observed"))
@@ -893,7 +920,16 @@ mod tests {
             .expect("DRASTC condition");
         assert_eq!(
             condition.first(),
-            Some(&Bson::Document(doc! { "$eq": ["$_id.strategy", "open_field"] }))
+            Some(&Bson::Document(doc! {
+                "$and": [
+                    { "$eq": ["$_id.strategy", "open_field"] },
+                    exact_pairing_condition(
+                        "$_id.primary_commander_id",
+                        "$_id.secondary_commander_id",
+                        &[supported_pairing],
+                    ),
+                ]
+            }))
         );
     }
 

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/scoring.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/scoring.rs
@@ -2,10 +2,7 @@ use std::collections::BTreeMap;
 
 use rokbattles_drastc::{DrastcModel, DrastcReferenceRanges, DrastcScore};
 
-use super::{
-    model::{PairingKey, PairingRawTotals},
-    ordered_pairing_keys,
-};
+use super::model::{PairingKey, PairingRawTotals};
 
 pub(super) fn build_drastc_scores_from_aggregates(
     observed: &BTreeMap<PairingKey, PairingRawTotals>,
@@ -32,14 +29,23 @@ pub(super) fn build_drastc_scores_from_aggregates(
     scores
 }
 
-pub(super) fn supported_drastc_pairings(legendary_ids: &[i64]) -> Vec<PairingKey> {
-    ordered_pairing_keys(legendary_ids)
-        .into_iter()
-        .filter(|key| {
-            u32::try_from(key.primary_commander_id)
-                .ok()
-                .zip(u32::try_from(key.secondary_commander_id).ok())
-                .is_some_and(|(primary, secondary)| DrastcModel::is_supported(primary, secondary))
+pub(super) fn supported_drastc_pairings(commander_ids: &[i64]) -> Vec<PairingKey> {
+    commander_ids
+        .iter()
+        .flat_map(|primary_commander_id| {
+            commander_ids.iter().filter_map(move |secondary_commander_id| {
+                if primary_commander_id == secondary_commander_id {
+                    return None;
+                }
+
+                let primary = u32::try_from(*primary_commander_id).ok()?;
+                let secondary = u32::try_from(*secondary_commander_id).ok()?;
+
+                DrastcModel::is_supported(primary, secondary).then_some(PairingKey {
+                    primary_commander_id: *primary_commander_id,
+                    secondary_commander_id: *secondary_commander_id,
+                })
+            })
         })
         .collect()
 }

--- a/crates/apps/rokbattles-jobs/src/scheduler.rs
+++ b/crates/apps/rokbattles-jobs/src/scheduler.rs
@@ -195,7 +195,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
             match precompute_commander_pairings_data(&reports_store).await {
                 Ok(stats) => {
                     info!(
-                        legendary_commanders = stats.legendary_commanders,
+                        commanders = stats.commanders,
                         observed_pairings = stats.observed_pairings,
                         supported_drastc_pairings = stats.supported_drastc_pairings,
                         scored_drastc_pairings = stats.scored_drastc_pairings,


### PR DESCRIPTION
## What changed

- load all 141 commander IDs from the commander dataset for Combat Lab aggregation and output
- generate every ordered non-self pairing, increasing the precomputed set from 11,990 legendary-only pairs to 19,740 all-commander pairs
- keep DRASTC observations, scores, and confidence restricted to `DrastcModel::is_supported` pairings
- preserve the existing legendary DRASTC reference-range population so this expansion does not recalibrate DRASTC
- update job statistics and scheduler logging to report the full commander count

## Why

The automated job previously used the legendary-only commander list both to filter battle aggregation and to build output documents. That prevented Combat Lab rankings from being generated for lower-rarity commanders.

This PR changes only the automated job. API and frontend support will follow separately.

## Performance

- the MongoDB aggregation remains a single streaming pipeline without facets
- supported DRASTC pairings are filtered lazily instead of allocating the full candidate pairing list first
- the required Combat Lab output vector is preallocated to the exact `N × (N - 1)` size
- existing unordered bulk-write batches remain capped at 1,000 documents

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p rokbattles-jobs` (68 passed)
- `cargo clippy -p rokbattles-jobs --all-targets --all-features --locked -- -D warnings -D clippy::perf`