### PR TITLE
feat(datasets): add combat lab loadout metadata

### DIFF
--- a/datasets/armaments.yaml
+++ b/datasets/armaments.yaml
@@ -20,6 +20,7 @@ armaments:
       zh_CN: "金矿采集速度"
       zh_TW: "金幣採集速度"
     percent: true
+    max_roll: 0.075
 
   3001:
     name:
@@ -42,6 +43,7 @@ armaments:
       zh_CN: "步兵单位攻击力"
       zh_TW: "步兵攻擊力"
     percent: true
+    max_roll: 0.035
 
   3002:
     name:
@@ -64,6 +66,7 @@ armaments:
       zh_CN: "骑兵单位攻击力"
       zh_TW: "騎兵攻擊力"
     percent: true
+    max_roll: 0.035
 
   3003:
     name:
@@ -86,6 +89,7 @@ armaments:
       zh_CN: "弓兵单位攻击力"
       zh_TW: "弓兵攻擊力"
     percent: true
+    max_roll: 0.035
 
   3004:
     name:
@@ -108,6 +112,7 @@ armaments:
       zh_CN: "攻城单位攻击力"
       zh_TW: "攻城單位攻擊力"
     percent: true
+    max_roll: 0.035
 
   3008:
     name:
@@ -174,6 +179,7 @@ armaments:
       zh_CN: "步兵单位防御力"
       zh_TW: "步兵防禦力"
     percent: true
+    max_roll: 0.035
 
   4002:
     name:
@@ -196,6 +202,7 @@ armaments:
       zh_CN: "骑兵单位防御力"
       zh_TW: "騎兵防禦力"
     percent: true
+    max_roll: 0.035
 
   4003:
     name:
@@ -218,6 +225,7 @@ armaments:
       zh_CN: "弓兵单位防御力"
       zh_TW: "弓兵防禦力"
     percent: true
+    max_roll: 0.035
 
   4004:
     name:
@@ -240,6 +248,7 @@ armaments:
       zh_CN: "攻城单位防御力"
       zh_TW: "攻城單位防禦力"
     percent: true
+    max_roll: 0.035
 
   5001:
     name:
@@ -262,6 +271,7 @@ armaments:
       zh_CN: "步兵单位生命值"
       zh_TW: "步兵生命值"
     percent: true
+    max_roll: 0.035
 
   5002:
     name:
@@ -284,6 +294,7 @@ armaments:
       zh_CN: "骑兵单位生命值"
       zh_TW: "騎兵生命值"
     percent: true
+    max_roll: 0.035
 
   5003:
     name:
@@ -306,6 +317,7 @@ armaments:
       zh_CN: "弓兵单位生命值"
       zh_TW: "弓兵生命值"
     percent: true
+    max_roll: 0.035
 
   5004:
     name:
@@ -328,6 +340,7 @@ armaments:
       zh_CN: "攻城单位生命值"
       zh_TW: "攻城單位生命值"
     percent: true
+    max_roll: 0.035
 
   5501:
     name:
@@ -614,6 +627,7 @@ armaments:
       zh_CN: "步兵速度"
       zh_TW: "步兵行軍速度"
     percent: true
+    max_roll: 0.035
 
   6002:
     name:
@@ -636,6 +650,7 @@ armaments:
       zh_CN: "骑兵速度"
       zh_TW: "騎兵行軍速度"
     percent: true
+    max_roll: 0.035
 
   6003:
     name:
@@ -658,6 +673,7 @@ armaments:
       zh_CN: "弓兵速度"
       zh_TW: "弓兵行軍速度"
     percent: true
+    max_roll: 0.035
 
   6004:
     name:
@@ -680,6 +696,7 @@ armaments:
       zh_CN: "攻城单位速度"
       zh_TW: "攻城單位行軍速度"
     percent: true
+    max_roll: 0.035
 
   8000:
     name:
@@ -702,6 +719,7 @@ armaments:
       zh_CN: "部队负载"
       zh_TW: "全軍負載"
     percent: true
+    max_roll: 0.07
 
   10002:
     name:
@@ -724,6 +742,7 @@ armaments:
       zh_CN: "所有伤害"
       zh_TW: "所有傷害"
     percent: true
+    max_roll: 0.02
 
   10006:
     name:
@@ -812,6 +831,7 @@ armaments:
       zh_CN: "对野蛮人的伤害"
       zh_TW: "對野蠻人的傷害"
     percent: true
+    max_roll: 0.07
 
   10020:
     name:
@@ -944,6 +964,7 @@ armaments:
       zh_CN: "野蛮人伤害减免"
       zh_TW: "受到的野蠻人傷害"
     percent: true
+    max_roll: 0.07
 
   10103:
     name:

--- a/datasets/equipment.yaml
+++ b/datasets/equipment.yaml
@@ -171,16 +171,6 @@ equipment:
       zh_CN: "饰品"
       zh_TW: "飾品"
 
-  # Missing:
-  # N_46 Dusk Visage
-  # N_47 Shadow of the Sands
-  # N_48 Yin and Yang
-  # N_49 Thoth's Sacrifice
-  # N_50 Udor's Legs
-  # N_301 Curio - Riding Crop
-  # N_302 Curio - Footman's Pledge
-  # N_303 Curio - Bowman's Pin
-  # N_304 Curio - Besieger's Brooch
   item:
     20001:
       name:
@@ -202,6 +192,7 @@ equipment:
         vi: "Quyền Lực Thần Thánh"
         zh_CN: "耀世·神圣裁决"
         zh_TW: "耀世·神聖裁決"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_5.png
 
@@ -225,6 +216,7 @@ equipment:
         vi: "Búa nhật nguyệt"
         zh_CN: "降临·日月之锤"
         zh_TW: "降臨.日月之鎚"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_6.png
 
@@ -248,6 +240,7 @@ equipment:
         vi: "Vụ nổ Hydra"
         zh_CN: "疾风·九头蛇弩"
         zh_TW: "疾風.九頭蛇弩"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_4.png
 
@@ -271,6 +264,7 @@ equipment:
         vi: "Niềm tự hào của Thành Cát Tư Hãn"
         zh_CN: "野势·可汗之怒"
         zh_TW: "野勢·可汗之怒"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_3.png
 
@@ -294,6 +288,7 @@ equipment:
         vi: "Mũ giáp của Kẻ Chinh Phạt"
         zh_CN: "征服·王者之盔"
         zh_TW: "征服.王者之盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_1.png
 
@@ -317,6 +312,7 @@ equipment:
         vi: "Mặt nạ tổ tiên của đêm tối"
         zh_CN: "暗夜·诅咒面罩"
         zh_TW: "暗夜.詛咒面罩"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_2.png
 
@@ -340,6 +336,7 @@ equipment:
         vi: "Trường Thương Địa Ngục"
         zh_CN: "炼狱焦土长枪"
         zh_TW: "煉獄焦土長槍"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_16.png
 
@@ -363,6 +360,7 @@ equipment:
         vi: "Mũ giáp chiến tranh địa ngục"
         zh_CN: "炼狱焦土战盔"
         zh_TW: "煉獄焦土戰盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_15.png
 
@@ -386,6 +384,7 @@ equipment:
         vi: "Giáp hạng nặng của địa ngục"
         zh_CN: "炼狱焦土重铠"
         zh_TW: "煉獄焦土重鎧"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_17.png
 
@@ -409,6 +408,7 @@ equipment:
         vi: "Vòng tay địa ngục"
         zh_CN: "炼狱焦土臂章"
         zh_TW: "煉獄焦土臂章"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_12.png
 
@@ -432,6 +432,7 @@ equipment:
         vi: "Giáp địa ngục"
         zh_CN: "炼狱焦土裙甲"
         zh_TW: "煉獄焦土裙甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_14.png
 
@@ -455,6 +456,7 @@ equipment:
         vi: "Giày địa ngục"
         zh_CN: "炼狱焦土钢靴"
         zh_TW: "煉獄焦土鋼靴"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_13.png
 
@@ -478,6 +480,7 @@ equipment:
         vi: "Lá chắn của đế chế vĩnh cửu"
         zh_CN: "永恒帝国之盾"
         zh_TW: "永恆帝國之盾"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_48.png
 
@@ -501,6 +504,7 @@ equipment:
         vi: "Mũ giáp vàng của đế chế vĩnh cửu"
         zh_CN: "永恒帝国的金盔"
         zh_TW: "永恆帝國的金盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_33.png
 
@@ -524,6 +528,7 @@ equipment:
         vi: "Giáp Gai Đế Chế Vĩnh Cửu"
         zh_CN: "永恒帝国的刺甲"
         zh_TW: "永恆帝國的刺甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_34.png
 
@@ -547,6 +552,7 @@ equipment:
         vi: "Giáp bắp tay của đế chế vĩnh cửu"
         zh_CN: "永恒帝国的护臂"
         zh_TW: "永恆帝國的護臂"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_32.png
 
@@ -570,6 +576,7 @@ equipment:
         vi: "Giáp ống chân của đế chế vĩnh cửu"
         zh_CN: "永恒帝国的精铁腿甲"
         zh_TW: "永恆帝國的精鐵腿甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_30.png
 
@@ -593,6 +600,7 @@ equipment:
         vi: "Giày cao cổ chắc chắn của đế chế vĩnh cửu"
         zh_CN: "永恒帝国的不破履"
         zh_TW: "永恆帝國的不破履"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_31.png
 
@@ -616,6 +624,7 @@ equipment:
         vi: "Hơi thở của hàm rồng"
         zh_CN: "无踪龙息之弓"
         zh_TW: "無蹤龍息之弓"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_44.png
 
@@ -639,6 +648,7 @@ equipment:
         vi: "Mũ Sắt Hơi Thở Rồng Mất Tích"
         zh_CN: "无踪龙息铁盔"
         zh_TW: "無蹤龍息鐵盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_26.png
 
@@ -662,6 +672,7 @@ equipment:
         vi: "Đĩa của hàm rồng"
         zh_CN: "无踪龙息铠甲"
         zh_TW: "無蹤龍息鎧甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_25.png
 
@@ -685,6 +696,7 @@ equipment:
         vi: "Giáp bắp tay của hàm rồng"
         zh_CN: "无踪龙息护臂"
         zh_TW: "無蹤龍息護臂"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_43.png
 
@@ -708,6 +720,7 @@ equipment:
         vi: "Giáp hàm rồng"
         zh_CN: "无踪龙息裙甲"
         zh_TW: "無蹤龍息裙甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_24.png
 
@@ -731,6 +744,7 @@ equipment:
         vi: "Giày cao cổ của hàm rồng"
         zh_CN: "无踪龙息之履"
         zh_TW: "無蹤龍息之履"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_45.png
 
@@ -754,6 +768,7 @@ equipment:
         vi: "Sự Trả Thù của Quân Đoàn Bóng Tối"
         zh_CN: "暗影军团的复仇"
         zh_TW: "暗影軍團的復仇"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_8.png
 
@@ -777,6 +792,7 @@ equipment:
         vi: "Áo choàng hy vọng"
         zh_CN: "希望斗篷"
         zh_TW: "希望斗篷"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_46.png
 
@@ -800,6 +816,7 @@ equipment:
         vi: "Dải ngân hà"
         zh_CN: "银河之魄"
         zh_TW: "銀河之魄"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_28.png
 
@@ -823,6 +840,7 @@ equipment:
         vi: "Sự kiểm soát của Navar"
         zh_CN: "纳瓦尔的掌控"
         zh_TW: "納瓦爾的掌控"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_18.png
 
@@ -846,6 +864,7 @@ equipment:
         vi: "Kìm linh thiên"
         zh_CN: "神圣之握"
         zh_TW: "神聖之握"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_42.png
 
@@ -869,6 +888,7 @@ equipment:
         vi: "Sự lựa chọn của Ian"
         zh_CN: "伊安的抉择"
         zh_TW: "伊安的抉擇"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_47.png
 
@@ -892,6 +912,7 @@ equipment:
         vi: "Quần Giáp Chiến Thần"
         zh_CN: "沸血战神"
         zh_TW: "沸血戰神"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_49.png
 
@@ -915,6 +936,7 @@ equipment:
         vi: "Đêm vĩnh cửu"
         zh_CN: "暗夜永生"
         zh_TW: "暗夜永生"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_22.png
 
@@ -938,6 +960,7 @@ equipment:
         vi: "Tro tàn bình minh"
         zh_CN: "黎明灰烬"
         zh_TW: "黎明灰燼"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_11.png
 
@@ -961,6 +984,7 @@ equipment:
         vi: "Sự quay lại của Shio"
         zh_CN: "希奥的归途"
         zh_TW: "希奧的歸途"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_27.png
 
@@ -984,6 +1008,7 @@ equipment:
         vi: "Máy ủi núi"
         zh_CN: "千山踏碎"
         zh_TW: "千山踏碎"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_19.png
 
@@ -1007,6 +1032,7 @@ equipment:
         vi: "Giày Chỉ huy"
         zh_CN: "统御者战靴"
         zh_TW: "統御者戰靴"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_21.png
 
@@ -1030,6 +1056,7 @@ equipment:
         vi: "Nhẫn Tận Thế"
         zh_CN: "末日之戒"
         zh_TW: "末日之戒"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_38.png
 
@@ -1053,6 +1080,7 @@ equipment:
         vi: "Vinh quang vĩ đại nhất"
         zh_CN: "极昼之耀"
         zh_TW: "極晝之耀"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_39.png
 
@@ -1076,6 +1104,7 @@ equipment:
         vi: "Ánh Sáng Đêm Trường"
         zh_CN: "永夜之辉"
         zh_TW: "永夜之輝"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_40.png
 
@@ -1099,6 +1128,7 @@ equipment:
         vi: "Chiếc sừng thịnh nộ"
         zh_CN: "狂怒之角"
         zh_TW: "狂怒之角"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_37.png
 
@@ -1122,6 +1152,7 @@ equipment:
         vi: "Dao găm ẩn"
         zh_CN: "无锋匕首"
         zh_TW: "無鋒匕首"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_23.png
 
@@ -1145,6 +1176,7 @@ equipment:
         vi: "Lưới Mora"
         zh_CN: "莫拉的蜘蛛网"
         zh_TW: "莫拉的蜘蛛網"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_35.png
 
@@ -1168,6 +1200,7 @@ equipment:
         vi: "Đồng tiền may mắn của Scolas"
         zh_CN: "斯科拉斯的幸运硬币"
         zh_TW: "斯科拉斯的幸運硬幣"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_41.png
 
@@ -1191,6 +1224,7 @@ equipment:
         vi: "Báo thù"
         zh_CN: "复仇者之怒"
         zh_TW: "復仇者之怒"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_36.png
 
@@ -1214,6 +1248,7 @@ equipment:
         vi: "Thử Thách Vương Quốc Đã Mất"
         zh_CN: "失落之地的试炼"
         zh_TW: "失落之地的試煉"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_20.png
 
@@ -1237,6 +1272,7 @@ equipment:
         vi: "Mũ giáp hồi sinh"
         zh_CN: "复兴者头盔"
         zh_TW: "復興者頭盔"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_7.png
 
@@ -1260,6 +1296,7 @@ equipment:
         vi: "Đĩa hồi sinh"
         zh_CN: "复兴者铠甲"
         zh_TW: "復興者鎧甲"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_5.png
 
@@ -1283,6 +1320,7 @@ equipment:
         vi: "Găng tay hồi sinh"
         zh_CN: "复兴者手套"
         zh_TW: "復興者手套"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_6.png
 
@@ -1306,6 +1344,7 @@ equipment:
         vi: "Giáp ống chân hồi sinh"
         zh_CN: "复兴者腿甲"
         zh_TW: "復興者腿甲"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_8.png
 
@@ -1329,6 +1368,7 @@ equipment:
         vi: "Vương trượng của Lính gác rừng"
         zh_CN: "密林守卫的神杖"
         zh_TW: "密林守衛的神杖"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_18.png
 
@@ -1352,6 +1392,7 @@ equipment:
         vi: "Áo của Lính gác rừng"
         zh_CN: "密林守卫的鬼面"
         zh_TW: "密林守衛的鬼面"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_16.png
 
@@ -1375,6 +1416,7 @@ equipment:
         vi: "Áo choàng của Lính gác rừng"
         zh_CN: "密林守卫的长袍"
         zh_TW: "密林守衛的長袍"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_19.png
 
@@ -1398,6 +1440,7 @@ equipment:
         vi: "Vuốt của Lính gác rừng"
         zh_CN: "密林守卫的利爪"
         zh_TW: "密林守衛的利爪"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_17.png
 
@@ -1421,6 +1464,7 @@ equipment:
         vi: "Hoa anh đào Fukubuki"
         zh_CN: "樱落"
         zh_TW: "櫻落"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_28.png
 
@@ -1444,6 +1488,7 @@ equipment:
         vi: "Thời đại vàng"
         zh_CN: "流金岁月"
         zh_TW: "流金歲月"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_27.png
 
@@ -1467,6 +1512,7 @@ equipment:
         vi: "Trái tim Thánh nữ"
         zh_CN: "圣者之心"
         zh_TW: "聖者之心"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_22.png
 
@@ -1490,6 +1536,7 @@ equipment:
         vi: "Sự u buồn vực thẳm"
         zh_CN: "深渊凝视"
         zh_TW: "深淵凝視"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_24.png
 
@@ -1513,6 +1560,7 @@ equipment:
         vi: "Dòng dõi phù thủy"
         zh_CN: "魔女之裔"
         zh_TW: "魔女之裔"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_20.png
 
@@ -1536,6 +1584,7 @@ equipment:
         vi: "Phước lành của chúa tể bóng tối"
         zh_CN: "索隆的护佑"
         zh_TW: "索隆的護佑"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_25.png
 
@@ -1559,6 +1608,7 @@ equipment:
         vi: "Linh Hồn Của Quinn"
         zh_CN: "奎因之魂"
         zh_TW: "奎因之魂"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_15.png
 
@@ -1582,6 +1632,7 @@ equipment:
         vi: "Sự đau đớn của Iset"
         zh_CN: "伊西斯的隐忍"
         zh_TW: "伊西斯的隱忍"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_26.png
 
@@ -1605,6 +1656,7 @@ equipment:
         vi: "Sự tàn bạo của Seth"
         zh_CN: "赛特的残暴"
         zh_TW: "賽特的殘暴"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_23.png
 
@@ -1628,6 +1680,7 @@ equipment:
         vi: "Sự nhân văn của Karuak"
         zh_CN: "卡鲁拉克的谦逊"
         zh_TW: "卡魯拉克的謙遜"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_13.png
 
@@ -1651,6 +1704,7 @@ equipment:
         vi: "Giáp cuồng tín"
         zh_CN: "狂热者裙甲"
         zh_TW: "狂熱者裙甲"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_14.png
 
@@ -1674,6 +1728,7 @@ equipment:
         vi: "Đấu sĩ"
         zh_CN: "角斗士"
         zh_TW: "角鬥士"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_12.png
 
@@ -1697,6 +1752,7 @@ equipment:
         vi: "Tay đua trên mây"
         zh_CN: "彩云追月"
         zh_TW: "彩雲追月"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_1.png
 
@@ -1720,6 +1776,7 @@ equipment:
         vi: "Bước chân sương giá"
         zh_CN: "寒冰之境"
         zh_TW: "寒冰之境"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_9.png
 
@@ -1743,6 +1800,7 @@ equipment:
         vi: "Bước chân lửa"
         zh_CN: "火凤燎原"
         zh_TW: "火鳳燎原"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_11.png
 
@@ -1766,6 +1824,7 @@ equipment:
         vi: "Mặt Dây Chuyền Thi Sĩ"
         zh_CN: "吟游诗人的咏叹"
         zh_TW: "吟遊詩人的詠嘆"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_4.png
 
@@ -1789,6 +1848,7 @@ equipment:
         vi: "Phán Xử Im Lặng"
         zh_CN: "沉寂审判"
         zh_TW: "沉寂審判"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_2.png
 
@@ -1812,6 +1872,7 @@ equipment:
         vi: "Bùa Hộ Mệnh Delane"
         zh_CN: "德莱恩的护符"
         zh_TW: "德萊恩的護符"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_3.png
 
@@ -1835,6 +1896,7 @@ equipment:
         vi: "Lưỡi hái của Peter"
         zh_CN: "皮特的镰刀"
         zh_TW: "皮特的鐮刀"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_21.png
 
@@ -1858,6 +1920,7 @@ equipment:
         vi: "Nhẫn màu đỏ thẫm"
         zh_CN: "赤血之戒"
         zh_TW: "赤血之戒"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_10.png
 
@@ -1881,6 +1944,7 @@ equipment:
         vi: "Khăn trùm người gặt"
         zh_CN: "收获者头巾"
         zh_TW: "收穫者頭巾"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_12.png
 
@@ -1904,6 +1968,7 @@ equipment:
         vi: "Áo choàng người gặt"
         zh_CN: "收获者罩袍"
         zh_TW: "收穫者罩袍"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_13.png
 
@@ -1927,6 +1992,7 @@ equipment:
         vi: "Ống Quần Người Thu Hoạch"
         zh_CN: "收获者长裤"
         zh_TW: "收穫者長褲"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_14.png
 
@@ -1950,6 +2016,7 @@ equipment:
         vi: "Giày người gặt"
         zh_CN: "收获者筒靴"
         zh_TW: "收穫者筒靴"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_15.png
 
@@ -1973,6 +2040,7 @@ equipment:
         vi: "Giáp chiến tranh lộng gió"
         zh_CN: "狂风战盔"
         zh_TW: "狂風戰盔"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_6.png
 
@@ -1996,6 +2064,7 @@ equipment:
         vi: "Giáp ngực lộng gió"
         zh_CN: "狂风胸甲"
         zh_TW: "狂風胸甲"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_4.png
 
@@ -2019,6 +2088,7 @@ equipment:
         vi: "Giáp tay lộng gió"
         zh_CN: "狂风护腕"
         zh_TW: "狂風護腕"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_3.png
 
@@ -2042,6 +2112,7 @@ equipment:
         vi: "Giày lộng gió"
         zh_CN: "狂风长靴"
         zh_TW: "狂風長靴"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_5.png
 
@@ -2065,6 +2136,7 @@ equipment:
         vi: "Rìu lửa"
         zh_CN: "炽炎之斧"
         zh_TW: "熾炎之斧"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_1.png
 
@@ -2088,6 +2160,7 @@ equipment:
         vi: "Gậy Mất mát"
         zh_CN: "失落之杖"
         zh_TW: "失落之杖"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_7.png
 
@@ -2111,6 +2184,7 @@ equipment:
         vi: "Khiên của người giữ cửa"
         zh_CN: "名门之盾"
         zh_TW: "名門之盾"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_10.png
 
@@ -2134,6 +2208,7 @@ equipment:
         vi: "Mũ giáp Chinh phạt"
         zh_CN: "远征战盔"
         zh_TW: "遠征戰盔"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_19.png
 
@@ -2157,6 +2232,7 @@ equipment:
         vi: "Áo giáp nặng của Chỉ huy"
         zh_CN: "指挥官重铠"
         zh_TW: "指揮官重鎧"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_20.png
 
@@ -2180,6 +2256,7 @@ equipment:
         vi: "Bài thánh ca"
         zh_CN: "圣女之歌"
         zh_TW: "聖女之歌"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_11.png
 
@@ -2203,6 +2280,7 @@ equipment:
         vi: "Bàn tay của Calvin"
         zh_CN: "卡尔文之手"
         zh_TW: "卡爾文之手"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_2.png
 
@@ -2226,6 +2304,7 @@ equipment:
         vi: "Giáp ống chân của người bị tù đày biệt xứ"
         zh_CN: "流放者胫甲"
         zh_TW: "流放者脛甲"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_8.png
 
@@ -2249,6 +2328,7 @@ equipment:
         vi: "Ống quần lính gác"
         zh_CN: "守望者长裤"
         zh_TW: "守望者長褲"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_17.png
 
@@ -2272,6 +2352,7 @@ equipment:
         vi: "Chó săn đỏ"
         zh_CN: "猩红猎犬"
         zh_TW: "猩紅獵犬"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_16.png
 
@@ -2295,6 +2376,7 @@ equipment:
         vi: "Kêu gọi sự trung thành"
         zh_CN: "忠诚召唤"
         zh_TW: "忠誠召喚"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_21.png
 
@@ -2318,6 +2400,7 @@ equipment:
         vi: "Vòng cổ xương người của Lohar"
         zh_CN: "洛哈的兽骨项链"
         zh_TW: "洛哈的獸骨項鏈"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_9.png
 
@@ -2341,6 +2424,7 @@ equipment:
         vi: "Vật tổ man rợ"
         zh_CN: "野蛮图腾"
         zh_TW: "野蠻圖騰"
+      rarity: elite
       sprite:
         - img_icon_item_equip_3_18.png
 
@@ -2364,6 +2448,7 @@ equipment:
         vi: "Kích Tiên phong"
         zh_CN: "先锋长戟"
         zh_TW: "先鋒長戟"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_9.png
 
@@ -2387,6 +2472,7 @@ equipment:
         vi: "Giám ống chân của quân tiên phong"
         zh_CN: "先锋胫甲"
         zh_TW: "先鋒脛甲"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_8.png
 
@@ -2410,6 +2496,7 @@ equipment:
         vi: "Thanh đao phước lành"
         zh_CN: "福佑之刃"
         zh_TW: "福佑之刃"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_3.png
 
@@ -2433,6 +2520,7 @@ equipment:
         vi: "Mũ giáp của sự sợ hãi"
         zh_CN: "敬畏之盔"
         zh_TW: "敬畏之盔"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_4.png
 
@@ -2456,6 +2544,7 @@ equipment:
         vi: "Mũ giáp phượng hoàng"
         zh_CN: "凤翅盔"
         zh_TW: "鳳翅盔"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_1.png
 
@@ -2479,6 +2568,7 @@ equipment:
         vi: "Áo giáp bộ binh"
         zh_CN: "步人甲"
         zh_TW: "步人甲"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_2.png
 
@@ -2502,6 +2592,7 @@ equipment:
         vi: "Đĩa Milanese"
         zh_CN: "米兰盔甲"
         zh_TW: "米蘭盔甲"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_5.png
 
@@ -2525,6 +2616,7 @@ equipment:
         vi: "Quần Lính cảnh binh"
         zh_CN: "游侠长裤"
         zh_TW: "遊俠長褲"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_12.png
 
@@ -2548,6 +2640,7 @@ equipment:
         vi: "Găng tay da"
         zh_CN: "皮革手套"
         zh_TW: "皮革手套"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_6.png
 
@@ -2571,6 +2664,7 @@ equipment:
         vi: "Áo choàng bằng đồng"
         zh_CN: "青铜护腕"
         zh_TW: "青銅護腕"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_7.png
 
@@ -2594,6 +2688,7 @@ equipment:
         vi: "Giày Mũi Nhọn"
         zh_CN: "刃靴"
         zh_TW: "刃靴"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_10.png
 
@@ -2617,6 +2712,7 @@ equipment:
         vi: "Giày cổ cao"
         zh_CN: "敬畏之靴"
         zh_TW: "敬畏之靴"
+      rarity: advanced
       sprite:
         - img_icon_item_equip_2_11.png
 
@@ -2640,6 +2736,7 @@ equipment:
         vi: "Kiếm dài sắt bén"
         zh_CN: "锋利长剑"
         zh_TW: "鋒利長劍"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_3.png
 
@@ -2663,6 +2760,7 @@ equipment:
         vi: "Mũ sắt"
         zh_CN: "铁制头盔"
         zh_TW: "鐵製頭盔"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_2.png
 
@@ -2686,6 +2784,7 @@ equipment:
         vi: "Thư chuỗi"
         zh_CN: "锁子甲"
         zh_TW: "鎖子甲"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_1.png
 
@@ -2709,6 +2808,7 @@ equipment:
         vi: "Quần ống túm thô"
         zh_CN: "粗布裤子"
         zh_TW: "粗布褲子"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_4.png
 
@@ -2732,6 +2832,7 @@ equipment:
         vi: "Găng tay vải"
         zh_CN: "棉麻手套"
         zh_TW: "棉麻手套"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_5.png
 
@@ -2755,6 +2856,7 @@ equipment:
         vi: "Giày cao gót chắc chắn"
         zh_CN: "耐用的布鞋"
         zh_TW: "耐用的布鞋"
+      rarity: normal
       sprite:
         - img_icon_item_equip_1_6.png
 
@@ -2778,6 +2880,7 @@ equipment:
         vi: "Trống Trận Karuak"
         zh_CN: "克拉克的战鼓"
         zh_TW: "克拉克的戰鼓"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_51.png
 
@@ -2801,6 +2904,7 @@ equipment:
         vi: "Tiếng Gọi Của Seth"
         zh_CN: "赛特的呼唤"
         zh_TW: "賽特的呼喚"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_52.png
 
@@ -2824,6 +2928,7 @@ equipment:
         vi: "Sẹo Gió"
         zh_CN: "凛风之痕"
         zh_TW: "凜風之痕"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_29.png
 
@@ -2847,6 +2952,7 @@ equipment:
         vi: "Mưu Kế Cổ Xưa"
         zh_CN: "上古兵书"
         zh_TW: "上古兵書"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_30.png
 
@@ -2870,6 +2976,7 @@ equipment:
         vi: "Mũ Nộ Mục Thương Lang"
         zh_CN: "黄昏揭示者"
         zh_TW: "蒼狼的怒目頭盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_55.png
 
@@ -2893,6 +3000,7 @@ equipment:
         vi: "Giáp Da Hộ Vệ Thương Lang"
         zh_CN: "苍狼的怒目头盔"
         zh_TW: "蒼狼的守護皮甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_54.png
 
@@ -2916,6 +3024,7 @@ equipment:
         vi: "Yết Thị Hoàng Hôn"
         zh_CN: "苍狼的守护皮甲"
         zh_TW: "黃昏揭示者"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_53.png
 
@@ -2939,6 +3048,7 @@ equipment:
         vi: "Găng Tay Bi Minh Thương Lang"
         zh_CN: "苍狼的悲鸣护手"
         zh_TW: "蒼狼的悲鳴護手"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_57.png
 
@@ -2962,6 +3072,7 @@ equipment:
         vi: "Quần Da Cao Ngạo Thương Lang"
         zh_CN: "苍狼的孤高皮裙"
         zh_TW: "蒼狼的孤高皮裙"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_56.png
 
@@ -2985,6 +3096,7 @@ equipment:
         vi: "Giày Đinh Gầm Rú Thương Lang"
         zh_CN: "苍狼的咆哮刃靴"
         zh_TW: "蒼狼的咆哮刃靴"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_58.png
 
@@ -3008,6 +3120,7 @@ equipment:
         vi: "Giáp Tay Bạc Màu Kỵ Sĩ"
         zh_CN: "骑士誓约之弓"
         zh_TW: "騎士銳痕手鎧"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_33.png
 
@@ -3031,6 +3144,7 @@ equipment:
         vi: "Quần Giáp Thắng Lợi Kỵ Sĩ"
         zh_CN: "骑士钢铁护额"
         zh_TW: "騎士勝利裙甲"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_32.png
 
@@ -3054,6 +3168,7 @@ equipment:
         vi: "Ủng Chiến Lãnh Phong Kỵ Sĩ"
         zh_CN: "骑士英魂披风"
         zh_TW: "騎士冷鋒戰靴"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_31.png
 
@@ -3077,6 +3192,7 @@ equipment:
         vi: "Băng Trán Gang Thép Kỵ Sĩ"
         zh_CN: "骑士锐痕手铠"
         zh_TW: "騎士鋼鐵護額"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_35.png
 
@@ -3100,6 +3216,7 @@ equipment:
         vi: "Áo Khoác Anh Hồn Kỵ Sĩ"
         zh_CN: "骑士胜利裙甲"
         zh_TW: "騎士英魂披風"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_34.png
 
@@ -3123,6 +3240,7 @@ equipment:
         vi: "Cung Thệ Ước Kỵ Sĩ"
         zh_CN: "骑士冷锋战靴"
         zh_TW: "騎士誓約之弓"
+      rarity: epic
       sprite:
         - img_icon_item_equip_4_36.png
 
@@ -3146,6 +3264,7 @@ equipment:
         vi: "Trượng Than Thở Vu Chúc"
         zh_CN: "巫祝的咏叹之杖"
         zh_TW: "巫祝的詠嘆之杖"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_6.png
 
@@ -3169,6 +3288,7 @@ equipment:
         vi: "Mão Tóc Khô Mộc Vu Chúc"
         zh_CN: "巫祝的枯木发冠"
         zh_TW: "巫祝的枯木髮冠"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_2.png
 
@@ -3192,6 +3312,7 @@ equipment:
         vi: "Áo Choàng Mê Chú Vu Chúc"
         zh_CN: "巫祝的迷咒斗篷"
         zh_TW: "巫祝的迷咒斗篷"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_4.png
 
@@ -3215,6 +3336,7 @@ equipment:
         vi: "Giáp Tay Sắc Đỏ Vu Chúc"
         zh_CN: "巫祝的赤色护腕"
         zh_TW: "巫祝的赤色護腕"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_1.png
 
@@ -3238,6 +3360,7 @@ equipment:
         vi: "Quần Dài Lấp Lánh Vu Chúc"
         zh_CN: "巫祝的流光长裤"
         zh_TW: "巫祝的流光長褲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_3.png
 
@@ -3261,6 +3384,7 @@ equipment:
         vi: "Giày Ngắn Bùn Lầy Vu Chúc"
         zh_CN: "巫祝的泥泞短靴"
         zh_TW: "巫祝的泥濘短靴"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_6_5.png
 
@@ -3284,6 +3408,7 @@ equipment:
         vi: "Quyền Trượng Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的权杖"
         zh_TW: "輝煌女神的權杖"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_62.png
 
@@ -3307,6 +3432,7 @@ equipment:
         vi: "Kim Khôi Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的金盔"
         zh_TW: "輝煌女神的金盔"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_63.png
 
@@ -3330,6 +3456,7 @@ equipment:
         vi: "Chiến Y Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的战衣"
         zh_TW: "輝煌女神的戰衣"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_59.png
 
@@ -3353,6 +3480,7 @@ equipment:
         vi: "Giáp Tay Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的腕甲"
         zh_TW: "輝煌女神的腕甲"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_61.png
 
@@ -3376,6 +3504,7 @@ equipment:
         vi: "Xà Cạp Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的绑腿"
         zh_TW: "輝煌女神的綁腿"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_64.png
 
@@ -3399,6 +3528,7 @@ equipment:
         vi: "Giày Chiến Nữ Thần Huy Hoàng"
         zh_CN: "辉煌女神的战靴"
         zh_TW: "輝煌女神的戰靴"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_5_60.png
 
@@ -3422,6 +3552,7 @@ equipment:
         vi: "Lông Vũ Cháy Trụi"
         zh_CN: "焚烬之羽"
         zh_TW: "焚燼之羽"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_7_1.png
 
@@ -3445,6 +3576,7 @@ equipment:
         vi: "Chuôi Kiếm Anh Hùng"
         zh_CN: "传奇剑柄"
         zh_TW: "傳奇劍柄"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_10_3.png
 
@@ -3468,6 +3600,7 @@ equipment:
         vi: "Yên Ngựa Ngàn Lời Chúc"
         zh_CN: "万福金鞍"
         zh_TW: "萬福金鞍"
+      rarity: legendary
       sprite:
         - img_icon_item_equip_9_3.png
 
@@ -3491,6 +3624,7 @@ equipment:
         vi: "Bí Vật – Cờ Hiệu Thiết Kỵ"
         zh_CN: "秘饰·铁骑之旌"
         zh_TW: "秘飾·鐵騎之旌"
+      rarity: legendary
       sprite:
         - img_icon_item_S11treasure2.png
 
@@ -3514,6 +3648,7 @@ equipment:
         vi: "Bí Vật – Ghim Cài Cuồng Chiến"
         zh_CN: "秘饰·狂战胸针"
         zh_TW: "秘飾·狂戰胸針"
+      rarity: legendary
       sprite:
         - img_icon_item_S11treasure1.png
 
@@ -3537,6 +3672,7 @@ equipment:
         vi: "Bí Vật – Mũi Tên Phá Hồn"
         zh_CN: "秘饰·破魂羽矢"
         zh_TW: "秘飾·破魂羽矢"
+      rarity: legendary
       sprite:
         - img_icon_item_S11treasure3.png
 
@@ -3560,6 +3696,7 @@ equipment:
         vi: "Bí Vật - Đai Lưng Megingjörð"
         zh_CN: "秘饰·雷神腰带"
         zh_TW: "秘飾·雷神腰帶"
+      rarity: legendary
       sprite:
         - img_icon_item_S19treasure1.png
 
@@ -3583,5 +3720,6 @@ equipment:
         vi: "Bí Vật - Huy Hiệu Nike"
         zh_CN: "秘饰·胜耀之徽"
         zh_TW: "秘飾・勝耀之徽"
+      rarity: legendary
       sprite:
         - img_icon_item_S20treasure1.png


### PR DESCRIPTION
## Summary

- add canonical maximum armament roll values
- add equipment rarity metadata using the game quality mapping
- keep localization names, rarity, and sprites grouped consistently

## Why

The new Combat Lab aggregation needs armament maximums and equipment rarity without reading runtime Excel exports or generated JSON projections.

## Impact

This establishes the YAML source of truth consumed by the scheduler and API branches later in this stack.

## Validation

- dataset generation
- scheduler catalog tests
- site TypeScript typecheck
- `git diff --check`