### PR TITLE
feat(jobs): add combat lab v2 precompute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,11 +4383,13 @@ dependencies = [
  "rokbattles-bson",
  "rokbattles-drastc",
  "sentry",
+ "serde",
  "thiserror 2.0.19",
  "tokio",
  "tokio-cron-scheduler",
  "tracing",
  "tracing-subscriber",
+ "yaml_serde",
 ]
 
 [[package]]

--- a/crates/apps/rokbattles-api/src/db/reports_store.rs
+++ b/crates/apps/rokbattles-api/src/db/reports_store.rs
@@ -27,6 +27,7 @@ pub struct ReportsStore {
     g_rok_prec_kahartreasure: Collection<Document>,
     g_rok_prec_karuakceremony: Collection<Document>,
     g_rok_prec_cmdr_pairings: Collection<Document>,
+    g_rok_prec_cmdr_pairings_v2: Collection<Document>,
 }
 
 impl ReportsStore {
@@ -52,6 +53,7 @@ impl ReportsStore {
             g_rok_prec_kahartreasure: db.collection("g_rok_prec_kahartreasure"),
             g_rok_prec_karuakceremony: db.collection("g_rok_prec_karuakceremony"),
             g_rok_prec_cmdr_pairings: db.collection("g_rok_prec_cmdr_pairings"),
+            g_rok_prec_cmdr_pairings_v2: db.collection("g_rok_prec_cmdr_pairings_v2"),
         }
     }
 
@@ -419,6 +421,10 @@ impl ReportsStore {
             self.g_rok_prec_cmdr_pairings.create_index(model).await?;
         }
 
+        for model in precomputed_commander_pairing_v2_indexes() {
+            self.g_rok_prec_cmdr_pairings_v2.create_index(model).await?;
+        }
+
         Ok(())
     }
 
@@ -510,5 +516,34 @@ impl ReportsStore {
     /// Access precomputed global commander pairing aggregates.
     pub fn precomputed_commander_pairings_collection(&self) -> &Collection<Document> {
         &self.g_rok_prec_cmdr_pairings
+    }
+
+    /// Access compact, chunked Combat Lab commander pairing aggregates.
+    pub fn precomputed_commander_pairings_v2_collection(&self) -> &Collection<Document> {
+        &self.g_rok_prec_cmdr_pairings_v2
+    }
+}
+
+fn precomputed_commander_pairing_v2_indexes() -> [IndexModel; 2] {
+    [
+        IndexModel::builder()
+            .keys(doc! { "k": 1, "p": 1, "s": 1, "g": -1, "m": 1, "q": 1 })
+            .options(IndexOptions::builder().unique(true).build())
+            .build(),
+        IndexModel::builder().keys(doc! { "g": 1 }).build(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_commander_pairing_indexes_support_generation_reads_and_cleanup() {
+        let [documents, generations] = precomputed_commander_pairing_v2_indexes();
+
+        assert_eq!(documents.keys, doc! { "k": 1, "p": 1, "s": 1, "g": -1, "m": 1, "q": 1 });
+        assert_eq!(documents.options.and_then(|options| options.unique), Some(true));
+        assert_eq!(generations.keys, doc! { "g": 1 });
     }
 }

--- a/crates/apps/rokbattles-jobs/Cargo.toml
+++ b/crates/apps/rokbattles-jobs/Cargo.toml
@@ -11,12 +11,14 @@ futures = { workspace = true, features = ["std"] }
 mongodb = { workspace = true }
 rokbattles-api = { path = "../rokbattles-api" }
 rokbattles-bson = { path = "../../common/rokbattles-bson" }
+serde = { workspace = true, features = ["derive"] }
 sentry = { workspace = true, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tokio-cron-scheduler = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+yaml_serde = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 mimalloc = { workspace = true, features = ["secure"] }

--- a/crates/apps/rokbattles-jobs/src/error.rs
+++ b/crates/apps/rokbattles-jobs/src/error.rs
@@ -13,8 +13,14 @@ pub enum JobsError {
     Scheduler(#[from] tokio_cron_scheduler::JobSchedulerError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    BsonSerialization(#[from] mongodb::bson::ser::Error),
+    #[error(transparent)]
+    Yaml(#[from] yaml_serde::Error),
     #[error("MONGODB_URI must include a default database")]
     MissingDatabase,
     #[error("Commander dataset contains no legendary commanders")]
     MissingLegendaryCommanders,
+    #[error("invalid Combat Lab data: {0}")]
+    InvalidCombatLabData(String),
 }

--- a/crates/apps/rokbattles-jobs/src/lib.rs
+++ b/crates/apps/rokbattles-jobs/src/lib.rs
@@ -8,6 +8,7 @@ pub mod precompute_barbarian;
 pub mod precompute_barbarianfort;
 pub mod precompute_baulur;
 pub mod precompute_cmdr_pairings;
+pub mod precompute_cmdr_pairings_v2;
 pub mod precompute_kahar_treasure;
 pub mod precompute_karuak_ceremony;
 pub mod refresh_binds;

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings/mod.rs
@@ -156,7 +156,7 @@ async fn write_pairing_documents(
     Ok(documents_written)
 }
 
-fn legendary_commander_ids() -> Result<Vec<i64>, JobsError> {
+pub(crate) fn legendary_commander_ids() -> Result<Vec<i64>, JobsError> {
     let mut ids = BTreeSet::new();
     let mut current_id = None;
     let mut current_is_legendary = false;

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/catalog.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/catalog.rs
@@ -1,0 +1,167 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use super::model::InscriptionRarity;
+use crate::error::JobsError;
+
+const INSCRIPTIONS_YAML: &str = include_str!("../../../../../datasets/inscriptions.yaml");
+const ARMAMENTS_YAML: &str = include_str!("../../../../../datasets/armaments.yaml");
+const EQUIPMENT_YAML: &str = include_str!("../../../../../datasets/equipment.yaml");
+
+#[derive(Debug)]
+pub(super) struct Catalogs {
+    pub(super) inscriptions: HashMap<i64, InscriptionRarity>,
+    pub(super) armament_max_rolls: HashMap<i64, f64>,
+    pub(super) equipment_qualities: HashMap<i64, i64>,
+}
+
+impl Catalogs {
+    pub(super) fn load() -> Result<Self, JobsError> {
+        let inscriptions = read_inscriptions()?;
+        let armament_max_rolls = read_armament_rolls()?;
+        let equipment_qualities = read_equipment_qualities()?;
+        if inscriptions.is_empty()
+            || armament_max_rolls.is_empty()
+            || equipment_qualities.is_empty()
+        {
+            return Err(JobsError::InvalidCombatLabData(
+                "one or more embedded game catalogs are empty".to_owned(),
+            ));
+        }
+
+        Ok(Self { inscriptions, armament_max_rolls, equipment_qualities })
+    }
+}
+
+fn read_inscriptions() -> Result<HashMap<i64, InscriptionRarity>, JobsError> {
+    let dataset: InscriptionDataset = yaml_serde::from_str(INSCRIPTIONS_YAML)?;
+    Ok(dataset
+        .inscriptions
+        .into_iter()
+        .filter(|(id, _)| *id > 0)
+        .map(|(id, definition)| {
+            let rarity = match definition.rarity {
+                DatasetInscriptionRarity::Common => InscriptionRarity::Common,
+                DatasetInscriptionRarity::Rare => InscriptionRarity::Rare,
+                DatasetInscriptionRarity::Special => InscriptionRarity::Special,
+            };
+            (id, rarity)
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct InscriptionDataset {
+    inscriptions: HashMap<i64, InscriptionDefinition>,
+}
+
+#[derive(Deserialize)]
+struct InscriptionDefinition {
+    rarity: DatasetInscriptionRarity,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum DatasetInscriptionRarity {
+    Common,
+    Rare,
+    Special,
+}
+
+fn read_armament_rolls() -> Result<HashMap<i64, f64>, JobsError> {
+    let dataset: ArmamentDataset = yaml_serde::from_str(ARMAMENTS_YAML)?;
+    Ok(dataset
+        .armaments
+        .into_iter()
+        .filter_map(|(id, definition)| {
+            let maximum = definition.max_roll?;
+            (id > 0 && maximum.is_finite() && maximum >= 0.0).then_some((id, maximum))
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct ArmamentDataset {
+    armaments: HashMap<i64, ArmamentDefinition>,
+}
+
+#[derive(Deserialize)]
+struct ArmamentDefinition {
+    max_roll: Option<f64>,
+}
+
+fn read_equipment_qualities() -> Result<HashMap<i64, i64>, JobsError> {
+    let dataset: EquipmentDataset = yaml_serde::from_str(EQUIPMENT_YAML)?;
+    Ok(dataset
+        .equipment
+        .items
+        .into_iter()
+        .filter(|(id, _)| *id > 0)
+        .map(|(id, definition)| (id, definition.rarity.quality()))
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct EquipmentDataset {
+    equipment: EquipmentCatalog,
+}
+
+#[derive(Deserialize)]
+struct EquipmentCatalog {
+    #[serde(rename = "item")]
+    items: HashMap<i64, EquipmentDefinition>,
+}
+
+#[derive(Deserialize)]
+struct EquipmentDefinition {
+    rarity: EquipmentRarity,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum EquipmentRarity {
+    Normal,
+    Advanced,
+    Elite,
+    Epic,
+    Legendary,
+}
+
+impl EquipmentRarity {
+    const fn quality(&self) -> i64 {
+        match self {
+            Self::Normal => 1,
+            Self::Advanced => 2,
+            Self::Elite => 3,
+            Self::Epic => 4,
+            Self::Legendary => 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yaml_catalogs_resolve_all_three_compact_aggregation_inputs() {
+        let catalogs = Catalogs::load().expect("catalogs");
+
+        assert!(!catalogs.inscriptions.is_empty());
+        assert!(catalogs.armament_max_rolls.values().all(|value| value.is_finite()));
+        assert!(catalogs.equipment_qualities.values().all(|quality| *quality > 0));
+    }
+
+    #[test]
+    fn equipment_rarities_map_to_game_quality_values() {
+        assert_eq!(EquipmentRarity::Legendary.quality(), 5);
+    }
+
+    #[test]
+    fn armament_yaml_contains_expected_maximum_rolls() {
+        let maximums = read_armament_rolls().expect("armament rolls");
+
+        assert_eq!(maximums.get(&3_001), Some(&0.035));
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/loadout.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/loadout.rs
@@ -1,0 +1,338 @@
+use std::collections::HashMap;
+
+use mongodb::bson::Bson;
+use rokbattles_bson::bson_to_i64;
+use serde::Deserialize;
+
+use super::{
+    catalog::Catalogs,
+    model::{InscriptionRarity, LoadoutBucket, MonthLoadouts, canonical_formation_id},
+};
+
+const LEGENDARY_EQUIPMENT_QUALITY: i64 = 5;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ProjectedLoadout {
+    pub(super) d: i64,
+    pub(super) c: i64,
+    pub(super) u: i64,
+    #[serde(default)]
+    pub(super) f: i64,
+    pub(super) e: Option<String>,
+    #[serde(default)]
+    pub(super) a: Vec<Armament>,
+}
+
+pub(super) fn map_projected_loadout(value: &Bson) -> Result<ProjectedLoadout, String> {
+    let values = value.as_array().ok_or("loadout record is not an array")?;
+    if values.len() != 6 {
+        return Err(format!("loadout record has {} fields instead of 6", values.len()));
+    }
+    let integer = |index: usize, name: &str| {
+        bson_to_i64(&values[index]).ok_or_else(|| format!("loadout {name} is not an integer"))
+    };
+    let e = match &values[4] {
+        Bson::String(value) => Some(value.clone()),
+        Bson::Null => None,
+        _ => return Err("loadout equipment is not a string or null".to_owned()),
+    };
+    let a = mongodb::bson::from_bson(values[5].clone())
+        .map_err(|error| format!("invalid loadout armaments: {error}"))?;
+
+    Ok(ProjectedLoadout {
+        d: integer(0, "day")?,
+        c: integer(1, "scenario")?,
+        u: integer(2, "governor")?,
+        f: integer(3, "formation")?,
+        e,
+        a,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct Armament {
+    id: i64,
+    affix: Option<String>,
+    buffs: Option<String>,
+}
+
+#[derive(Debug)]
+struct EquipmentToken {
+    slot: i64,
+    item_id: i64,
+    attribute: i64,
+}
+
+pub(super) fn accumulate_snapshot(
+    month: &mut MonthLoadouts,
+    snapshot: &ProjectedLoadout,
+    catalogs: &Catalogs,
+) {
+    let bucket = month.buckets.entry((snapshot.d, snapshot.c)).or_default();
+    accumulate_formation(bucket, snapshot.f);
+    accumulate_armaments(bucket, &snapshot.a, catalogs);
+    accumulate_equipment(bucket, snapshot.e.as_deref(), catalogs);
+}
+
+fn accumulate_formation(bucket: &mut LoadoutBucket, formation_id: i64) {
+    let formation_id = canonical_formation_id(formation_id);
+    if formation_id > 0 {
+        bucket.formation.sample += 1;
+        *bucket.formation.counts.entry(formation_id).or_default() += 1;
+    }
+}
+
+fn accumulate_armaments(bucket: &mut LoadoutBucket, armaments: &[Armament], catalogs: &Catalogs) {
+    for armament in armaments.iter().filter(|armament| (1..=4).contains(&armament.id)) {
+        let slot = bucket.armaments.entry(armament.id).or_default();
+        slot.sample += 1;
+
+        let mut rarities = parse_signed_integers(armament.affix.as_deref())
+            .into_iter()
+            .filter_map(|id| catalogs.inscriptions.get(&id).copied())
+            .collect::<Vec<_>>();
+        rarities.sort_by_key(|rarity| match rarity {
+            InscriptionRarity::Common => 0,
+            InscriptionRarity::Rare => 1,
+            InscriptionRarity::Special => 2,
+        });
+        match rarities.as_slice() {
+            [InscriptionRarity::Special] => slot.inscriptions.special += 1,
+            [InscriptionRarity::Rare] => slot.inscriptions.rare += 1,
+            [InscriptionRarity::Common] => slot.inscriptions.common += 1,
+            [InscriptionRarity::Common, InscriptionRarity::Special] => {
+                slot.inscriptions.special_common += 1;
+            }
+            [InscriptionRarity::Common, InscriptionRarity::Rare] => {
+                slot.inscriptions.rare_common += 1;
+            }
+            [InscriptionRarity::Common, InscriptionRarity::Common] => {
+                slot.inscriptions.common_common += 1;
+            }
+            _ => {}
+        }
+
+        let buffs =
+            parse_buff_pairs(armament.buffs.as_deref()).into_iter().collect::<HashMap<_, _>>();
+        for (id, value) in buffs {
+            let Some(maximum) = catalogs.armament_max_rolls.get(&id) else {
+                continue;
+            };
+            let accumulator = slot.buffs.entry(id).or_default();
+            accumulator.observations += 1;
+            accumulator.total_roll += value;
+            accumulator.max_rolls += i64::from(value + 1e-9 >= *maximum);
+        }
+    }
+}
+
+fn accumulate_equipment(bucket: &mut LoadoutBucket, value: Option<&str>, catalogs: &Catalogs) {
+    let tokens = parse_equipment(value)
+        .into_iter()
+        .filter(|token| (1..=8).contains(&token.slot))
+        .collect::<Vec<_>>();
+    let mut accessories = tokens
+        .iter()
+        .filter(|token| matches!(token.slot, 7 | 8))
+        .map(|token| token.item_id)
+        .collect::<Vec<_>>();
+    if accessories.len() == 2 {
+        accessories.sort_unstable();
+        bucket.accessory_sample += 1;
+        *bucket.accessory_pairs.entry((accessories[0], accessories[1])).or_default() += 1;
+    }
+
+    for token in tokens {
+        let Some(quality) = catalogs.equipment_qualities.get(&token.item_id) else {
+            continue;
+        };
+        let slot_id = if token.slot == 8 { 7 } else { token.slot };
+        let slot = bucket.equipment.entry(slot_id).or_default();
+        let special_talent_code = token.attribute.div_euclid(10);
+        let iconic =
+            if special_talent_code > 0 { token.attribute.rem_euclid(10) } else { token.attribute };
+
+        *slot.items.entry(token.item_id).or_default() += 1;
+        if *quality == LEGENDARY_EQUIPMENT_QUALITY {
+            slot.count += 1;
+            *slot.iconic.entry(iconic.max(0)).or_default() += 1;
+        } else {
+            slot.excluded += 1;
+        }
+        if special_talent_code > 0 {
+            slot.special_talent += 1;
+        } else {
+            slot.normal += 1;
+        }
+    }
+}
+
+pub(super) fn pack_month(month: MonthLoadouts) -> Vec<Bson> {
+    let mut records = Vec::new();
+    for ((day, scenario), bucket) in month.buckets {
+        if bucket.formation.sample > 0 {
+            let mut record =
+                vec![0_i64.into(), day.into(), scenario.into(), bucket.formation.sample.into()];
+            for (id, count) in bucket.formation.counts {
+                record.extend([id.into(), count.into()]);
+            }
+            records.push(Bson::Array(record));
+        }
+
+        for (slot_id, slot) in bucket.armaments {
+            let mut buffs = Vec::with_capacity(slot.buffs.len() * 4);
+            for (id, buff) in slot.buffs {
+                buffs.extend([
+                    id.into(),
+                    buff.observations.into(),
+                    buff.total_roll.into(),
+                    buff.max_rolls.into(),
+                ]);
+            }
+            records.push(Bson::Array(vec![
+                1_i64.into(),
+                day.into(),
+                scenario.into(),
+                slot_id.into(),
+                slot.sample.into(),
+                slot.inscriptions.special.into(),
+                slot.inscriptions.rare.into(),
+                slot.inscriptions.common.into(),
+                slot.inscriptions.special_common.into(),
+                slot.inscriptions.rare_common.into(),
+                slot.inscriptions.common_common.into(),
+                Bson::Array(buffs),
+            ]));
+        }
+
+        for (slot_id, slot) in bucket.equipment {
+            let mut items = Vec::with_capacity(slot.items.len() * 2);
+            for (id, count) in slot.items {
+                items.extend([id.into(), count.into()]);
+            }
+            let mut iconic = Vec::with_capacity(slot.iconic.len() * 2);
+            for (level, count) in slot.iconic {
+                iconic.extend([level.into(), count.into()]);
+            }
+            records.push(Bson::Array(vec![
+                2_i64.into(),
+                day.into(),
+                scenario.into(),
+                slot_id.into(),
+                slot.count.into(),
+                slot.excluded.into(),
+                slot.special_talent.into(),
+                slot.normal.into(),
+                Bson::Array(items),
+                Bson::Array(iconic),
+            ]));
+        }
+
+        if bucket.accessory_sample > 0 {
+            let mut pairs = Vec::with_capacity(bucket.accessory_pairs.len() * 3);
+            for ((id, id2), count) in bucket.accessory_pairs {
+                pairs.extend([id.into(), id2.into(), count.into()]);
+            }
+            records.push(Bson::Array(vec![
+                3_i64.into(),
+                day.into(),
+                scenario.into(),
+                bucket.accessory_sample.into(),
+                Bson::Array(pairs),
+            ]));
+        }
+    }
+    records
+}
+
+fn parse_equipment(value: Option<&str>) -> Vec<EquipmentToken> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    let value = value.trim().trim_start_matches('{').trim_end_matches('}');
+    if value.is_empty() {
+        return Vec::new();
+    }
+    value
+        .split(',')
+        .filter_map(|part| {
+            let mut fields = part.split(':').map(str::trim);
+            let slot = fields.next()?.parse::<i64>().ok()?;
+            let item_id = fields.next()?.split('_').next()?.parse::<i64>().ok()?;
+            let attribute = fields.next()?.parse::<i64>().ok()?;
+            Some(EquipmentToken { slot, item_id, attribute })
+        })
+        .collect()
+}
+
+fn parse_signed_integers(value: Option<&str>) -> Vec<i64> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    let mut values = Vec::new();
+    let mut current = String::new();
+    for character in value.chars().chain(std::iter::once(' ')) {
+        if character.is_ascii_digit() || (character == '-' && current.is_empty()) {
+            current.push(character);
+        } else if !current.is_empty() {
+            if let Ok(value) = current.parse::<i64>()
+                && value > 0
+            {
+                values.push(value);
+            }
+            current.clear();
+        }
+    }
+    values
+}
+
+fn parse_buff_pairs(value: Option<&str>) -> Vec<(i64, f64)> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    value
+        .split([';', ','])
+        .filter_map(|part| {
+            let mut fields = part.trim().split(['_', ':']);
+            let id = fields.next()?.parse::<i64>().ok()?;
+            let value = fields.next()?.parse::<f64>().ok()?;
+            (id > 0 && value.is_finite() && value >= 0.0).then_some((id, value))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::precompute_cmdr_pairings_v2::model::PairingKey;
+
+    #[test]
+    fn accessory_pairs_are_order_agnostic_and_accessory_slots_are_combined() {
+        let catalogs = Catalogs {
+            inscriptions: HashMap::new(),
+            armament_max_rolls: HashMap::new(),
+            equipment_qualities: HashMap::from([(101, 5), (202, 5)]),
+        };
+        let mut bucket = LoadoutBucket::default();
+        accumulate_equipment(&mut bucket, Some("{7:202_0:0,8:101_0:0}"), &catalogs);
+
+        assert_eq!(bucket.accessory_pairs.get(&(101, 202)), Some(&1));
+        assert_eq!(bucket.equipment.get(&7).map(|slot| slot.count), Some(2));
+    }
+
+    #[test]
+    fn packed_equipment_uses_ids_and_counts_without_names() {
+        let mut month = MonthLoadouts {
+            pairing: PairingKey { primary: 1, secondary: 2 },
+            month: 0,
+            ..MonthLoadouts::default()
+        };
+        let bucket = month.buckets.entry((10, 1)).or_default();
+        bucket.equipment.entry(1).or_default().items.insert(101, 3);
+
+        let packed = pack_month(month);
+
+        assert_eq!(packed.len(), 1);
+        assert!(!format!("{packed:?}").contains("name"));
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -1,0 +1,657 @@
+//! Compact, chunked Combat Lab precomputation.
+
+mod catalog;
+mod loadout;
+mod model;
+mod pipeline;
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    mem,
+    time::Instant,
+};
+
+use futures::{StreamExt, stream};
+use mongodb::{
+    Collection,
+    bson::{Bson, DateTime, Document, doc},
+    options::Hint,
+};
+use rokbattles_api::db::ReportsStore;
+use rokbattles_bson::{bson_to_f64, bson_to_i64};
+
+use self::{
+    catalog::Catalogs,
+    loadout::{accumulate_snapshot, map_projected_loadout, pack_month},
+    model::{MonthLoadouts, PairingKey, PairingRoot, PerformancePoint, RawTotals, range_cutoffs},
+    pipeline::{loadout_pipeline, performance_pipeline},
+};
+use crate::{error::JobsError, precompute_cmdr_pairings::legendary_commander_ids};
+
+const PERFORMANCE_KIND: i64 = 1;
+const LOADOUT_KIND: i64 = 2;
+const ROOT_KIND: i64 = 0;
+const BULK_WRITE_BATCH_SIZE: usize = 500;
+const SAFE_BSON_BYTES: usize = 12 * 1024 * 1024;
+const PERFORMANCE_CHUNK_MS: i64 = 32 * model::DAY_MS;
+const LOADOUT_CHUNK_MS: i64 = 126 * model::DAY_MS;
+const PARTITION_CONCURRENCY: usize = 12;
+const DAILY_LOADOUT_DAYS: i64 = 8;
+
+/// Counts and timings from one compact Combat Lab refresh.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CommanderPairingsV2PrecomputeStats {
+    pub legendary_commanders: usize,
+    pub pairings: usize,
+    pub performance_points: usize,
+    pub loadout_snapshots: usize,
+    pub documents_written: usize,
+    pub max_document_bytes: usize,
+    pub performance_seconds: u64,
+    pub loadout_seconds: u64,
+    pub total_seconds: u64,
+}
+
+/// Refresh compact Combat Lab data while reusing DRASTC from the existing pairing collection.
+pub async fn precompute_commander_pairings_v2_data(
+    reports_store: &ReportsStore,
+) -> Result<CommanderPairingsV2PrecomputeStats, JobsError> {
+    let started = Instant::now();
+    let generation = DateTime::now();
+    let now_ms = generation.timestamp_millis();
+    let cutoffs = range_cutoffs(now_ms);
+    let daily_loadout_cutoff = now_ms - DAILY_LOADOUT_DAYS * model::DAY_MS;
+    let legendary_ids = legendary_commander_ids()?;
+    let catalogs = Catalogs::load()?;
+    let output = reports_store.precomputed_commander_pairings_v2_collection();
+    let mut roots = read_stored_drastc(reports_store).await?;
+    let performance_partitions = time_partitions(cutoffs[0], now_ms, PERFORMANCE_CHUNK_MS);
+    let mut documents_written = 0_usize;
+    let mut max_document_bytes = 0_usize;
+
+    let performance_started = Instant::now();
+    let mut performance_points = 0_usize;
+    let mut performance_runs = stream::iter(performance_partitions)
+        .map(|(start_ms, end_ms)| {
+            read_performance_partition(
+                reports_store.battle_collection(),
+                output,
+                &legendary_ids,
+                start_ms,
+                end_ms,
+                generation,
+                &cutoffs,
+            )
+        })
+        .buffer_unordered(PARTITION_CONCURRENCY);
+    while let Some(result) = performance_runs.next().await {
+        let result = result?;
+        merge_roots(&mut roots, result.roots);
+        performance_points += result.rows;
+        documents_written += result.documents_written;
+        max_document_bytes = max_document_bytes.max(result.max_document_bytes);
+    }
+    let performance_seconds = performance_started.elapsed().as_secs();
+
+    let loadout_started = Instant::now();
+    let mut loadout_snapshots = 0_usize;
+    let mut governor_last_seen = HashMap::<(PairingKey, i64, i64), i64>::new();
+    let loadout_partitions = time_partitions(cutoffs[0], now_ms, LOADOUT_CHUNK_MS);
+    let loadout_context = LoadoutPartitionContext {
+        source: reports_store.battle_collection(),
+        output,
+        legendary_ids: &legendary_ids,
+        daily_cutoff_ms: daily_loadout_cutoff,
+        generation,
+        catalogs: &catalogs,
+    };
+    let mut loadout_runs = stream::iter(loadout_partitions)
+        .map(|(start_ms, end_ms)| read_loadout_partition(&loadout_context, start_ms, end_ms))
+        .buffer_unordered(PARTITION_CONCURRENCY);
+    while let Some(result) = loadout_runs.next().await {
+        let result = result?;
+        merge_governors(&mut governor_last_seen, result.governors);
+        loadout_snapshots += result.rows;
+        documents_written += result.documents_written;
+        max_document_bytes = max_document_bytes.max(result.max_document_bytes);
+    }
+    finalize_all_governors(&mut roots, &cutoffs, governor_last_seen);
+    let loadout_seconds = loadout_started.elapsed().as_secs();
+
+    let pairings = roots.len();
+    let mut writer = BulkWriter::new(output);
+    for (key, root) in roots {
+        writer.push(root_document(key, root, generation)?).await?;
+    }
+    writer.flush().await?;
+    documents_written += writer.documents_written;
+    max_document_bytes = max_document_bytes.max(writer.max_document_bytes);
+
+    // New roots are published only after all of their generation's chunks exist. Readers can
+    // select the newest root and use its generation while this removes the previous snapshot.
+    output.delete_many(doc! { "g": { "$ne": generation } }).await?;
+
+    Ok(CommanderPairingsV2PrecomputeStats {
+        legendary_commanders: legendary_ids.len(),
+        pairings,
+        performance_points,
+        loadout_snapshots,
+        documents_written,
+        max_document_bytes,
+        performance_seconds,
+        loadout_seconds,
+        total_seconds: started.elapsed().as_secs(),
+    })
+}
+
+async fn read_stored_drastc(
+    reports_store: &ReportsStore,
+) -> Result<BTreeMap<PairingKey, PairingRoot>, JobsError> {
+    let mut cursor = reports_store
+        .precomputed_commander_pairings_collection()
+        .find(doc! {})
+        .projection(doc! {
+            "_id": 0,
+            "primary_commander_id": 1,
+            "secondary_commander_id": 1,
+            "drastc": 1,
+        })
+        .await?;
+    let mut roots = BTreeMap::<PairingKey, PairingRoot>::new();
+    while let Some(next) = cursor.next().await {
+        let document = next?;
+        let Some(key) = pairing_key(&document, "primary_commander_id", "secondary_commander_id")
+        else {
+            continue;
+        };
+        roots.entry(key).or_default().drastc = pack_drastc(&document);
+    }
+    Ok(roots)
+}
+
+fn time_partitions(first_ms: i64, now_ms: i64, width_ms: i64) -> Vec<(i64, i64)> {
+    let end = now_ms.saturating_add(1);
+    let mut partitions = Vec::new();
+    let mut start = first_ms;
+    while start < end {
+        let aligned_next =
+            start.saturating_sub(start.rem_euclid(width_ms)).saturating_add(width_ms);
+        let next = aligned_next.min(end);
+        partitions.push((start, next));
+        start = next;
+    }
+    partitions
+}
+
+fn merge_roots(
+    destination: &mut BTreeMap<PairingKey, PairingRoot>,
+    sources: BTreeMap<PairingKey, PairingRoot>,
+) {
+    for (pairing, source) in sources {
+        let destination = destination.entry(pairing).or_default();
+        for (key, totals) in source.summaries {
+            destination.summaries.entry(key).or_default().accumulate(totals);
+        }
+    }
+}
+
+fn merge_governors(
+    destination: &mut HashMap<(PairingKey, i64, i64), i64>,
+    sources: HashMap<(PairingKey, i64, i64), i64>,
+) {
+    for (key, day) in sources {
+        destination.entry(key).and_modify(|current| *current = (*current).max(day)).or_insert(day);
+    }
+}
+
+struct PerformancePartition {
+    roots: BTreeMap<PairingKey, PairingRoot>,
+    rows: usize,
+    documents_written: usize,
+    max_document_bytes: usize,
+}
+
+async fn read_performance_partition(
+    source: &Collection<Document>,
+    output: &Collection<Document>,
+    legendary_ids: &[i64],
+    start_ms: i64,
+    end_ms: i64,
+    generation: DateTime,
+    cutoffs: &[i64; 4],
+) -> Result<PerformancePartition, JobsError> {
+    let mut cursor = source
+        .aggregate(performance_pipeline(legendary_ids, start_ms, end_ms))
+        .allow_disk_use(true)
+        .batch_size(1_000)
+        .hint(Hint::Keys(doc! { "metadata.kvk": 1, "metadata.mail_time": -1 }))
+        .await?;
+    let mut writer = BulkWriter::new(output);
+    let mut roots = BTreeMap::<PairingKey, PairingRoot>::new();
+    let mut points = 0_usize;
+
+    while let Some(next) = cursor.next().await {
+        let document = next?;
+        let pairing = pairing_key(&document, "p", "s").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("performance chunk is missing commander IDs".to_owned())
+        })?;
+        let month = document_i64(&document, "m").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("performance chunk is missing its month".to_owned())
+        })?;
+        let records = document.get_array("v").cloned().map_err(|_| {
+            JobsError::InvalidCombatLabData("performance chunk has no records".to_owned())
+        })?;
+        for record in &records {
+            let point = map_performance_record(pairing, month, record)?;
+            roots.entry(pairing).or_default().accumulate(point, cutoffs);
+            points += 1;
+        }
+        write_chunk_records(&mut writer, PERFORMANCE_KIND, pairing, month, generation, 0, records)
+            .await?;
+    }
+    writer.flush().await?;
+    Ok(PerformancePartition {
+        roots,
+        rows: points,
+        documents_written: writer.documents_written,
+        max_document_bytes: writer.max_document_bytes,
+    })
+}
+
+struct LoadoutPartition {
+    governors: HashMap<(PairingKey, i64, i64), i64>,
+    rows: usize,
+    documents_written: usize,
+    max_document_bytes: usize,
+}
+
+struct LoadoutPartitionContext<'a> {
+    source: &'a Collection<Document>,
+    output: &'a Collection<Document>,
+    legendary_ids: &'a [i64],
+    daily_cutoff_ms: i64,
+    generation: DateTime,
+    catalogs: &'a Catalogs,
+}
+
+async fn read_loadout_partition(
+    context: &LoadoutPartitionContext<'_>,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<LoadoutPartition, JobsError> {
+    let mut cursor = context
+        .source
+        .aggregate(loadout_pipeline(
+            context.legendary_ids,
+            start_ms,
+            end_ms,
+            context.daily_cutoff_ms,
+        ))
+        .allow_disk_use(true)
+        .batch_size(1_000)
+        .hint(Hint::Keys(doc! { "metadata.kvk": 1, "metadata.mail_time": -1 }))
+        .await?;
+    let mut writer = BulkWriter::new(context.output);
+    let mut governor_last_seen = HashMap::<(PairingKey, i64, i64), i64>::new();
+    let mut snapshots = 0_usize;
+
+    while let Some(next) = cursor.next().await {
+        let document = next?;
+        let pairing = pairing_key(&document, "p", "s").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("loadout chunk is missing commander IDs".to_owned())
+        })?;
+        let month_start = document_i64(&document, "m").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("loadout chunk is missing its range".to_owned())
+        })?;
+        let day = document_i64(&document, "d").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("loadout chunk is missing its day".to_owned())
+        })?;
+        let scenario = document_i64(&document, "c").ok_or_else(|| {
+            JobsError::InvalidCombatLabData("loadout chunk is missing its scenario".to_owned())
+        })?;
+        let records = document.get_array("v").map_err(|_| {
+            JobsError::InvalidCombatLabData("loadout chunk has no records".to_owned())
+        })?;
+        let mut month = MonthLoadouts { pairing, month: month_start, ..MonthLoadouts::default() };
+        for record in records {
+            let snapshot = map_projected_loadout(record).map_err(|error| {
+                JobsError::InvalidCombatLabData(format!("invalid loadout aggregation row: {error}"))
+            })?;
+            governor_last_seen
+                .entry((pairing, snapshot.c, snapshot.u))
+                .and_modify(|day| *day = (*day).max(snapshot.d))
+                .or_insert(snapshot.d);
+            accumulate_snapshot(&mut month, &snapshot, context.catalogs);
+            snapshots += 1;
+        }
+        let part = ((day - month_start).div_euclid(model::DAY_MS) * 5 + scenario) * 1_000;
+        write_loadout_month(&mut writer, month, context.generation, part).await?;
+    }
+    writer.flush().await?;
+    Ok(LoadoutPartition {
+        governors: governor_last_seen,
+        rows: snapshots,
+        documents_written: writer.documents_written,
+        max_document_bytes: writer.max_document_bytes,
+    })
+}
+
+async fn write_loadout_month(
+    writer: &mut BulkWriter<'_>,
+    month: MonthLoadouts,
+    generation: DateTime,
+    first_part: i64,
+) -> Result<(), JobsError> {
+    let pairing = month.pairing;
+    let month_start = month.month;
+    write_chunk_records(
+        writer,
+        LOADOUT_KIND,
+        pairing,
+        month_start,
+        generation,
+        first_part,
+        pack_month(month),
+    )
+    .await
+}
+
+fn finalize_all_governors(
+    roots: &mut BTreeMap<PairingKey, PairingRoot>,
+    cutoffs: &[i64; 4],
+    last_seen: HashMap<(PairingKey, i64, i64), i64>,
+) {
+    for ((pairing, scenario, _player), day) in last_seen {
+        let root = roots.entry(pairing).or_default();
+        for (range, cutoff) in cutoffs.iter().enumerate() {
+            if day >= *cutoff {
+                *root.governors.entry((range as i64, scenario)).or_default() += 1;
+            }
+        }
+    }
+}
+
+async fn write_chunk_records(
+    writer: &mut BulkWriter<'_>,
+    kind: i64,
+    pairing: PairingKey,
+    month: i64,
+    generation: DateTime,
+    first_part: i64,
+    records: Vec<Bson>,
+) -> Result<(), JobsError> {
+    let mut part = first_part;
+    let mut current = Vec::new();
+
+    for record in records {
+        current.push(record);
+        let candidate = chunk_document(kind, pairing, month, generation, part, current.clone());
+        if encoded_size(&candidate)? > SAFE_BSON_BYTES {
+            let record = current.pop().expect("record was just pushed");
+            if current.is_empty() {
+                return Err(JobsError::InvalidCombatLabData(
+                    "one packed Combat Lab record exceeds the safe BSON limit".to_owned(),
+                ));
+            }
+            writer
+                .push(chunk_document(
+                    kind,
+                    pairing,
+                    month,
+                    generation,
+                    part,
+                    mem::take(&mut current),
+                ))
+                .await?;
+            part += 1;
+            current.push(record);
+        }
+    }
+
+    if !current.is_empty() {
+        writer.push(chunk_document(kind, pairing, month, generation, part, current)).await?;
+    }
+    Ok(())
+}
+
+fn chunk_document(
+    kind: i64,
+    pairing: PairingKey,
+    month: i64,
+    generation: DateTime,
+    part: i64,
+    records: Vec<Bson>,
+) -> Document {
+    doc! {
+        "k": kind,
+        "p": pairing.primary,
+        "s": pairing.secondary,
+        "g": generation,
+        "m": month,
+        "q": part,
+        "v": records,
+    }
+}
+
+fn root_document(
+    pairing: PairingKey,
+    root: PairingRoot,
+    generation: DateTime,
+) -> Result<Document, JobsError> {
+    let mut summaries = Vec::new();
+    for ((range, scenario), totals) in root.summaries {
+        summaries.push(Bson::Array(vec![
+            range.into(),
+            scenario.into(),
+            totals.battles.into(),
+            root.governors.get(&(range, scenario)).copied().unwrap_or_default().into(),
+            totals.kill_points_gained.into(),
+            totals.kill_points_lost.into(),
+            totals.severely_wounded_inflicted.into(),
+            totals.severely_wounded_taken.into(),
+            totals.battle_duration_ms.into(),
+            totals.rate_duration_ms.into(),
+            totals.damage.into(),
+            totals.healing.into(),
+        ]));
+    }
+    let mut document = doc! {
+        "k": ROOT_KIND,
+        "p": pairing.primary,
+        "s": pairing.secondary,
+        "g": generation,
+        "q": 0_i64,
+        "r": summaries,
+    };
+    if let Some(drastc) = root.drastc {
+        document.insert("d", drastc);
+    }
+    ensure_safe_size(&document)?;
+    Ok(document)
+}
+
+fn map_performance_record(
+    pairing: PairingKey,
+    month: i64,
+    value: &Bson,
+) -> Result<PerformancePoint, JobsError> {
+    let values = value.as_array().ok_or_else(|| {
+        JobsError::InvalidCombatLabData("performance record is not an array".to_owned())
+    })?;
+    let required = |index: usize| {
+        values.get(index).and_then(bson_to_i64).ok_or_else(|| {
+            JobsError::InvalidCombatLabData(format!(
+                "performance record is missing tuple index {index}"
+            ))
+        })
+    };
+    Ok(PerformancePoint {
+        pairing,
+        month,
+        day: required(0)?,
+        scenario: required(1)?,
+        totals: RawTotals {
+            battles: required(2)?,
+            kill_points_gained: required(3)?,
+            kill_points_lost: required(4)?,
+            severely_wounded_inflicted: required(5)?,
+            severely_wounded_taken: required(6)?,
+            battle_duration_ms: required(7)?,
+            rate_duration_ms: required(8)?,
+            damage: required(9)?,
+            healing: required(10)?,
+        },
+    })
+}
+
+fn pack_drastc(document: &Document) -> Option<Bson> {
+    let drastc = document.get_document("drastc").ok()?;
+    let confidence = drastc.get_document("confidence").ok()?;
+    let breakdown = drastc.get_document("breakdown").ok()?;
+    let categories = ["damage", "rage", "assist", "sustainability", "trade", "consistency"]
+        .into_iter()
+        .map(|key| {
+            let category = breakdown.get_document(key).ok()?;
+            Some(Bson::Array(vec![
+                number(category, "value")?.into(),
+                number(category, "p10")?.into(),
+                number(category, "p90")?.into(),
+                number(category, "score")?.into(),
+            ]))
+        })
+        .collect::<Option<Vec<_>>>()?;
+
+    Some(Bson::Array(vec![
+        document_i64(drastc, "samples")?.into(),
+        number(drastc, "overall")?.into(),
+        number(confidence, "score")?.into(),
+        document_i64(confidence, "unique_governors")?.into(),
+        number(confidence, "effective_governors")?.into(),
+        Bson::Array(categories),
+    ]))
+}
+
+fn pairing_key(document: &Document, primary: &str, secondary: &str) -> Option<PairingKey> {
+    Some(PairingKey {
+        primary: document.get(primary).and_then(bson_to_i64)?,
+        secondary: document.get(secondary).and_then(bson_to_i64)?,
+    })
+}
+
+fn document_i64(document: &Document, key: &str) -> Option<i64> {
+    document.get(key).and_then(bson_to_i64)
+}
+
+fn number(document: &Document, key: &str) -> Option<f64> {
+    document.get(key).and_then(bson_to_f64)
+}
+
+fn encoded_size(document: &Document) -> Result<usize, JobsError> {
+    Ok(mongodb::bson::to_vec(document)?.len())
+}
+
+fn ensure_safe_size(document: &Document) -> Result<usize, JobsError> {
+    let size = encoded_size(document)?;
+    if size > SAFE_BSON_BYTES {
+        return Err(JobsError::InvalidCombatLabData(format!(
+            "packed document is {size} bytes; safe limit is {SAFE_BSON_BYTES}"
+        )));
+    }
+    Ok(size)
+}
+
+struct BulkWriter<'a> {
+    output: &'a Collection<Document>,
+    models: Vec<mongodb::options::ReplaceOneModel>,
+    documents_written: usize,
+    max_document_bytes: usize,
+}
+
+impl<'a> BulkWriter<'a> {
+    fn new(output: &'a Collection<Document>) -> Self {
+        Self {
+            output,
+            models: Vec::with_capacity(BULK_WRITE_BATCH_SIZE),
+            documents_written: 0,
+            max_document_bytes: 0,
+        }
+    }
+
+    async fn push(&mut self, document: Document) -> Result<(), JobsError> {
+        let size = ensure_safe_size(&document)?;
+        self.max_document_bytes = self.max_document_bytes.max(size);
+        let mut selector = doc! {
+            "k": document_i64(&document, "k").unwrap_or_default(),
+            "p": document_i64(&document, "p").unwrap_or_default(),
+            "s": document_i64(&document, "s").unwrap_or_default(),
+            "g": document.get_datetime("g").copied().unwrap_or(DateTime::from_millis(0)),
+            "q": document_i64(&document, "q").unwrap_or_default(),
+        };
+        if let Some(month) = document.get("m").and_then(bson_to_i64) {
+            selector.insert("m", month);
+        } else {
+            selector.insert("m", Bson::Null);
+        }
+        let mut model = self.output.replace_one_model(selector, &document)?;
+        model.upsert = Some(true);
+        self.models.push(model);
+        if self.models.len() >= BULK_WRITE_BATCH_SIZE {
+            self.flush().await?;
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), JobsError> {
+        if self.models.is_empty() {
+            return Ok(());
+        }
+        let batch = mem::replace(&mut self.models, Vec::with_capacity(BULK_WRITE_BATCH_SIZE));
+        let count = batch.len();
+        self.output.client().bulk_write(batch).ordered(false).await?;
+        self.documents_written += count;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_root_omits_unavailable_drastc_and_long_field_names() {
+        let document = root_document(
+            PairingKey { primary: 1, secondary: 2 },
+            PairingRoot::default(),
+            DateTime::from_millis(10),
+        )
+        .expect("root");
+
+        assert!(!document.contains_key("d"));
+        assert!(!format!("{document:?}").contains("schemaVersion"));
+        assert!(!format!("{document:?}").contains("primaryCommanderName"));
+    }
+
+    #[test]
+    fn chunk_documents_remain_below_the_safety_margin() {
+        let records = (0..50_000)
+            .map(|value| Bson::Array(vec![value.into(), value.into(), value.into()]))
+            .collect();
+        let document = chunk_document(
+            PERFORMANCE_KIND,
+            PairingKey { primary: 1, secondary: 2 },
+            0,
+            DateTime::from_millis(0),
+            0,
+            records,
+        );
+
+        assert!(ensure_safe_size(&document).is_ok());
+    }
+
+    #[test]
+    fn time_partitions_snap_to_aligned_boundaries_after_the_partial_first_range() {
+        let partitions = time_partitions(15, 45, 10);
+
+        assert_eq!(partitions, vec![(15, 20), (20, 30), (30, 40), (40, 46)]);
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/model.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/model.rs
@@ -1,0 +1,172 @@
+use std::collections::BTreeMap;
+
+use mongodb::bson::Bson;
+
+pub(super) const DAY_MS: i64 = 24 * 60 * 60 * 1_000;
+pub(super) const WEDGE_FORMATION_ID: i64 = 2;
+pub(super) const WEDGE_FORMATION_II_ID: i64 = 19;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(super) struct PairingKey {
+    pub(super) primary: i64,
+    pub(super) secondary: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(super) struct RawTotals {
+    pub(super) battles: i64,
+    pub(super) kill_points_gained: i64,
+    pub(super) kill_points_lost: i64,
+    pub(super) severely_wounded_inflicted: i64,
+    pub(super) severely_wounded_taken: i64,
+    pub(super) battle_duration_ms: i64,
+    pub(super) rate_duration_ms: i64,
+    pub(super) damage: i64,
+    pub(super) healing: i64,
+}
+
+impl RawTotals {
+    pub(super) fn accumulate(&mut self, other: Self) {
+        self.battles += other.battles;
+        self.kill_points_gained += other.kill_points_gained;
+        self.kill_points_lost += other.kill_points_lost;
+        self.severely_wounded_inflicted += other.severely_wounded_inflicted;
+        self.severely_wounded_taken += other.severely_wounded_taken;
+        self.battle_duration_ms += other.battle_duration_ms;
+        self.rate_duration_ms += other.rate_duration_ms;
+        self.damage += other.damage;
+        self.healing += other.healing;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct PerformancePoint {
+    pub(super) pairing: PairingKey,
+    pub(super) month: i64,
+    pub(super) day: i64,
+    pub(super) scenario: i64,
+    pub(super) totals: RawTotals,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(super) struct PairingRoot {
+    pub(super) drastc: Option<Bson>,
+    pub(super) summaries: BTreeMap<(i64, i64), RawTotals>,
+    pub(super) governors: BTreeMap<(i64, i64), i64>,
+}
+
+impl PairingRoot {
+    pub(super) fn accumulate(&mut self, point: PerformancePoint, cutoffs: &[i64; 4]) {
+        for (range, cutoff) in cutoffs.iter().enumerate() {
+            if point.day >= *cutoff {
+                self.summaries
+                    .entry((range as i64, point.scenario))
+                    .or_default()
+                    .accumulate(point.totals);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct FormationAccumulator {
+    pub(super) sample: i64,
+    pub(super) counts: BTreeMap<i64, i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct InscriptionAccumulator {
+    pub(super) special: i64,
+    pub(super) rare: i64,
+    pub(super) common: i64,
+    pub(super) special_common: i64,
+    pub(super) rare_common: i64,
+    pub(super) common_common: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct BuffAccumulator {
+    pub(super) observations: i64,
+    pub(super) total_roll: f64,
+    pub(super) max_rolls: i64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct ArmamentSlotAccumulator {
+    pub(super) sample: i64,
+    pub(super) inscriptions: InscriptionAccumulator,
+    pub(super) buffs: BTreeMap<i64, BuffAccumulator>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct EquipmentSlotAccumulator {
+    pub(super) count: i64,
+    pub(super) excluded: i64,
+    pub(super) special_talent: i64,
+    pub(super) normal: i64,
+    pub(super) items: BTreeMap<i64, i64>,
+    pub(super) iconic: BTreeMap<i64, i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct LoadoutBucket {
+    pub(super) formation: FormationAccumulator,
+    pub(super) armaments: BTreeMap<i64, ArmamentSlotAccumulator>,
+    pub(super) equipment: BTreeMap<i64, EquipmentSlotAccumulator>,
+    pub(super) accessory_sample: i64,
+    pub(super) accessory_pairs: BTreeMap<(i64, i64), i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct MonthLoadouts {
+    pub(super) pairing: PairingKey,
+    pub(super) month: i64,
+    pub(super) buckets: BTreeMap<(i64, i64), LoadoutBucket>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InscriptionRarity {
+    Common,
+    Rare,
+    Special,
+}
+
+pub(super) fn canonical_formation_id(id: i64) -> i64 {
+    if id == WEDGE_FORMATION_II_ID { WEDGE_FORMATION_ID } else { id }
+}
+
+pub(super) fn range_cutoffs(now_ms: i64) -> [i64; 4] {
+    [
+        now_ms.saturating_sub(365 * DAY_MS),
+        now_ms.saturating_sub(183 * DAY_MS),
+        now_ms.saturating_sub(30 * DAY_MS),
+        now_ms.saturating_sub(7 * DAY_MS),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wedge_two_is_stored_as_wedge() {
+        assert_eq!(canonical_formation_id(WEDGE_FORMATION_II_ID), WEDGE_FORMATION_ID);
+    }
+
+    #[test]
+    fn root_accumulates_only_matching_time_ranges() {
+        let mut root = PairingRoot::default();
+        let point = PerformancePoint {
+            pairing: PairingKey { primary: 1, secondary: 2 },
+            month: 0,
+            day: 800,
+            scenario: 1,
+            totals: RawTotals { battles: 3, ..RawTotals::default() },
+        };
+        root.accumulate(point, &[700, 750, 800, 900]);
+
+        assert_eq!(root.summaries.get(&(0, 1)).map(|value| value.battles), Some(3));
+        assert_eq!(root.summaries.get(&(2, 1)).map(|value| value.battles), Some(3));
+        assert!(!root.summaries.contains_key(&(3, 1)));
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
@@ -1,0 +1,415 @@
+use mongodb::bson::{Bson, Document, doc};
+
+const DAY_MS: i64 = 24 * 60 * 60 * 1_000;
+const PERFORMANCE_CHUNK_MS: i64 = 32 * DAY_MS;
+const LOADOUT_CHUNK_MS: i64 = 126 * DAY_MS;
+const WEEK_MS: i64 = 7 * DAY_MS;
+
+pub(super) fn performance_pipeline(
+    legendary_ids: &[i64],
+    start_ms: i64,
+    end_ms: i64,
+) -> Vec<Document> {
+    let mut pipeline =
+        pairing_entries_pipeline(legendary_ids, start_ms, end_ms, EntryShape::Performance);
+    pipeline.extend([
+        scenario_and_date_stage(PERFORMANCE_CHUNK_MS),
+        doc! { "$unwind": "$c" },
+        doc! {
+            "$group": {
+                "_id": { "p": "$p", "s": "$s", "m": "$m", "d": "$d", "c": "$c" },
+                "b": { "$sum": 1_i64 },
+                "kg": { "$sum": "$kg" },
+                "kl": { "$sum": "$kl" },
+                "si": { "$sum": "$si" },
+                "st": { "$sum": "$st" },
+                "du": { "$sum": "$du" },
+                "rd": { "$sum": { "$cond": [{ "$gt": ["$du", 0_i64] }, "$du", 1_000_i64] } },
+                "da": { "$sum": "$da" },
+                "h": { "$sum": "$h" },
+            }
+        },
+        doc! {
+            "$project": {
+                "_id": 0, "p": "$_id.p", "s": "$_id.s", "m": "$_id.m",
+                "v": ["$_id.d", "$_id.c", "$b", "$kg", "$kl", "$si", "$st", "$du", "$rd", "$da", "$h"],
+            }
+        },
+        doc! {
+            "$group": {
+                "_id": { "p": "$p", "s": "$s", "m": "$m" },
+                "v": { "$push": "$v" },
+            }
+        },
+        doc! { "$project": { "_id": 0, "p": "$_id.p", "s": "$_id.s", "m": "$_id.m", "v": 1 } },
+    ]);
+    pipeline
+}
+
+pub(super) fn loadout_pipeline(
+    legendary_ids: &[i64],
+    start_ms: i64,
+    end_ms: i64,
+    daily_cutoff_ms: i64,
+) -> Vec<Document> {
+    let mut pipeline =
+        pairing_entries_pipeline(legendary_ids, start_ms, end_ms, EntryShape::Loadout);
+    pipeline.extend([
+        doc! { "$match": { "u": { "$gt": 0_i64 } } },
+        loadout_scenario_and_date_stage(daily_cutoff_ms),
+        doc! { "$unwind": "$c" },
+        doc! {
+            "$group": {
+                "_id": { "p": "$p", "s": "$s", "m": "$m", "d": "$d", "c": "$c", "u": "$u" },
+                "x": {
+                    "$top": {
+                        "sortBy": { "t": -1 },
+                        "output": { "f": "$f", "e": "$e", "a": "$a" },
+                    }
+                },
+            }
+        },
+        doc! {
+            "$project": {
+                "_id": 0, "p": "$_id.p", "s": "$_id.s", "m": "$_id.m",
+                "d": "$_id.d", "c": "$_id.c",
+                "v": ["$_id.d", "$_id.c", "$_id.u", "$x.f", "$x.e", "$x.a"],
+            }
+        },
+        doc! {
+            "$group": {
+                "_id": { "p": "$p", "s": "$s", "m": "$m", "d": "$d", "c": "$c" },
+                "v": { "$push": "$v" },
+            }
+        },
+        doc! {
+            "$project": {
+                "_id": 0, "p": "$_id.p", "s": "$_id.s", "m": "$_id.m",
+                "d": "$_id.d", "c": "$_id.c", "v": 1,
+            }
+        },
+    ]);
+    pipeline
+}
+
+#[derive(Clone, Copy)]
+enum EntryShape {
+    Performance,
+    Loadout,
+}
+
+fn pairing_entries_pipeline(
+    legendary_ids: &[i64],
+    start_ms: i64,
+    end_ms: i64,
+    shape: EntryShape,
+) -> Vec<Document> {
+    let ids = legendary_ids.iter().copied().map(Bson::Int64).collect::<Vec<_>>();
+    let sender_condition = commander_condition(
+        "$sender.commanders.primary.id",
+        "$sender.commanders.secondary.id",
+        &ids,
+    );
+    let opponent_condition = commander_condition(
+        "$opponents.commanders.primary.id",
+        "$opponents.commanders.secondary.id",
+        &ids,
+    );
+    let sender = conditional_entry(
+        sender_condition,
+        perspective_entry(
+            "$sender.commanders.primary.id",
+            "$sender.commanders.secondary.id",
+            "$sender.player_id",
+            "$sender.commanders.primary",
+            "$_senderScenario",
+            "opponents.battle_results.sender",
+            "opponents.battle_results.opponent",
+            shape,
+        ),
+    );
+    let opponent = conditional_entry(
+        opponent_condition,
+        perspective_entry(
+            "$opponents.commanders.primary.id",
+            "$opponents.commanders.secondary.id",
+            "$opponents.player_id",
+            "$opponents.commanders.primary",
+            opponent_scenario_expr(),
+            "opponents.battle_results.opponent",
+            "opponents.battle_results.sender",
+            shape,
+        ),
+    );
+
+    vec![
+        doc! {
+            "$match": {
+                "metadata.kvk": true,
+                "metadata.mail_time": {
+                    "$gte": start_ms.saturating_mul(1_000),
+                    "$lt": end_ms.saturating_mul(1_000),
+                },
+                "opponents": { "$elemMatch": { "player_id": { "$gt": 0_i64 } } },
+                "$or": [
+                    {
+                        "sender.commanders.primary.id": { "$in": ids.clone() },
+                        "sender.commanders.secondary.id": { "$in": ids.clone() },
+                    },
+                    {
+                        "opponents": {
+                            "$elemMatch": {
+                                "player_id": { "$gt": 0_i64 },
+                                "commanders.primary.id": { "$in": ids.clone() },
+                                "commanders.secondary.id": { "$in": ids },
+                            }
+                        }
+                    },
+                ],
+            }
+        },
+        doc! { "$set": { "_senderScenario": sender_scenario_expr() } },
+        doc! { "$unwind": "$opponents" },
+        doc! { "$match": { "opponents.player_id": { "$gt": 0_i64 } } },
+        doc! { "$project": { "x": { "$concatArrays": [sender, opponent] } } },
+        doc! { "$unwind": "$x" },
+        doc! { "$replaceRoot": { "newRoot": "$x" } },
+        doc! { "$match": { "t": { "$gte": start_ms, "$lt": end_ms } } },
+    ]
+}
+
+fn scenario_and_date_stage(chunk_ms: i64) -> Document {
+    doc! {
+        "$set": {
+            "c": [0_i64, "$c"],
+            "d": { "$subtract": ["$t", { "$mod": ["$t", DAY_MS] }] },
+            "m": { "$subtract": ["$t", { "$mod": ["$t", chunk_ms] }] },
+        }
+    }
+}
+
+fn loadout_scenario_and_date_stage(daily_cutoff_ms: i64) -> Document {
+    doc! {
+        "$set": {
+            "c": [0_i64, "$c"],
+            "d": {
+                "$cond": [
+                    { "$gte": ["$t", daily_cutoff_ms] },
+                    { "$subtract": ["$t", { "$mod": ["$t", DAY_MS] }] },
+                    { "$subtract": ["$t", { "$mod": ["$t", WEEK_MS] }] },
+                ]
+            },
+            "m": { "$subtract": ["$t", { "$mod": ["$t", LOADOUT_CHUNK_MS] }] },
+        }
+    }
+}
+
+fn commander_condition(primary: &str, secondary: &str, ids: &[Bson]) -> Document {
+    doc! {
+        "$and": [
+            { "$in": [primary, ids.to_vec()] },
+            { "$in": [secondary, ids.to_vec()] },
+            { "$ne": [primary, secondary] },
+        ]
+    }
+}
+
+fn conditional_entry(condition: Document, entry: Document) -> Document {
+    doc! {
+        "$cond": [
+            condition,
+            Bson::Array(vec![Bson::Document(entry)]),
+            Bson::Array(Vec::new()),
+        ]
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn perspective_entry(
+    primary: &'static str,
+    secondary: &'static str,
+    player: &'static str,
+    primary_path: &'static str,
+    scenario: impl Into<Bson>,
+    own_results: &'static str,
+    enemy_results: &'static str,
+    shape: EntryShape,
+) -> Document {
+    let mut entry = doc! {
+        "p": primary,
+        "s": secondary,
+        "t": normalize_timestamp_expr(doc! { "$ifNull": ["$metadata.mail_time", 0_i64] }),
+        "u": { "$ifNull": [player, 0_i64] },
+        "c": scenario.into(),
+    };
+
+    match shape {
+        EntryShape::Performance => {
+            let inflicted = numeric_field(enemy_results, "severely_wounded");
+            entry.extend(doc! {
+                "kg": numeric_field(own_results, "kill_points"),
+                "kl": numeric_field(enemy_results, "kill_points"),
+                "si": inflicted.clone(),
+                "st": numeric_field(own_results, "severely_wounded"),
+                "du": battle_duration_expr(),
+                "da": { "$add": [numeric_field(enemy_results, "slightly_wounded"), inflicted] },
+                "h": numeric_field(own_results, "heal"),
+            });
+        }
+        EntryShape::Loadout => {
+            entry.extend(doc! {
+                "f": { "$ifNull": [format!("{primary_path}.formation"), 0_i64] },
+                "e": { "$ifNull": [format!("{primary_path}.equipment"), Bson::Null] },
+                "a": { "$ifNull": [format!("{primary_path}.armaments"), []] },
+            });
+        }
+    }
+    entry
+}
+
+fn numeric_field(path: &str, field: &str) -> Document {
+    doc! { "$toLong": { "$ifNull": [format!("${path}.{field}"), 0_i64] } }
+}
+
+fn sender_scenario_expr() -> Document {
+    doc! {
+        "$switch": {
+            "branches": [
+                { "case": sender_garrison_expr(), "then": 4_i64 },
+                { "case": { "$eq": ["$sender.rally", true] }, "then": 3_i64 },
+                { "case": opponent_rally_or_garrison_expr(), "then": 2_i64 },
+            ],
+            "default": 1_i64,
+        }
+    }
+}
+
+fn opponent_scenario_expr() -> Document {
+    doc! {
+        "$switch": {
+            "branches": [
+                { "case": opponent_garrison_expr(), "then": 4_i64 },
+                { "case": { "$eq": ["$opponents.rally", true] }, "then": 3_i64 },
+                {
+                    "case": { "$or": [sender_garrison_expr(), { "$eq": ["$sender.rally", true] }] },
+                    "then": 2_i64,
+                },
+            ],
+            "default": 1_i64,
+        }
+    }
+}
+
+fn sender_garrison_expr() -> Document {
+    doc! {
+        "$or": [
+            { "$ne": [{ "$ifNull": ["$sender.alliance_building_id", Bson::Null] }, Bson::Null] },
+            { "$ne": [{ "$ifNull": ["$sender.structure_id", Bson::Null] }, Bson::Null] },
+        ]
+    }
+}
+
+fn opponent_garrison_expr() -> Document {
+    doc! {
+        "$or": [
+            { "$ne": [{ "$ifNull": ["$opponents.alliance_building_id", Bson::Null] }, Bson::Null] },
+            { "$ne": [{ "$ifNull": ["$opponents.structure_id", Bson::Null] }, Bson::Null] },
+        ]
+    }
+}
+
+fn opponent_rally_or_garrison_expr() -> Document {
+    doc! {
+        "$gt": [
+            {
+                "$size": {
+                    "$filter": {
+                        "input": { "$ifNull": ["$opponents", []] },
+                        "as": "opponent",
+                        "cond": {
+                            "$or": [
+                                { "$eq": ["$$opponent.rally", true] },
+                                { "$ne": [{ "$ifNull": ["$$opponent.alliance_building_id", Bson::Null] }, Bson::Null] },
+                                { "$ne": [{ "$ifNull": ["$$opponent.structure_id", Bson::Null] }, Bson::Null] },
+                            ]
+                        },
+                    }
+                }
+            },
+            0_i64,
+        ]
+    }
+}
+
+fn battle_duration_expr() -> Document {
+    doc! {
+        "$toLong": {
+            "$max": [
+                0_i64,
+                {
+                    "$subtract": [
+                        normalize_timestamp_expr(doc! {
+                            "$add": [
+                                { "$ifNull": ["$timeline.start_timestamp", 0_i64] },
+                                { "$ifNull": ["$opponents.end_tick", 0_i64] },
+                            ]
+                        }),
+                        normalize_timestamp_expr(doc! {
+                            "$add": [
+                                { "$ifNull": ["$timeline.start_timestamp", 0_i64] },
+                                { "$ifNull": ["$opponents.start_tick", 0_i64] },
+                            ]
+                        }),
+                    ]
+                },
+            ]
+        }
+    }
+}
+
+fn normalize_timestamp_expr(value: Document) -> Document {
+    doc! {
+        "$toLong": {
+            "$let": {
+                "vars": { "raw": value.clone(), "abs": { "$abs": value } },
+                "in": {
+                    "$switch": {
+                        "branches": [
+                            {
+                                "case": { "$lt": ["$$abs", 1_000_000_000_000_f64] },
+                                "then": { "$multiply": ["$$raw", 1_000.0] },
+                            },
+                            {
+                                "case": { "$gte": ["$$abs", 100_000_000_000_000_000_f64] },
+                                "then": { "$divide": ["$$raw", 1_000_000.0] },
+                            },
+                            {
+                                "case": { "$gte": ["$$abs", 100_000_000_000_000_f64] },
+                                "then": { "$divide": ["$$raw", 1_000.0] },
+                            },
+                        ],
+                        "default": "$$raw",
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn performance_pipeline_groups_once_by_day_instead_of_expanding_time_ranges() {
+        let pipeline = performance_pipeline(&[1, 2], 0, 100);
+        let rendered = format!("{pipeline:?}");
+
+        assert!(!rendered.contains("range"));
+        assert_eq!(rendered.matches("$unwind").count(), 3);
+        assert!(!rendered.contains("$dateTrunc"));
+        assert!(!rendered.contains("$sort"));
+        assert!(rendered.contains("\"m\""));
+        assert!(rendered.contains("\"d\""));
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/scheduler.rs
+++ b/crates/apps/rokbattles-jobs/src/scheduler.rs
@@ -12,6 +12,7 @@ use crate::{
     precompute_barbarianfort::precompute_barbarian_fort_data,
     precompute_baulur::precompute_baulur_data,
     precompute_cmdr_pairings::precompute_commander_pairings_data,
+    precompute_cmdr_pairings_v2::precompute_commander_pairings_v2_data,
     precompute_kahar_treasure::precompute_kahar_treasure_data,
     precompute_karuak_ceremony::precompute_karuak_ceremony_data,
     refresh_binds::refresh_claimed_governor_bindings,
@@ -31,6 +32,8 @@ pub const PRECOMPUTE_KAHAR_TREASURE_CRON: &str = "0 0 */8 * * *";
 pub const PRECOMPUTE_KARUAK_CEREMONY_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
 pub const PRECOMPUTE_COMMANDER_PAIRINGS_CRON: &str = "0 0 */8 * * *";
+/// Every 8 hours, offset four hours from the existing commander pairing job.
+pub const PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON: &str = "0 0 4,12,20 * * *";
 
 /// Create the scheduler with the governor bind refresh job registered.
 pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler, JobsError> {
@@ -43,6 +46,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
     let kahar_treasure_lock = Arc::new(Mutex::new(()));
     let karuak_ceremony_lock = Arc::new(Mutex::new(()));
     let commander_pairings_lock = Arc::new(Mutex::new(()));
+    let commander_pairings_v2_lock = Arc::new(Mutex::new(()));
 
     add_locked_job(
         &scheduler,
@@ -188,7 +192,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
     add_locked_job(
         &scheduler,
         PRECOMPUTE_COMMANDER_PAIRINGS_CRON,
-        reports_store,
+        Arc::clone(&reports_store),
         commander_pairings_lock,
         "commander pairings precompute is already running; skipping this tick",
         |reports_store| async move {
@@ -207,6 +211,34 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
                 }
                 Err(error) => {
                     error!(%error, "failed to precompute commander pairings data");
+                }
+            }
+        },
+    )
+    .await?;
+
+    add_locked_job(
+        &scheduler,
+        PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON,
+        reports_store,
+        commander_pairings_v2_lock,
+        "compact commander pairings precompute is already running; skipping this tick",
+        |reports_store| async move {
+            match precompute_commander_pairings_v2_data(&reports_store).await {
+                Ok(stats) => info!(
+                    legendary_commanders = stats.legendary_commanders,
+                    pairings = stats.pairings,
+                    performance_points = stats.performance_points,
+                    loadout_snapshots = stats.loadout_snapshots,
+                    documents_written = stats.documents_written,
+                    max_document_bytes = stats.max_document_bytes,
+                    performance_seconds = stats.performance_seconds,
+                    loadout_seconds = stats.loadout_seconds,
+                    total_seconds = stats.total_seconds,
+                    "precomputed compact commander pairings data"
+                ),
+                Err(error) => {
+                    error!(%error, "failed to precompute compact commander pairings data")
                 }
             }
         },
@@ -252,8 +284,8 @@ where
 mod tests {
     use super::{
         PRECOMPUTE_BARBARIAN_CRON, PRECOMPUTE_BARBARIAN_FORT_CRON, PRECOMPUTE_BAULUR_CRON,
-        PRECOMPUTE_COMMANDER_PAIRINGS_CRON, PRECOMPUTE_KAHAR_TREASURE_CRON,
-        PRECOMPUTE_KARUAK_CEREMONY_CRON, REFRESH_BINDS_CRON,
+        PRECOMPUTE_COMMANDER_PAIRINGS_CRON, PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON,
+        PRECOMPUTE_KAHAR_TREASURE_CRON, PRECOMPUTE_KARUAK_CEREMONY_CRON, REFRESH_BINDS_CRON,
     };
 
     #[test]
@@ -284,6 +316,11 @@ mod tests {
     #[test]
     fn precompute_commander_pairings_cron_runs_every_eight_hours_utc() {
         assert_eq!(PRECOMPUTE_COMMANDER_PAIRINGS_CRON, "0 0 */8 * * *");
+    }
+
+    #[test]
+    fn compact_commander_pairings_cron_runs_at_four_twelve_and_twenty_utc() {
+        assert_eq!(PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON, "0 0 4,12,20 * * *");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- generate compact Combat Lab performance and loadout aggregates
- reuse completed DRASTC results from the existing pairing collection
- store generation-scoped chunk documents with supporting indexes
- schedule refreshes at 04:00, 12:00, and 20:00 UTC

## Why

The redesigned Combat Lab needs time-series performance and build data for roughly 12,000 commander pairings without producing oversized MongoDB documents.

## Impact

The job performs partitioned aggregation, compact packing, bulk writes, and generation cleanup while leaving the existing v1 job and routes unchanged.

## Docker

No Dockerfile update is required. The jobs build binds the repository root into `/src`, `datasets/` is included in the build context, and Rust embeds the YAML through `include_str!` at compile time.

## Validation

- `cargo test -p rokbattles-api -p rokbattles-jobs`
- `cargo clippy -p rokbattles-api -p rokbattles-jobs --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`