### PR TITLE
feat(combat-lab): add v2 API and experience

### DIFF
--- a/crates/apps/rokbattles-api/src/routes/combat_lab/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab/mod.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{error::ApiError, state::AppState};
 
+pub(super) mod v2;
+
 /// Returns one precomputed legendary commander pairing for Combat Lab.
 pub async fn get_pairing(
     State(state): State<Arc<AppState>>,

--- a/crates/apps/rokbattles-api/src/routes/combat_lab/v2.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab/v2.rs
@@ -1,0 +1,238 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, LazyLock},
+};
+
+use axum::{
+    Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use futures::TryStreamExt;
+use mongodb::{
+    bson::{Bson, Document, doc},
+    options::FindOneOptions,
+};
+use rokbattles_bson::{bson_to_f64, bson_to_i64};
+use serde::{Deserialize, Serialize};
+
+use super::{CategoryScore, DrastcCategories, DrastcConfidence, DrastcScore, parse_required_i64};
+use crate::{error::ApiError, state::AppState};
+
+const ARMAMENTS_YAML: &str = include_str!("../../../../../../datasets/armaments.yaml");
+static ARMAMENT_MAXIMUMS: LazyLock<Option<BTreeMap<i64, f64>>> =
+    LazyLock::new(|| read_armament_maximums().ok());
+
+/// Return one completed compact Combat Lab generation.
+pub async fn get_pairing(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let primary = parse_required_i64(&params, "primary")?;
+    let secondary = parse_required_i64(&params, "secondary")?;
+    if primary == secondary {
+        return Err(ApiError::bad_request("Commanders must be different"));
+    }
+
+    let collection = state.reports_store.precomputed_commander_pairings_v2_collection();
+    let root_options =
+        FindOneOptions::builder().projection(doc! { "_id": 0 }).sort(doc! { "g": -1 }).build();
+    let Some(root) = collection
+        .find_one(doc! { "k": 0_i64, "p": primary, "s": secondary })
+        .with_options(root_options)
+        .await
+        .map_err(internal_mongo)?
+    else {
+        return Err(ApiError::not_found("pairing not found"));
+    };
+    let generation = root
+        .get_datetime("g")
+        .copied()
+        .map_err(|error| ApiError::internal(format!("invalid Combat Lab generation: {error}")))?;
+    let summaries = root
+        .get_array("r")
+        .cloned()
+        .map_err(|error| ApiError::internal(format!("invalid Combat Lab summaries: {error}")))?;
+    let drastc = root.get("d").map(map_drastc).transpose()?;
+    let armament_maximums = ARMAMENT_MAXIMUMS
+        .as_ref()
+        .ok_or_else(|| ApiError::internal("invalid embedded armament dataset"))?;
+
+    let cursor = collection
+        .find(doc! {
+            "k": { "$in": [1_i64, 2_i64] },
+            "p": primary,
+            "s": secondary,
+            "g": generation,
+        })
+        .projection(doc! { "_id": 0, "k": 1, "m": 1, "q": 1, "v": 1 })
+        .sort(doc! { "k": 1, "m": 1, "q": 1 })
+        .await
+        .map_err(internal_mongo)?;
+    let chunks: Vec<Document> = cursor.try_collect().await.map_err(internal_mongo)?;
+    let mut performance = Vec::new();
+    let mut loadouts = Vec::new();
+    for chunk in chunks {
+        let kind = direct_i64(&chunk, "k")
+            .ok_or_else(|| ApiError::internal("compact Combat Lab chunk is missing its kind"))?;
+        let values = chunk.get_array("v").map_err(|error| {
+            ApiError::internal(format!("invalid compact Combat Lab chunk: {error}"))
+        })?;
+        match kind {
+            1 => performance.extend(values.iter().cloned()),
+            2 => loadouts.extend(values.iter().cloned()),
+            _ => {}
+        }
+    }
+
+    let response = CombatLabV2Response {
+        generated_at_ms: generation.timestamp_millis(),
+        pairing: Pairing { primary_commander_id: primary, secondary_commander_id: secondary },
+        drastc,
+        summaries,
+        performance,
+        loadouts,
+        armament_maximums,
+    };
+    Ok((StatusCode::OK, [("Cache-Control", "public, max-age=3600")], Json(response)))
+}
+
+fn map_drastc(value: &Bson) -> Result<DrastcScore, ApiError> {
+    let values = tuple(value, "DRASTC")?;
+    let categories = values
+        .get(5)
+        .and_then(Bson::as_array)
+        .ok_or_else(|| ApiError::internal("compact DRASTC categories are missing"))?;
+    let category = |index| -> Result<CategoryScore, ApiError> {
+        let values = categories
+            .get(index)
+            .ok_or_else(|| ApiError::internal("compact DRASTC category is missing"))?;
+        let values = tuple(values, "DRASTC category")?;
+        Ok(CategoryScore {
+            value: tuple_f64(values, 0)?,
+            p10: tuple_f64(values, 1)?,
+            p90: tuple_f64(values, 2)?,
+            score: tuple_f64(values, 3)?,
+        })
+    };
+
+    Ok(DrastcScore {
+        samples: tuple_i64(values, 0)?,
+        overall: tuple_f64(values, 1)?,
+        confidence: DrastcConfidence {
+            score: tuple_f64(values, 2)?,
+            unique_governors: tuple_i64(values, 3)?,
+            effective_governors: tuple_f64(values, 4)?,
+        },
+        breakdown: DrastcCategories {
+            damage: category(0)?,
+            rage: category(1)?,
+            assist: category(2)?,
+            sustainability: category(3)?,
+            trade: category(4)?,
+            consistency: category(5)?,
+        },
+    })
+}
+
+fn tuple<'a>(value: &'a Bson, label: &str) -> Result<&'a [Bson], ApiError> {
+    value
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| ApiError::internal(format!("compact {label} is not an array")))
+}
+
+fn tuple_i64(values: &[Bson], index: usize) -> Result<i64, ApiError> {
+    values
+        .get(index)
+        .and_then(bson_to_i64)
+        .ok_or_else(|| ApiError::internal(format!("compact tuple index {index} is not an integer")))
+}
+
+fn tuple_f64(values: &[Bson], index: usize) -> Result<f64, ApiError> {
+    values
+        .get(index)
+        .and_then(bson_to_f64)
+        .ok_or_else(|| ApiError::internal(format!("compact tuple index {index} is not numeric")))
+}
+
+fn direct_i64(document: &Document, key: &str) -> Option<i64> {
+    document.get(key).and_then(bson_to_i64)
+}
+
+fn internal_mongo(error: mongodb::error::Error) -> ApiError {
+    ApiError::internal(error.to_string())
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CombatLabV2Response<'a> {
+    generated_at_ms: i64,
+    pairing: Pairing,
+    drastc: Option<DrastcScore>,
+    summaries: Vec<Bson>,
+    performance: Vec<Bson>,
+    loadouts: Vec<Bson>,
+    armament_maximums: &'a BTreeMap<i64, f64>,
+}
+
+fn read_armament_maximums() -> Result<BTreeMap<i64, f64>, yaml_serde::Error> {
+    let dataset: ArmamentDataset = yaml_serde::from_str(ARMAMENTS_YAML)?;
+    Ok(dataset
+        .armaments
+        .into_iter()
+        .filter_map(|(id, definition)| {
+            let maximum = definition.max_roll?;
+            (id > 0 && maximum.is_finite() && maximum >= 0.0).then_some((id, maximum))
+        })
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct ArmamentDataset {
+    armaments: BTreeMap<i64, ArmamentDefinition>,
+}
+
+#[derive(Deserialize)]
+struct ArmamentDefinition {
+    max_roll: Option<f64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Pairing {
+    primary_commander_id: i64,
+    secondary_commander_id: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_drastc_maps_fixed_category_order() {
+        let category = Bson::Array(vec![1.0.into(), 2.0.into(), 3.0.into(), 4.0.into()]);
+        let value = Bson::Array(vec![
+            10_i64.into(),
+            80.0.into(),
+            95.0.into(),
+            20_i64.into(),
+            12.5.into(),
+            Bson::Array(vec![category; 6]),
+        ]);
+
+        let score = map_drastc(&value).expect("DRASTC");
+
+        assert_eq!(score.samples, 10);
+        assert_eq!(score.breakdown.consistency.score, 4.0);
+        assert_eq!(score.confidence.unique_governors, 20);
+    }
+
+    #[test]
+    fn armament_yaml_contains_expected_maximum_rolls() {
+        let maximums = read_armament_maximums().expect("armament maximums");
+
+        assert_eq!(maximums.get(&10_002), Some(&0.02));
+    }
+}

--- a/crates/apps/rokbattles-api/src/routes/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/mod.rs
@@ -13,7 +13,14 @@ mod reports;
 
 /// Build the top-level API router.
 pub fn router() -> Router<Arc<AppState>> {
-    Router::new().route("/health", get(health::get)).nest("/v1", v1_router())
+    Router::new()
+        .route("/health", get(health::get))
+        .nest("/v1", v1_router())
+        .nest("/v2", v2_router())
+}
+
+fn v2_router() -> Router<Arc<AppState>> {
+    Router::new().route("/global/combat-lab", get(combat_lab::v2::get_pairing))
 }
 
 fn v1_router() -> Router<Arc<AppState>> {

--- a/packages/site/src/app/(legacy)/combat-lab/new/page.tsx
+++ b/packages/site/src/app/(legacy)/combat-lab/new/page.tsx
@@ -1,0 +1,21 @@
+import { getLocale } from "next-intl/server";
+import { CombatLabPreview } from "@/components/combat-lab/new/combat-lab-preview";
+import { fetchCombatLabPreview } from "@/lib/combat-lab/preview-api";
+
+export default async function CombatLabPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ primary?: string; secondary?: string }>;
+}) {
+  const params = await searchParams;
+  const primary = positiveInteger(params.primary) ?? 509;
+  const secondary = positiveInteger(params.secondary) ?? 6;
+  const locale = await getLocale();
+  const data = await fetchCombatLabPreview({ primary, secondary, locale });
+  return <CombatLabPreview data={data} />;
+}
+
+function positiveInteger(value: string | undefined): number | null {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
+}

--- a/packages/site/src/components/combat-lab/combat-lab-rankings-table.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-rankings-table.tsx
@@ -88,7 +88,7 @@ export function CombatLabRankingsTable({
         {items.map((item, index) => {
           const primaryName = getCommanderName(item.primaryCommanderId, locale) ?? "Unknown";
           const secondaryName = getCommanderName(item.secondaryCommanderId, locale) ?? "Unknown";
-          const href = `/combat-lab?primary=${item.primaryCommanderId}&secondary=${item.secondaryCommanderId}`;
+          const href = `/combat-lab/new?primary=${item.primaryCommanderId}&secondary=${item.secondaryCommanderId}`;
 
           return (
             <TableRow

--- a/packages/site/src/components/combat-lab/confidence-score.tsx
+++ b/packages/site/src/components/combat-lab/confidence-score.tsx
@@ -1,6 +1,7 @@
-import { useExtracted } from "next-intl";
+import { useExtracted, useLocale } from "next-intl";
+import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
-import { clampScore, scoreFormatter } from "@/lib/combat-lab/format";
+import { clampScore } from "@/lib/combat-lab/format";
 
 type ConfidenceScoreProps = {
   score: number;
@@ -10,6 +11,15 @@ type ConfidenceLevel = "veryLow" | "low" | "moderate" | "high" | "veryHigh";
 
 export function ConfidenceScore({ score }: ConfidenceScoreProps) {
   const t = useExtracted();
+  const locale = useLocale();
+  const scoreFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+      }),
+    [locale]
+  );
   const normalizedScore = clampScore(score);
   const percentage = Math.min(99.99, normalizedScore * 10);
   const level = getConfidenceLevel(normalizedScore);
@@ -22,7 +32,7 @@ export function ConfidenceScore({ score }: ConfidenceScoreProps) {
   }[level];
 
   return (
-    <div className="flex items-baseline justify-between gap-3">
+    <div className="flex items-baseline justify-between gap-2">
       <div className="flex min-w-0 items-center gap-2">
         <div className="truncate font-semibold text-sm text-zinc-950 dark:text-white">
           {t("Confidence")}

--- a/packages/site/src/components/combat-lab/new/combat-lab-preview-charts.tsx
+++ b/packages/site/src/components/combat-lab/new/combat-lab-preview-charts.tsx
@@ -1,0 +1,1434 @@
+"use client";
+
+import { useExtracted, useLocale } from "next-intl";
+import { useMemo, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  type TooltipContentProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { CombatLabPreviewEmptyState } from "@/components/combat-lab/new/combat-lab-preview-empty-state";
+import { Subheading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import { getArmamentInfo } from "@/hooks/use-armament-name";
+import { getEquipmentName } from "@/hooks/use-equipment-name";
+import { getFormationName } from "@/hooks/use-formation-name";
+import type {
+  CombatLabPreviewAccessoryPairings,
+  CombatLabPreviewArmamentSlot,
+  CombatLabPreviewEquipmentSlot,
+  CombatLabPreviewFormationUsagePoint,
+  CombatLabPreviewRangeKey,
+  CombatLabPreviewTrend,
+} from "@/lib/combat-lab/preview-types";
+import { toRomanNumeral } from "@/lib/equipment";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const formationColors = [
+  "#0891b2",
+  "#2563eb",
+  "#7c3aed",
+  "#e11d48",
+  "#059669",
+  "#d97706",
+  "#9333ea",
+  "#db2777",
+  "#65a30d",
+  "#ea580c",
+  "#4f46e5",
+  "#0d9488",
+  "#ca8a04",
+  "#c026d3",
+  "#0284c7",
+  "#16a34a",
+] as const;
+const equipmentColors = ["#2563eb", "#7c3aed", "#0891b2", "#059669", "#d97706"] as const;
+const iconicColors = ["#a1a1aa", "#2563eb", "#0891b2", "#7c3aed", "#d97706", "#e11d48"] as const;
+
+type MetricKey = "dps" | "sps" | "tps" | "hps";
+type InscriptionKey =
+  | "special"
+  | "rare"
+  | "common"
+  | "specialCommon"
+  | "rareCommon"
+  | "commonCommon";
+
+function formatBattleTempoValue(
+  value: number,
+  compactFormatter: Intl.NumberFormat,
+  decimalFormatter: Intl.NumberFormat
+) {
+  return Math.abs(value) >= 1_000 ? compactFormatter.format(value) : decimalFormatter.format(value);
+}
+
+function formatCount(
+  value: number,
+  compactFormatter: Intl.NumberFormat,
+  integerFormatter: Intl.NumberFormat
+) {
+  return Math.abs(value) >= 1_000
+    ? compactFormatter.format(value)
+    : integerFormatter.format(Math.round(value));
+}
+
+function numberOrZero(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function CombatLabPreviewCharts({
+  rangeKey,
+  trends,
+}: {
+  rangeKey: CombatLabPreviewRangeKey;
+  trends: CombatLabPreviewTrend[];
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const compactFormatter = createCompactFormatter(locale);
+  const decimalFormatter = createDecimalFormatter(locale);
+  const integerFormatter = createIntegerFormatter(locale);
+  const metricOptions = [
+    { key: "dps", label: t("Damage dealt"), color: "#2563eb" },
+    { key: "sps", label: t("Severely wounded inflicted"), color: "#7c3aed" },
+    { key: "tps", label: t("Severely wounded taken"), color: "#e11d48" },
+    { key: "hps", label: t("Healing"), color: "#059669" },
+  ] as const;
+  const [metric, setMetric] = useState<MetricKey>("dps");
+  const chartData = useMemo(
+    () => aggregateTrends(trends, rangeKey, locale),
+    [locale, rangeKey, trends]
+  );
+  const selectedMetric = metricOptions.find((option) => option.key === metric) ?? metricOptions[0];
+
+  if (!chartData.some((point) => point.battles > 0)) {
+    return (
+      <div className="grid gap-5 xl:grid-cols-2">
+        <EmptyChartCard
+          message={t("No kill-point history was observed for these filters.")}
+          title={t("Kill points")}
+        />
+        <EmptyChartCard
+          message={t("No per-second combat metrics were observed for these filters.")}
+          title={t("Battle tempo")}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-5 xl:grid-cols-2">
+      <article className="min-w-0 overflow-hidden rounded-md border border-zinc-950/10 bg-white dark:border-white/10 dark:bg-zinc-900">
+        <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+          <Subheading level={3}>{t("Kill points")}</Subheading>
+          <div className="mt-4 flex h-9 items-center gap-3 text-xs font-medium">
+            <ChartLegend color="bg-blue-600" label={t("Gained")} />
+            <ChartLegend color="bg-rose-500" label={t("Lost")} />
+          </div>
+        </div>
+        <div className="h-72 px-2 pt-5 pr-4 pb-3">
+          <ResponsiveContainer minWidth={0}>
+            <AreaChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+              <defs>
+                <linearGradient id="kp-gained" x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor="#2563eb" stopOpacity={0.3} />
+                  <stop offset="100%" stopColor="#2563eb" stopOpacity={0.02} />
+                </linearGradient>
+                <linearGradient id="kp-lost" x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stopColor="#f43f5e" stopOpacity={0.2} />
+                  <stop offset="100%" stopColor="#f43f5e" stopOpacity={0.01} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                stroke="rgba(113,113,122,.18)"
+                strokeDasharray="3 5"
+                vertical={false}
+              />
+              <XAxis
+                axisLine={false}
+                dataKey="date"
+                minTickGap={42}
+                tick={{ fill: "#71717a", fontSize: 11 }}
+                tickLine={false}
+              />
+              <YAxis
+                axisLine={false}
+                tick={{ fill: "#71717a", fontSize: 11 }}
+                tickFormatter={(value) =>
+                  formatCount(Number(value), compactFormatter, integerFormatter)
+                }
+                tickLine={false}
+                width={46}
+              />
+              <RechartsTooltip
+                content={(props) => (
+                  <ChartTooltip
+                    {...props}
+                    formatName={(dataKey) =>
+                      dataKey === "killPointsGained" ? t("Gained") : t("Lost")
+                    }
+                    formatValue={(value) => formatCount(value, compactFormatter, integerFormatter)}
+                  />
+                )}
+              />
+              <Area
+                dataKey="killPointsGained"
+                dot={false}
+                fill="url(#kp-gained)"
+                isAnimationActive={false}
+                stroke="#2563eb"
+                strokeWidth={2.25}
+                type="monotone"
+              />
+              <Area
+                dataKey="killPointsLost"
+                dot={false}
+                fill="url(#kp-lost)"
+                isAnimationActive={false}
+                stroke="#f43f5e"
+                strokeWidth={2}
+                type="monotone"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </article>
+
+      <article className="min-w-0 overflow-hidden rounded-md border border-zinc-950/10 bg-white dark:border-white/10 dark:bg-zinc-900">
+        <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+          <Subheading level={3}>{t("Battle tempo")}</Subheading>
+          <div className="mt-4 flex h-9 gap-1 overflow-x-auto rounded-lg bg-zinc-950/5 p-1 dark:bg-white/5">
+            {metricOptions.map((option) => (
+              <button
+                key={option.key}
+                aria-pressed={metric === option.key}
+                className="shrink-0 rounded-md px-2.5 py-1.5 font-medium text-xs text-zinc-600 transition data-[active=true]:bg-white data-[active=true]:text-zinc-950 dark:text-zinc-300 dark:data-[active=true]:bg-zinc-700 dark:data-[active=true]:text-white"
+                data-active={metric === option.key}
+                onClick={() => setMetric(option.key)}
+                type="button"
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="h-72 px-2 pt-5 pr-4 pb-3">
+          <ResponsiveContainer minWidth={0}>
+            <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+              <CartesianGrid
+                stroke="rgba(113,113,122,.18)"
+                strokeDasharray="3 5"
+                vertical={false}
+              />
+              <XAxis
+                axisLine={false}
+                dataKey="date"
+                minTickGap={42}
+                tick={{ fill: "#71717a", fontSize: 11 }}
+                tickLine={false}
+              />
+              <YAxis
+                axisLine={false}
+                tick={{ fill: "#71717a", fontSize: 11 }}
+                tickFormatter={(value) =>
+                  formatBattleTempoValue(Number(value), compactFormatter, decimalFormatter)
+                }
+                tickLine={false}
+                width={46}
+              />
+              <RechartsTooltip
+                content={(props) => (
+                  <ChartTooltip
+                    {...props}
+                    formatName={() => selectedMetric.label}
+                    formatValue={(value) =>
+                      formatBattleTempoValue(value, compactFormatter, decimalFormatter)
+                    }
+                  />
+                )}
+              />
+              <Line
+                dataKey={metric}
+                dot={false}
+                isAnimationActive={false}
+                stroke={selectedMetric.color}
+                strokeWidth={2.5}
+                type="monotone"
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function EmptyChartCard({ message, title }: { message: string; title: string }) {
+  return (
+    <article className="min-w-0 overflow-hidden rounded-md border border-zinc-950/10 bg-white dark:border-white/10 dark:bg-zinc-900">
+      <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+        <Subheading level={3}>{title}</Subheading>
+      </div>
+      <CombatLabPreviewEmptyState className="m-5 min-h-64" message={message} />
+    </article>
+  );
+}
+
+export function CombatLabPreviewFormationChart({
+  points,
+  rangeKey,
+}: {
+  points: CombatLabPreviewFormationUsagePoint[];
+  rangeKey: CombatLabPreviewRangeKey;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const decimalFormatter = createDecimalFormatter(locale);
+  const { chartData, series } = useMemo(
+    () =>
+      aggregateFormationUsage(points, rangeKey, locale, (id) =>
+        t("Formation {id}", { id: id.toString() })
+      ),
+    [locale, points, rangeKey, t]
+  );
+  const seriesByKey = useMemo(
+    () => new Map(series.map((formation) => [formation.dataKey, formation.name])),
+    [series]
+  );
+
+  if (chartData.length === 0 || series.length === 0) {
+    return (
+      <article className="min-w-0 overflow-hidden rounded-md border border-zinc-950/10 bg-white xl:col-span-2 dark:border-white/10 dark:bg-zinc-900">
+        <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+          <Subheading level={3}>{t("Formation usage")}</Subheading>
+        </div>
+        <CombatLabPreviewEmptyState
+          className="m-5 min-h-72 sm:m-6 sm:min-h-80"
+          message={t("No formations were observed for these filters.")}
+        />
+      </article>
+    );
+  }
+
+  return (
+    <article className="min-w-0 overflow-hidden rounded-md border border-zinc-950/10 bg-white xl:col-span-2 dark:border-white/10 dark:bg-zinc-900">
+      <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+        <Subheading level={3}>{t("Formation usage")}</Subheading>
+        <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs font-medium">
+          {series.map((formation) => (
+            <span
+              key={formation.id}
+              className="inline-flex items-center gap-1.5 text-zinc-600 dark:text-zinc-300"
+            >
+              <span className="size-2 rounded-full" style={{ backgroundColor: formation.color }} />
+              {formation.name}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="h-80 px-2 pt-5 pr-4 pb-3 sm:h-96">
+        <ResponsiveContainer minWidth={0}>
+          <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+            <CartesianGrid stroke="rgba(113,113,122,.18)" strokeDasharray="3 5" vertical={false} />
+            <XAxis
+              axisLine={false}
+              dataKey="date"
+              minTickGap={42}
+              tick={{ fill: "#71717a", fontSize: 11 }}
+              tickLine={false}
+            />
+            <YAxis
+              axisLine={false}
+              domain={[0, 100]}
+              tick={{ fill: "#71717a", fontSize: 11 }}
+              tickFormatter={(value) => `${Number(value).toFixed(0)}%`}
+              tickLine={false}
+              width={46}
+            />
+            <RechartsTooltip
+              content={(props) => (
+                <ChartTooltip
+                  {...props}
+                  formatName={(dataKey) =>
+                    seriesByKey.get(String(dataKey)) ?? t("Unknown formation")
+                  }
+                  formatValue={(value) => `${decimalFormatter.format(value)}%`}
+                />
+              )}
+            />
+            {series.map((formation) => (
+              <Line
+                key={formation.id}
+                dataKey={formation.dataKey}
+                dot={false}
+                isAnimationActive={false}
+                name={formation.name}
+                stroke={formation.color}
+                strokeWidth={formation.id === 2 ? 2.75 : 1.75}
+                type="monotone"
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </article>
+  );
+}
+
+export function CombatLabPreviewArmamentChart({
+  rangeKey,
+  slot,
+}: {
+  rangeKey: CombatLabPreviewRangeKey;
+  slot: CombatLabPreviewArmamentSlot;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const decimalFormatter = createDecimalFormatter(locale);
+  const inscriptionOptions = [
+    { key: "special", label: t("Special"), color: "#2563eb" },
+    { key: "rare", label: t("Rare"), color: "#7c3aed" },
+    { key: "common", label: t("Common"), color: "#71717a" },
+    { key: "specialCommon", label: t("Special + Common"), color: "#0891b2" },
+    { key: "rareCommon", label: t("Rare + Common"), color: "#d97706" },
+    { key: "commonCommon", label: t("Common + Common"), color: "#059669" },
+  ] as const;
+  const buffOptions = useMemo(
+    () => getArmamentBuffOptions(slot, locale, (id) => t("Buff {id}", { id: id.toString() })),
+    [locale, slot, t]
+  );
+  const [requestedBuffId, setRequestedBuffId] = useState<number | null>(null);
+  const selectedBuffId = buffOptions.some((buff) => buff.id === requestedBuffId)
+    ? requestedBuffId
+    : (buffOptions[0]?.id ?? null);
+  const { chartData, inscriptionSeries } = useMemo(
+    () => aggregateArmamentUsage(slot, rangeKey, selectedBuffId, locale, inscriptionOptions),
+    [inscriptionOptions, locale, rangeKey, selectedBuffId, slot]
+  );
+  const selectedBuff = buffOptions.find((buff) => buff.id === selectedBuffId);
+  const selectedBuffInfo = selectedBuff ? getArmamentInfo(selectedBuff.id, locale) : undefined;
+
+  if (!slot.points.some((point) => point.sampleSize > 0)) {
+    return (
+      <CombatLabPreviewEmptyState
+        className="min-h-[34rem]"
+        message={t("No armaments were observed for these filters.")}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-7">
+      <div>
+        <Subheading level={4}>{t("Inscription usage")}</Subheading>
+        <div className="mt-3 flex min-h-9 flex-wrap gap-x-3 gap-y-2 text-xs font-medium">
+          {inscriptionSeries.map((series) => (
+            <span
+              className="inline-flex items-center gap-1.5 text-zinc-600 dark:text-zinc-300"
+              key={series.key}
+            >
+              <span className="size-2 rounded-full" style={{ backgroundColor: series.color }} />
+              {series.label}
+            </span>
+          ))}
+        </div>
+        <div className="mt-2 h-52">
+          <ResponsiveContainer minWidth={0}>
+            <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 0 }}>
+              <CartesianGrid
+                stroke="rgba(113,113,122,.18)"
+                strokeDasharray="3 5"
+                vertical={false}
+              />
+              <XAxis
+                axisLine={false}
+                dataKey="date"
+                minTickGap={36}
+                tick={{ fill: "#71717a", fontSize: 10 }}
+                tickLine={false}
+              />
+              <YAxis
+                axisLine={false}
+                domain={[0, 100]}
+                tick={{ fill: "#71717a", fontSize: 10 }}
+                tickFormatter={(value) => `${Number(value).toFixed(0)}%`}
+                tickLine={false}
+                width={40}
+              />
+              <RechartsTooltip
+                content={(props) => (
+                  <ChartTooltip
+                    {...props}
+                    formatName={(dataKey) =>
+                      inscriptionOptions.find((option) => option.key === dataKey)?.label ??
+                      t("Inscription")
+                    }
+                    formatValue={(value) => `${decimalFormatter.format(value)}%`}
+                  />
+                )}
+              />
+              {inscriptionSeries.map((series) => (
+                <Line
+                  dataKey={series.key}
+                  dot={false}
+                  isAnimationActive={false}
+                  key={series.key}
+                  stroke={series.color}
+                  strokeWidth={series.key === "common" ? 2.5 : 1.75}
+                  type="monotone"
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div>
+        <Subheading level={4}>{t("Buff rolls")}</Subheading>
+        <div className="mt-3 flex gap-1 overflow-x-auto rounded-lg bg-zinc-950/5 p-1 dark:bg-white/5">
+          {buffOptions.map((buff) => (
+            <button
+              aria-pressed={selectedBuffId === buff.id}
+              className="shrink-0 rounded-md px-2.5 py-1.5 font-medium text-xs text-zinc-600 transition data-[active=true]:bg-white data-[active=true]:text-zinc-950 dark:text-zinc-300 dark:data-[active=true]:bg-zinc-700 dark:data-[active=true]:text-white"
+              data-active={selectedBuffId === buff.id}
+              key={buff.id}
+              onClick={() => setRequestedBuffId(buff.id)}
+              type="button"
+            >
+              {buff.name}
+            </button>
+          ))}
+        </div>
+        <div className="mt-2 h-52">
+          {selectedBuffId === null ? (
+            <Text className="flex h-full items-center justify-center !text-sm">
+              {t("No buff rolls observed.")}
+            </Text>
+          ) : (
+            <ResponsiveContainer minWidth={0}>
+              <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 0 }}>
+                <CartesianGrid
+                  stroke="rgba(113,113,122,.18)"
+                  strokeDasharray="3 5"
+                  vertical={false}
+                />
+                <XAxis
+                  axisLine={false}
+                  dataKey="date"
+                  minTickGap={36}
+                  tick={{ fill: "#71717a", fontSize: 10 }}
+                  tickLine={false}
+                />
+                <YAxis
+                  allowDataOverflow
+                  axisLine={false}
+                  domain={[0, selectedBuff?.maximumRoll ?? "auto"]}
+                  tick={{ fill: "#71717a", fontSize: 10 }}
+                  tickFormatter={(value) =>
+                    formatArmamentValue(Number(value), decimalFormatter, selectedBuffInfo?.percent)
+                  }
+                  tickLine={false}
+                  width={48}
+                />
+                <RechartsTooltip
+                  content={(props) => (
+                    <ArmamentBuffTooltip
+                      {...props}
+                      averageRollLabel={t("Average roll")}
+                      buffName={selectedBuff?.name ?? t("Buff")}
+                      decimalFormatter={decimalFormatter}
+                      maxRollUsageLabel={t("Max roll usage")}
+                      percent={selectedBuffInfo?.percent}
+                      usageLabel={t("Usage")}
+                    />
+                  )}
+                />
+                <Line
+                  dataKey="buffAverage"
+                  dot={false}
+                  isAnimationActive={false}
+                  stroke="#7c3aed"
+                  strokeWidth={2.5}
+                  type="monotone"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CombatLabPreviewEquipmentChart({
+  accessoryPairings,
+  rangeKey,
+  slot,
+}: {
+  accessoryPairings?: CombatLabPreviewAccessoryPairings;
+  rangeKey: CombatLabPreviewRangeKey;
+  slot: CombatLabPreviewEquipmentSlot;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const compactFormatter = createCompactFormatter(locale);
+  const decimalFormatter = createDecimalFormatter(locale);
+  const integerFormatter = createIntegerFormatter(locale);
+  const { chartData, iconicData, nonLegendaryCount, series, specialTalentData, totals } = useMemo(
+    () =>
+      aggregateEquipmentUsage(slot, rangeKey, locale, {
+        iconic: (level) => `${t("Iconic")} ${level}`,
+        item: (id) => t("Item {id}", { id: id.toString() }),
+        noIconic: t("No iconic"),
+        noSpecialTalent: t("No special talent"),
+        otherPieces: t("Other pieces"),
+        specialTalent: t("Special talent"),
+      }),
+    [locale, rangeKey, slot, t]
+  );
+  const namesByKey = useMemo(
+    () => new Map(series.map((item) => [item.dataKey, item.name])),
+    [series]
+  );
+  const specialTalentPercent =
+    totals.observations > 0 ? (totals.specialTalent / totals.observations) * 100 : 0;
+  const accessoryPairingData = useMemo(
+    () =>
+      getAccessoryPairingData(accessoryPairings, locale, {
+        item: (id) => t("Item {id}", { id: id.toString() }),
+        otherPairings: t("Other pairings"),
+      }),
+    [accessoryPairings, locale, t]
+  );
+
+  if (totals.observations <= 0) {
+    return (
+      <CombatLabPreviewEmptyState
+        className="min-h-[31rem]"
+        message={t("No equipment was observed for these filters.")}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-7">
+      <div>
+        <Subheading level={4}>{t("Piece usage")}</Subheading>
+        <div className="mt-3 flex min-h-9 flex-wrap gap-x-3 gap-y-2 text-xs font-medium">
+          {series.map((item) => (
+            <span
+              className="inline-flex min-w-0 items-center gap-1.5 text-zinc-600 dark:text-zinc-300"
+              key={item.dataKey}
+              title={item.name}
+            >
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: item.color }}
+              />
+              <span className="max-w-44 truncate">{item.name}</span>
+            </span>
+          ))}
+        </div>
+        <div className="mt-2 h-52">
+          <ResponsiveContainer minWidth={0}>
+            <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 4, left: 0 }}>
+              <CartesianGrid
+                stroke="rgba(113,113,122,.18)"
+                strokeDasharray="3 5"
+                vertical={false}
+              />
+              <XAxis
+                axisLine={false}
+                dataKey="date"
+                minTickGap={36}
+                tick={{ fill: "#71717a", fontSize: 10 }}
+                tickLine={false}
+              />
+              <YAxis
+                axisLine={false}
+                domain={[0, 100]}
+                tick={{ fill: "#71717a", fontSize: 10 }}
+                tickFormatter={(value) => `${Number(value).toFixed(0)}%`}
+                tickLine={false}
+                width={40}
+              />
+              <RechartsTooltip
+                content={(props) => (
+                  <ChartTooltip
+                    {...props}
+                    formatName={(dataKey) => namesByKey.get(String(dataKey)) ?? t("Equipment")}
+                    formatValue={(value) => `${decimalFormatter.format(value)}%`}
+                  />
+                )}
+              />
+              {series.map((item) => (
+                <Line
+                  dataKey={item.dataKey}
+                  dot={false}
+                  isAnimationActive={false}
+                  key={item.dataKey}
+                  stroke={item.color}
+                  strokeWidth={item.isOther ? 1.5 : 2}
+                  strokeDasharray={item.isOther ? "4 4" : undefined}
+                  type="monotone"
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+
+      <div className={`grid gap-6 ${slot.slot === 7 ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
+        <EquipmentDonut
+          ariaLabel={t("Iconic level distribution among legendary equipment")}
+          centerLabel={t("legendary")}
+          centerValue={formatCount(totals.legendary, compactFormatter, integerFormatter)}
+          data={iconicData}
+          emptyLabel={t("No legendary pieces observed.")}
+          title={t("Iconic levels")}
+          tooltipLabels={{ count: t("Count"), usage: t("Usage") }}
+          decimalFormatter={decimalFormatter}
+        />
+        <EquipmentDonut
+          ariaLabel={t("Special talent usage across equipment")}
+          centerLabel={t("special talent")}
+          centerValue={`${decimalFormatter.format(specialTalentPercent)}%`}
+          data={specialTalentData}
+          emptyLabel={t("No talent data observed.")}
+          title={t("Special talent")}
+          tooltipLabels={{ count: t("Count"), usage: t("Usage") }}
+          decimalFormatter={decimalFormatter}
+        />
+        {slot.slot === 7 ? (
+          <EquipmentDonut
+            ariaLabel={t("Most common order-agnostic accessory pairings")}
+            centerLabel={t("pairings")}
+            centerValue={formatCount(
+              accessoryPairings?.sampleSize ?? 0,
+              compactFormatter,
+              integerFormatter
+            )}
+            data={accessoryPairingData}
+            emptyLabel={t("No complete accessory pairings observed.")}
+            title={t("Accessory pairings")}
+            tooltipLabels={{ count: t("Count"), usage: t("Usage") }}
+            decimalFormatter={decimalFormatter}
+          />
+        ) : null}
+      </div>
+      <Text className="text-center !text-xs/5">
+        {t(
+          "{count, plural, one {# piece of equipment was excluded from iconic levels because it was not legendary.} other {# pieces of equipment were excluded from iconic levels because they were not legendary.}}",
+          { count: nonLegendaryCount }
+        )}
+      </Text>
+    </div>
+  );
+}
+
+function EquipmentDonut({
+  ariaLabel,
+  centerLabel,
+  centerValue,
+  data,
+  emptyLabel,
+  title,
+  tooltipLabels,
+  decimalFormatter,
+}: {
+  ariaLabel: string;
+  centerLabel: string;
+  centerValue: string;
+  data: EquipmentDonutDatum[];
+  emptyLabel: string;
+  title: string;
+  tooltipLabels: { count: string; usage: string };
+  decimalFormatter: Intl.NumberFormat;
+}) {
+  const total = data.reduce((sum, item) => sum + item.count, 0);
+
+  return (
+    <div className="min-w-0">
+      <Subheading level={4} className="text-center">
+        {title}
+      </Subheading>
+      {total > 0 ? (
+        <div className="relative mt-2 h-44" role="img" aria-label={ariaLabel}>
+          <ResponsiveContainer minWidth={0}>
+            <PieChart>
+              <Pie
+                data={data}
+                dataKey="count"
+                innerRadius={50}
+                isAnimationActive={false}
+                nameKey="name"
+                outerRadius={70}
+                paddingAngle={2}
+                stroke="transparent"
+              >
+                {data.map((item) => (
+                  <Cell fill={item.color} key={item.key} />
+                ))}
+              </Pie>
+              <RechartsTooltip
+                content={(props) => (
+                  <EquipmentDonutTooltip
+                    {...props}
+                    decimalFormatter={decimalFormatter}
+                    labels={tooltipLabels}
+                    total={total}
+                  />
+                )}
+                wrapperStyle={{ zIndex: 20 }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+            <span className="font-semibold text-sm tabular-nums text-zinc-950 dark:text-white">
+              {centerValue}
+            </span>
+            <span className="mt-0.5 text-[10px] text-zinc-500 dark:text-zinc-400">
+              {centerLabel}
+            </span>
+          </div>
+        </div>
+      ) : (
+        <Text className="mt-2 flex h-44 items-center justify-center text-center !text-xs/5">
+          {emptyLabel}
+        </Text>
+      )}
+      {total > 0 ? (
+        <div className="mt-1 flex flex-wrap justify-center gap-x-3 gap-y-1.5 text-[11px] text-zinc-600 dark:text-zinc-300">
+          {data.map((item) => (
+            <span
+              className="inline-flex min-w-0 max-w-full items-center gap-1.5"
+              key={item.key}
+              title={item.name}
+            >
+              <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: item.color }}
+              />
+              <span className="max-w-44 truncate">{item.name}</span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function EquipmentDonutTooltip({
+  active,
+  decimalFormatter,
+  labels,
+  payload,
+  total,
+}: TooltipContentProps & {
+  decimalFormatter: Intl.NumberFormat;
+  labels: { count: string; usage: string };
+  total: number;
+}) {
+  const item = payload?.[0]?.payload as EquipmentDonutDatum | undefined;
+  if (!(active && item)) {
+    return null;
+  }
+
+  return (
+    <div
+      className="rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-xs text-zinc-950 dark:border-white/10 dark:bg-zinc-900 dark:text-white"
+      data-chart-tooltip=""
+    >
+      <div className="flex items-center gap-1.5 font-medium">
+        <span className="size-2 rounded-full" style={{ backgroundColor: item.color }} />
+        {item.name}
+      </div>
+      <dl className="mt-2 grid grid-cols-[auto_auto] gap-x-5 gap-y-1 tabular-nums">
+        <dt className="text-zinc-500 dark:text-zinc-400">{labels.usage}</dt>
+        <dd className="text-right">{decimalFormatter.format((item.count / total) * 100)}%</dd>
+        <dt className="text-zinc-500 dark:text-zinc-400">{labels.count}</dt>
+        <dd className="text-right">
+          {new Intl.NumberFormat(decimalFormatter.resolvedOptions().locale).format(item.count)}
+        </dd>
+      </dl>
+    </div>
+  );
+}
+
+function ArmamentBuffTooltip({
+  active,
+  averageRollLabel,
+  buffName,
+  decimalFormatter,
+  label,
+  maxRollUsageLabel,
+  payload,
+  percent,
+  usageLabel,
+}: TooltipContentProps & {
+  averageRollLabel: string;
+  buffName: string;
+  decimalFormatter: Intl.NumberFormat;
+  maxRollUsageLabel: string;
+  percent?: boolean;
+  usageLabel: string;
+}) {
+  const row = payload?.[0]?.payload as ArmamentChartData | undefined;
+  if (!(active && row && row.buffObservations > 0)) {
+    return null;
+  }
+
+  return (
+    <div
+      className="min-w-52 rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-xs text-zinc-950 dark:border-white/10 dark:bg-zinc-900 dark:text-white"
+      data-chart-tooltip=""
+    >
+      <div className="text-zinc-500 dark:text-zinc-400">{label}</div>
+      <div className="mt-1.5 font-medium">{buffName}</div>
+      <dl className="mt-2 grid grid-cols-[auto_auto] gap-x-5 gap-y-1">
+        <dt className="text-zinc-500 dark:text-zinc-400">{usageLabel}</dt>
+        <dd className="text-right tabular-nums">{decimalFormatter.format(row.buffUsage)}%</dd>
+        <dt className="text-zinc-500 dark:text-zinc-400">{maxRollUsageLabel}</dt>
+        <dd className="text-right tabular-nums">{decimalFormatter.format(row.buffMaxPercent)}%</dd>
+        <dt className="text-zinc-500 dark:text-zinc-400">{averageRollLabel}</dt>
+        <dd className="text-right tabular-nums">
+          {formatArmamentValue(row.buffAverage, decimalFormatter, percent)}
+        </dd>
+      </dl>
+    </div>
+  );
+}
+
+function ChartLegend({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-zinc-600 dark:text-zinc-300">
+      <span className={`size-2 rounded-full ${color}`} />
+      {label}
+    </span>
+  );
+}
+
+function ChartTooltip({
+  active,
+  formatName,
+  formatValue,
+  label,
+  payload,
+}: TooltipContentProps & {
+  formatName: (dataKey: unknown) => string;
+  formatValue: (value: number) => string;
+}) {
+  if (!(active && payload.length > 0)) {
+    return null;
+  }
+
+  return (
+    <div
+      className="min-w-32 rounded-md border border-zinc-950/10 bg-white px-3 py-2 text-xs text-zinc-950 dark:border-white/10 dark:bg-zinc-900 dark:text-white"
+      data-chart-tooltip=""
+    >
+      <div className="mb-1.5 text-zinc-500 dark:text-zinc-400">{label}</div>
+      <div className="space-y-1">
+        {payload.map((entry) => (
+          <div
+            key={`${entry.graphicalItemId}-${String(entry.dataKey)}`}
+            className="flex items-center justify-between gap-4"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <span
+                className="size-2 rounded-full"
+                style={{ backgroundColor: entry.color ?? entry.stroke }}
+              />
+              {formatName(entry.dataKey)}
+            </span>
+            <span className="font-medium tabular-nums">{formatValue(Number(entry.value))}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type AggregatedTrend = CombatLabPreviewTrend & { date: string };
+
+function aggregateTrends(
+  trends: CombatLabPreviewTrend[],
+  rangeKey: CombatLabPreviewRangeKey,
+  locale: string
+): AggregatedTrend[] {
+  const bucketMs = trendBucketDays(rangeKey) * DAY_MS;
+  const grouped = new Map<number, CombatLabPreviewTrend>();
+
+  for (const point of trends) {
+    const bucket = Math.floor(point.bucketStartMs / bucketMs) * bucketMs;
+    const current = grouped.get(bucket);
+    if (!current) {
+      grouped.set(bucket, { ...point, bucketStartMs: bucket });
+      continue;
+    }
+    const totalBattles = current.battles + point.battles;
+    const weighted = (key: "dps" | "sps" | "tps" | "hps") =>
+      totalBattles > 0
+        ? (current[key] * current.battles + point[key] * point.battles) / totalBattles
+        : 0;
+    grouped.set(bucket, {
+      bucketStartMs: bucket,
+      battles: totalBattles,
+      killPointsGained: current.killPointsGained + point.killPointsGained,
+      killPointsLost: current.killPointsLost + point.killPointsLost,
+      dps: weighted("dps"),
+      sps: weighted("sps"),
+      tps: weighted("tps"),
+      hps: weighted("hps"),
+    });
+  }
+
+  const dateFormatter = trendDateFormatter(locale);
+  return Array.from(grouped.values())
+    .sort((a, b) => a.bucketStartMs - b.bucketStartMs)
+    .map((point) => ({ ...point, date: dateFormatter.format(point.bucketStartMs) }));
+}
+
+type FormationChartSeries = {
+  id: number;
+  dataKey: string;
+  name: string;
+  color: string;
+};
+
+type FormationChartBucket = {
+  bucketStartMs: number;
+  sampleSize: number;
+  counts: Map<number, number>;
+};
+
+type FormationChartData = Record<string, number | string> & {
+  bucketStartMs: number;
+  date: string;
+};
+
+function aggregateFormationUsage(
+  points: CombatLabPreviewFormationUsagePoint[],
+  rangeKey: CombatLabPreviewRangeKey,
+  locale: string,
+  fallbackName: (id: number) => string
+): { chartData: FormationChartData[]; series: FormationChartSeries[] } {
+  const bucketMs = trendBucketDays(rangeKey) * DAY_MS;
+  const grouped = new Map<number, FormationChartBucket>();
+  const totals = new Map<number, number>();
+
+  for (const point of points) {
+    const bucketStartMs = Math.floor(point.bucketStartMs / bucketMs) * bucketMs;
+    const bucket = grouped.get(bucketStartMs) ?? {
+      bucketStartMs,
+      sampleSize: 0,
+      counts: new Map<number, number>(),
+    };
+    bucket.sampleSize += numberOrZero(point.sampleSize);
+    for (const formation of Array.isArray(point.formations) ? point.formations : []) {
+      const count = numberOrZero(formation.count);
+      bucket.counts.set(formation.id, (bucket.counts.get(formation.id) ?? 0) + count);
+      totals.set(formation.id, (totals.get(formation.id) ?? 0) + count);
+    }
+    grouped.set(bucketStartMs, bucket);
+  }
+
+  const series = Array.from(totals)
+    .sort((left, right) => right[1] - left[1] || left[0] - right[0])
+    .map(([id]) => ({
+      id,
+      dataKey: `formation-${id}`,
+      name: getFormationName(id, locale) ?? fallbackName(id),
+      color: formationColors[(id - 1) % formationColors.length],
+    }));
+  const dateFormatter = trendDateFormatter(locale);
+  const chartData = Array.from(grouped.values())
+    .sort((left, right) => left.bucketStartMs - right.bucketStartMs)
+    .map((bucket) => {
+      const row: FormationChartData = {
+        bucketStartMs: bucket.bucketStartMs,
+        date: dateFormatter.format(bucket.bucketStartMs),
+      };
+      for (const formation of series) {
+        row[formation.dataKey] =
+          bucket.sampleSize > 0
+            ? ((bucket.counts.get(formation.id) ?? 0) / bucket.sampleSize) * 100
+            : 0;
+      }
+      return row;
+    });
+
+  return { chartData, series };
+}
+
+type ArmamentBuffAggregate = {
+  observations: number;
+  totalRoll: number;
+  maximumRoll: number;
+  maxRollCount: number;
+};
+
+type ArmamentChartBucket = {
+  bucketStartMs: number;
+  sampleSize: number;
+  inscriptions: Record<InscriptionKey, number>;
+  buffs: Map<number, ArmamentBuffAggregate>;
+};
+
+type ArmamentChartData = Record<InscriptionKey, number> & {
+  bucketStartMs: number;
+  date: string;
+  sampleSize: number;
+  buffAverage: number;
+  buffUsage: number;
+  buffObservations: number;
+  buffMaxPercent: number;
+};
+
+function getArmamentBuffOptions(
+  slot: CombatLabPreviewArmamentSlot,
+  locale: string,
+  fallbackName: (id: number) => string
+) {
+  const totals = new Map<number, { maximumRoll: number; observations: number }>();
+  for (const point of slot.points) {
+    for (const buff of Array.isArray(point.buffs) ? point.buffs : []) {
+      const current = totals.get(buff.id) ?? { maximumRoll: 0, observations: 0 };
+      current.maximumRoll = Math.max(current.maximumRoll, buff.maximumRoll);
+      current.observations += buff.observations;
+      totals.set(buff.id, current);
+    }
+  }
+
+  return Array.from(totals)
+    .sort((left, right) => right[1].observations - left[1].observations || left[0] - right[0])
+    .slice(0, 4)
+    .map(([id, { maximumRoll }]) => ({
+      id,
+      maximumRoll,
+      name: getArmamentInfo(id, locale)?.name ?? fallbackName(id),
+    }));
+}
+
+function aggregateArmamentUsage(
+  slot: CombatLabPreviewArmamentSlot,
+  rangeKey: CombatLabPreviewRangeKey,
+  selectedBuffId: number | null,
+  locale: string,
+  inscriptionOptions: readonly { key: InscriptionKey; label: string; color: string }[]
+) {
+  const bucketMs = trendBucketDays(rangeKey) * DAY_MS;
+  const grouped = new Map<number, ArmamentChartBucket>();
+  const inscriptionTotals = new Map<InscriptionKey, number>();
+
+  for (const point of slot.points) {
+    const bucketStartMs = Math.floor(point.bucketStartMs / bucketMs) * bucketMs;
+    const bucket = grouped.get(bucketStartMs) ?? {
+      bucketStartMs,
+      sampleSize: 0,
+      inscriptions: {
+        special: 0,
+        rare: 0,
+        common: 0,
+        specialCommon: 0,
+        rareCommon: 0,
+        commonCommon: 0,
+      },
+      buffs: new Map<number, ArmamentBuffAggregate>(),
+    };
+    bucket.sampleSize += numberOrZero(point.sampleSize);
+
+    for (const option of inscriptionOptions) {
+      const count = numberOrZero(point.inscriptions?.[option.key]?.count);
+      bucket.inscriptions[option.key] += count;
+      inscriptionTotals.set(option.key, (inscriptionTotals.get(option.key) ?? 0) + count);
+    }
+    for (const buff of Array.isArray(point.buffs) ? point.buffs : []) {
+      const aggregate = bucket.buffs.get(buff.id) ?? {
+        observations: 0,
+        totalRoll: 0,
+        maximumRoll: buff.maximumRoll,
+        maxRollCount: 0,
+      };
+      aggregate.observations += buff.observations;
+      aggregate.totalRoll += buff.averageRoll * buff.observations;
+      aggregate.maximumRoll = Math.max(aggregate.maximumRoll, buff.maximumRoll);
+      aggregate.maxRollCount += buff.maxRollCount;
+      bucket.buffs.set(buff.id, aggregate);
+    }
+    grouped.set(bucketStartMs, bucket);
+  }
+
+  const inscriptionSeries = inscriptionOptions.filter(
+    (option) => (inscriptionTotals.get(option.key) ?? 0) > 0
+  );
+  const dateFormatter = trendDateFormatter(locale);
+  const chartData = Array.from(grouped.values())
+    .sort((left, right) => left.bucketStartMs - right.bucketStartMs)
+    .map((bucket): ArmamentChartData => {
+      const buff = selectedBuffId === null ? undefined : bucket.buffs.get(selectedBuffId);
+      const inscriptionPercent = (key: InscriptionKey) =>
+        bucket.sampleSize > 0 ? (bucket.inscriptions[key] / bucket.sampleSize) * 100 : 0;
+      return {
+        bucketStartMs: bucket.bucketStartMs,
+        date: dateFormatter.format(bucket.bucketStartMs),
+        sampleSize: bucket.sampleSize,
+        special: inscriptionPercent("special"),
+        rare: inscriptionPercent("rare"),
+        common: inscriptionPercent("common"),
+        specialCommon: inscriptionPercent("specialCommon"),
+        rareCommon: inscriptionPercent("rareCommon"),
+        commonCommon: inscriptionPercent("commonCommon"),
+        buffAverage: buff && buff.observations > 0 ? buff.totalRoll / buff.observations : 0,
+        buffUsage:
+          buff && bucket.sampleSize > 0 ? (buff.observations / bucket.sampleSize) * 100 : 0,
+        buffObservations: buff?.observations ?? 0,
+        buffMaxPercent:
+          buff && buff.observations > 0 ? (buff.maxRollCount / buff.observations) * 100 : 0,
+      };
+    });
+
+  return { chartData, inscriptionSeries };
+}
+
+type EquipmentChartSeries = {
+  dataKey: string;
+  name: string;
+  color: string;
+  isOther: boolean;
+};
+
+type EquipmentChartBucket = {
+  bucketStartMs: number;
+  sampleSize: number;
+  items: Map<number, number>;
+};
+
+type EquipmentChartData = Record<string, number | string> & {
+  bucketStartMs: number;
+  date: string;
+};
+
+type EquipmentDonutDatum = {
+  key: string;
+  name: string;
+  count: number;
+  color: string;
+};
+
+function getAccessoryPairingData(
+  accessoryPairings: CombatLabPreviewAccessoryPairings | undefined,
+  locale: string,
+  labels: { item: (id: number) => string; otherPairings: string }
+): EquipmentDonutDatum[] {
+  if (
+    !accessoryPairings ||
+    accessoryPairings.sampleSize === 0 ||
+    !Array.isArray(accessoryPairings.pairings)
+  ) {
+    return [];
+  }
+
+  const topPairings = accessoryPairings.pairings
+    .toSorted(
+      (left, right) =>
+        right.count - left.count ||
+        left.firstItemId - right.firstItemId ||
+        left.secondItemId - right.secondItemId
+    )
+    .slice(0, 4);
+  const topPairingCount = topPairings.reduce((sum, pairing) => sum + pairing.count, 0);
+  const data = topPairings.map(
+    (pairing, index): EquipmentDonutDatum => ({
+      key: `pair-${pairing.firstItemId}-${pairing.secondItemId}`,
+      name: `${getEquipmentName(pairing.firstItemId, locale) ?? labels.item(pairing.firstItemId)} + ${getEquipmentName(pairing.secondItemId, locale) ?? labels.item(pairing.secondItemId)}`,
+      count: pairing.count,
+      color: equipmentColors[index],
+    })
+  );
+  const otherCount = Math.max(0, accessoryPairings.sampleSize - topPairingCount);
+  if (otherCount > 0) {
+    data.push({
+      key: "other-pairings",
+      name: labels.otherPairings,
+      count: otherCount,
+      color: equipmentColors[4],
+    });
+  }
+
+  return data;
+}
+
+function aggregateEquipmentUsage(
+  slot: CombatLabPreviewEquipmentSlot,
+  rangeKey: CombatLabPreviewRangeKey,
+  locale: string,
+  labels: {
+    iconic: (level: string) => string;
+    item: (id: number) => string;
+    noIconic: string;
+    noSpecialTalent: string;
+    otherPieces: string;
+    specialTalent: string;
+  }
+) {
+  const bucketMs = trendBucketDays(rangeKey) * DAY_MS;
+  const grouped = new Map<number, EquipmentChartBucket>();
+  const itemTotals = new Map<number, number>();
+  const iconicTotals = new Map<number, number>();
+  let observations = 0;
+  let legendary = 0;
+  let nonLegendaryCount = 0;
+  let specialTalent = 0;
+  let noSpecialTalent = 0;
+
+  for (const point of slot.points) {
+    const bucketStartMs = Math.floor(point.bucketStartMs / bucketMs) * bucketMs;
+    const bucket = grouped.get(bucketStartMs) ?? {
+      bucketStartMs,
+      sampleSize: 0,
+      items: new Map<number, number>(),
+    };
+    bucket.sampleSize += numberOrZero(point.sampleSize);
+    observations += numberOrZero(point.sampleSize);
+    legendary += numberOrZero(point.legendaryCount);
+    nonLegendaryCount += numberOrZero(point.nonLegendaryCount);
+    specialTalent += numberOrZero(point.specialTalentCount);
+    noSpecialTalent += numberOrZero(point.noSpecialTalentCount);
+
+    for (const item of Array.isArray(point.items) ? point.items : []) {
+      const count = numberOrZero(item.count);
+      bucket.items.set(item.id, (bucket.items.get(item.id) ?? 0) + count);
+      itemTotals.set(item.id, (itemTotals.get(item.id) ?? 0) + count);
+    }
+    for (const iconic of Array.isArray(point.iconicLevels) ? point.iconicLevels : []) {
+      const count = numberOrZero(iconic.count);
+      iconicTotals.set(iconic.level, (iconicTotals.get(iconic.level) ?? 0) + count);
+    }
+    grouped.set(bucketStartMs, bucket);
+  }
+
+  const selectedItemIds = Array.from(itemTotals)
+    .sort((left, right) => right[1] - left[1] || left[0] - right[0])
+    .slice(0, 4)
+    .map(([id]) => id);
+  const selectedItemSet = new Set(selectedItemIds);
+  const selectedTotal = selectedItemIds.reduce((sum, id) => sum + (itemTotals.get(id) ?? 0), 0);
+  const otherTotal = Math.max(0, observations - selectedTotal);
+  const series: EquipmentChartSeries[] = selectedItemIds.map((id, index) => ({
+    dataKey: `equipment-${id}`,
+    name: getEquipmentName(id, locale) ?? labels.item(id),
+    color: equipmentColors[index],
+    isOther: false,
+  }));
+  if (otherTotal > 0) {
+    series.push({
+      dataKey: "equipment-other",
+      name: labels.otherPieces,
+      color: equipmentColors[4],
+      isOther: true,
+    });
+  }
+
+  const dateFormatter = trendDateFormatter(locale);
+  const chartData = Array.from(grouped.values())
+    .sort((left, right) => left.bucketStartMs - right.bucketStartMs)
+    .map((bucket): EquipmentChartData => {
+      const row: EquipmentChartData = {
+        bucketStartMs: bucket.bucketStartMs,
+        date: dateFormatter.format(bucket.bucketStartMs),
+      };
+      for (const id of selectedItemIds) {
+        const count = bucket.items.get(id) ?? 0;
+        row[`equipment-${id}`] = bucket.sampleSize > 0 ? (count / bucket.sampleSize) * 100 : 0;
+      }
+      if (otherTotal > 0) {
+        const otherCount = Array.from(bucket.items).reduce(
+          (sum, [id, count]) => sum + (selectedItemSet.has(id) ? 0 : count),
+          0
+        );
+        row["equipment-other"] = bucket.sampleSize > 0 ? (otherCount / bucket.sampleSize) * 100 : 0;
+      }
+      return row;
+    });
+
+  const iconicData = Array.from(iconicTotals)
+    .sort((left, right) => left[0] - right[0])
+    .map(
+      ([level, count]): EquipmentDonutDatum => ({
+        key: `iconic-${level}`,
+        name:
+          level === 0 ? labels.noIconic : labels.iconic(toRomanNumeral(level) ?? level.toString()),
+        count,
+        color: iconicColors[level % iconicColors.length],
+      })
+    );
+  const specialTalentData: EquipmentDonutDatum[] = [
+    {
+      key: "special-talent",
+      name: labels.specialTalent,
+      count: specialTalent,
+      color: "#2563eb",
+    },
+    {
+      key: "no-special-talent",
+      name: labels.noSpecialTalent,
+      count: noSpecialTalent,
+      color: "#a1a1aa",
+    },
+  ].filter((item) => item.count > 0);
+
+  return {
+    chartData,
+    iconicData,
+    nonLegendaryCount,
+    series,
+    specialTalentData,
+    totals: { observations, legendary, specialTalent },
+  };
+}
+
+function formatArmamentValue(value: number, decimalFormatter: Intl.NumberFormat, isPercent = true) {
+  return isPercent ? `${decimalFormatter.format(value * 100)}%` : decimalFormatter.format(value);
+}
+
+function trendBucketDays(rangeKey: CombatLabPreviewRangeKey) {
+  return rangeKey === "1y" ? 14 : rangeKey === "6m" ? 7 : 1;
+}
+
+function trendDateFormatter(locale: string) {
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function createCompactFormatter(locale: string) {
+  return new Intl.NumberFormat(locale, {
+    notation: "compact",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function createDecimalFormatter(locale: string) {
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function createIntegerFormatter(locale: string) {
+  return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 });
+}

--- a/packages/site/src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+++ b/packages/site/src/components/combat-lab/new/combat-lab-preview-drastc.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useExtracted, useLocale } from "next-intl";
+import { ConfidenceScore } from "@/components/combat-lab/confidence-score";
+import { DrastcCredits } from "@/components/combat-lab/drastc-credits";
+import { DrastcRadarChart } from "@/components/combat-lab/drastc-radar-chart";
+import { Heading, Subheading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import type { CombatLabPreviewDrastc as DrastcData } from "@/lib/combat-lab/preview-types";
+
+export function CombatLabPreviewDrastc({ score }: { score: DrastcData }) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const numberFormatter = new Intl.NumberFormat(locale);
+  const scoreFormatter = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+  const categories = [
+    { key: "damage", axis: "D", label: t("Damage") },
+    { key: "rage", axis: "R", label: t("Rage") },
+    { key: "assist", axis: "A", label: t("Assist") },
+    { key: "sustainability", axis: "S", label: t("Sustainability") },
+    { key: "trade", axis: "T", label: t("Trade") },
+    { key: "consistency", axis: "C", label: t("Consistency") },
+  ] as const;
+  const radar = categories.map((category) => ({
+    axis: category.axis,
+    fullName: category.label,
+    score: score.breakdown[category.key].score,
+  }));
+
+  return (
+    <section aria-labelledby="drastc-title" className="scroll-mt-28">
+      <Heading id="drastc-title" level={2} className="mb-4">
+        {t("DRASTC")}
+      </Heading>
+
+      <div className="overflow-hidden rounded-md border border-zinc-950/10 bg-white shadow-sm dark:border-white/10 dark:bg-zinc-900">
+        <div className="grid lg:grid-cols-[minmax(0,1fr)_minmax(22rem,.85fr)]">
+          <div className="p-5 sm:p-7">
+            <div className="grid gap-6 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-center">
+              <div>
+                <Text className="!text-sm font-medium">{t("Overall score")}</Text>
+                <div className="mt-1 flex items-end gap-1.5">
+                  <span className="font-semibold text-5xl tracking-tight text-zinc-950 tabular-nums dark:text-white">
+                    {scoreFormatter.format(score.overall)}
+                  </span>
+                  <Text className="pb-1 !text-zinc-400">/ 10</Text>
+                </div>
+              </div>
+              <div className="mx-auto w-full max-w-80">
+                <DrastcRadarChart data={radar} />
+              </div>
+            </div>
+          </div>
+
+          <div className="border-zinc-950/10 border-t bg-zinc-50/80 p-5 sm:p-7 lg:border-t-0 lg:border-l dark:border-white/10 dark:bg-white/[.025]">
+            <ConfidenceScore score={score.confidence.score} />
+            <Text className="mt-2 !text-sm/6">
+              {t("Based on {battles} battle reports and {governors} governors.", {
+                battles: numberFormatter.format(score.samples),
+                governors: numberFormatter.format(score.confidence.unique_governors),
+              })}
+            </Text>
+
+            <Subheading level={3} className="mt-7">
+              {t("Breakdown")}
+            </Subheading>
+            <div className="mt-3 space-y-3">
+              {categories.map((category) => {
+                const value = score.breakdown[category.key].score;
+                return (
+                  <div
+                    key={category.key}
+                    className="grid grid-cols-[7.25rem_1fr_3rem] items-center gap-3 text-sm"
+                  >
+                    <Text className="!text-sm/5 !text-zinc-600 dark:!text-zinc-300">
+                      {category.label}
+                    </Text>
+                    <div className="h-1.5 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-700">
+                      <div
+                        className="h-full rounded-full bg-blue-600"
+                        style={{ width: `${Math.min(100, value * 10)}%` }}
+                      />
+                    </div>
+                    <Text className="text-right font-medium !text-sm/5 !text-zinc-950 tabular-nums dark:!text-white">
+                      {scoreFormatter.format(value)}
+                    </Text>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-zinc-950/10 border-t px-5 py-5 sm:px-7 dark:border-white/10">
+          <DrastcCredits />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/site/src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+++ b/packages/site/src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useExtracted } from "next-intl";
+import { Text } from "@/components/ui/text";
+
+export function CombatLabPreviewEmptyState({
+  className = "",
+  message,
+}: {
+  className?: string;
+  message: string;
+}) {
+  const t = useExtracted();
+
+  return (
+    <div
+      className={`flex min-h-48 items-center justify-center rounded-md border border-zinc-950/10 border-dashed bg-zinc-950/[.02] px-6 py-10 text-center dark:border-white/10 dark:bg-white/[.02] ${className}`}
+    >
+      <div>
+        <Text className="font-medium !text-sm/5 !text-zinc-700 dark:!text-zinc-200">
+          {t("No data available")}
+        </Text>
+        <Text className="mt-1 max-w-md !text-sm/5">{message}</Text>
+      </div>
+    </div>
+  );
+}

--- a/packages/site/src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+++ b/packages/site/src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useExtracted, useLocale } from "next-intl";
+import { Heading, Subheading } from "@/components/ui/heading";
+import { getEquipmentSlotName } from "@/hooks/use-equipment-name";
+import type {
+  CombatLabPreviewFormationUsagePoint,
+  CombatLabPreviewRangeKey,
+  CombatLabPreviewLoadouts as LoadoutData,
+} from "@/lib/combat-lab/preview-types";
+
+const CombatLabPreviewFormationChart = dynamic(
+  () =>
+    import("@/components/combat-lab/new/combat-lab-preview-charts").then(
+      (module) => module.CombatLabPreviewFormationChart
+    ),
+  {
+    loading: () => <FormationChartSkeleton />,
+    ssr: false,
+  }
+);
+
+const CombatLabPreviewArmamentChart = dynamic(
+  () =>
+    import("@/components/combat-lab/new/combat-lab-preview-charts").then(
+      (module) => module.CombatLabPreviewArmamentChart
+    ),
+  {
+    loading: () => (
+      <div className="h-[34rem] animate-pulse rounded-md bg-zinc-950/[.035] dark:bg-white/5" />
+    ),
+    ssr: false,
+  }
+);
+
+const CombatLabPreviewEquipmentChart = dynamic(
+  () =>
+    import("@/components/combat-lab/new/combat-lab-preview-charts").then(
+      (module) => module.CombatLabPreviewEquipmentChart
+    ),
+  {
+    loading: () => (
+      <div className="h-[31rem] animate-pulse rounded-md bg-zinc-950/[.035] dark:bg-white/5" />
+    ),
+    ssr: false,
+  }
+);
+
+const armamentSlotOrder = [1, 3, 2, 4] as const;
+const equipmentSlotOrder = [1, 2, 3, 4, 5, 6, 7] as const;
+
+function FormationChartSkeleton() {
+  return (
+    <article className="min-w-0 animate-pulse overflow-hidden rounded-md border border-zinc-950/10 bg-white xl:col-span-2 dark:border-white/10 dark:bg-zinc-900">
+      <div className="min-h-[5.25rem] border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+        <div className="h-5 w-32 rounded bg-zinc-200 dark:bg-zinc-800" />
+        <div className="mt-4 flex gap-4">
+          {["one", "two", "three", "four"].map((item) => (
+            <div className="h-3 w-16 rounded bg-zinc-200 dark:bg-zinc-800" key={item} />
+          ))}
+        </div>
+      </div>
+      <div className="h-80 p-5 sm:h-96">
+        <div className="h-full rounded bg-zinc-950/[.035] dark:bg-white/5" />
+      </div>
+    </article>
+  );
+}
+
+export function CombatLabPreviewLoadouts({
+  formationUsage,
+  loadouts,
+  rangeKey,
+}: {
+  formationUsage: CombatLabPreviewFormationUsagePoint[];
+  loadouts?: LoadoutData | null;
+  rangeKey: CombatLabPreviewRangeKey;
+}) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const equipmentSlotNames: Record<number, string> = {
+    1: getEquipmentSlotName(1, locale),
+    2: getEquipmentSlotName(2, locale),
+    3: getEquipmentSlotName(3, locale),
+    4: getEquipmentSlotName(4, locale),
+    5: getEquipmentSlotName(5, locale),
+    6: getEquipmentSlotName(6, locale),
+    7: getEquipmentSlotName(7, locale),
+  };
+  const armamentSlotNames: Record<number, string> = {
+    1: t("Scroll"),
+    2: t("Instrument"),
+    3: t("Flag"),
+    4: t("Emblem"),
+  };
+  const armamentSlots = Array.isArray(loadouts?.armaments?.slots) ? loadouts.armaments.slots : [];
+  const equipmentSlots = Array.isArray(loadouts?.equipment?.slots) ? loadouts.equipment.slots : [];
+
+  return (
+    <section aria-labelledby="loadouts-title" className="scroll-mt-28">
+      <Heading id="loadouts-title" level={2} className="mb-4">
+        {t("Build breakdown")}
+      </Heading>
+
+      <div className="grid gap-5 xl:grid-cols-2">
+        <CombatLabPreviewFormationChart points={formationUsage} rangeKey={rangeKey} />
+        {armamentSlotOrder.map((slotId) => {
+          const matchingSlot = armamentSlots.find((item) => item.slot === slotId);
+          const slot = {
+            slot: slotId,
+            points: Array.isArray(matchingSlot?.points) ? matchingSlot.points : [],
+          };
+          return (
+            <Panel key={slotId} title={t("Armament: {slot}", { slot: armamentSlotNames[slotId] })}>
+              <CombatLabPreviewArmamentChart rangeKey={rangeKey} slot={slot} />
+            </Panel>
+          );
+        })}
+        {equipmentSlotOrder.map((slotId) => {
+          const matchingSlot = equipmentSlots.find((item) => item.slot === slotId);
+          const slot = {
+            slot: slotId,
+            points: Array.isArray(matchingSlot?.points) ? matchingSlot.points : [],
+          };
+          return (
+            <Panel
+              className={slotId === 7 ? "xl:col-span-2" : undefined}
+              key={slotId}
+              title={t("Equipment: {slot}", { slot: equipmentSlotNames[slotId] })}
+            >
+              <CombatLabPreviewEquipmentChart
+                accessoryPairings={
+                  slotId === 7 ? loadouts?.equipment?.accessoryPairings : undefined
+                }
+                rangeKey={rangeKey}
+                slot={slot}
+              />
+            </Panel>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function Panel({
+  children,
+  className = "",
+  title,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  title: string;
+}) {
+  return (
+    <article
+      className={`min-w-0 rounded-md border border-zinc-950/10 bg-white p-5 dark:border-white/10 dark:bg-zinc-900 sm:p-6 ${className}`}
+    >
+      <Subheading level={3} className="!text-lg/7">
+        {title}
+      </Subheading>
+      <div className="mt-3">{children}</div>
+    </article>
+  );
+}

--- a/packages/site/src/components/combat-lab/new/combat-lab-preview.tsx
+++ b/packages/site/src/components/combat-lab/new/combat-lab-preview.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import { ArrowLeftIcon, InformationCircleIcon } from "@heroicons/react/16/solid";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { useExtracted, useLocale } from "next-intl";
+import { type CSSProperties, useState } from "react";
+import { CombatLabPreviewDrastc } from "@/components/combat-lab/new/combat-lab-preview-drastc";
+import { CombatLabPreviewEmptyState } from "@/components/combat-lab/new/combat-lab-preview-empty-state";
+import { CombatLabPreviewLoadouts } from "@/components/combat-lab/new/combat-lab-preview-loadouts";
+import { CommanderIcon } from "@/components/commander-icon";
+import { Heading } from "@/components/ui/heading";
+import { Text } from "@/components/ui/text";
+import { formatRefreshedAt } from "@/lib/combat-lab/format";
+import {
+  type CombatLabPreviewData,
+  type CombatLabPreviewRangeKey,
+  type CombatLabPreviewScenarioKey,
+  type CombatLabPreviewSummary,
+  combatLabPreviewRangeKeys,
+  combatLabPreviewScenarioKeys,
+  type CombatLabPreviewDrastc as DrastcData,
+} from "@/lib/combat-lab/preview-types";
+
+const CombatLabPreviewCharts = dynamic(
+  () =>
+    import("@/components/combat-lab/new/combat-lab-preview-charts").then(
+      (module) => module.CombatLabPreviewCharts
+    ),
+  { loading: () => <ChartSkeleton />, ssr: false }
+);
+
+const drastcCategoryKeys = [
+  "damage",
+  "rage",
+  "assist",
+  "sustainability",
+  "trade",
+  "consistency",
+] as const;
+const skeletonChartBarHeights = [35, 62, 48, 76, 58, 84, 68] as const;
+
+export function CombatLabPreview({ data }: { data: CombatLabPreviewData }) {
+  const t = useExtracted();
+  const locale = useLocale();
+  const rangeLabels: Record<CombatLabPreviewRangeKey, string> = {
+    "1y": t("1 year"),
+    "6m": t("6 months"),
+    "1m": t("1 month"),
+    "7d": t("7 days"),
+  };
+  const scenarioLabels: Record<CombatLabPreviewScenarioKey, string> = {
+    all: t("All"),
+    openField: t("Open field"),
+    swarming: t("Swarming"),
+    rally: t("Rally"),
+    garrison: t("Garrison"),
+  };
+  const compactFormatter = new Intl.NumberFormat(locale, {
+    notation: "compact",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const numberFormatter = new Intl.NumberFormat(locale);
+  const decimalFormatter = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  const [rangeKey, setRangeKey] = useState<CombatLabPreviewRangeKey>("1y");
+  const [scenarioKey, setScenarioKey] = useState<CombatLabPreviewScenarioKey>("openField");
+
+  const selected = data.ranges?.[rangeKey]?.scenarios?.[scenarioKey];
+  const summary = normalizeSummary(selected?.summary);
+  const hasCombatSummary = summary.battles > 0;
+  const hasSummaryMetric = (key: keyof CombatLabPreviewSummary) =>
+    isFiniteNumber(selected?.summary?.[key]);
+  const trends = Array.isArray(selected?.trends) ? selected.trends : [];
+  const formationUsage = Array.isArray(selected?.formationUsage) ? selected.formationUsage : [];
+  const drastc = isCompleteDrastc(data.drastc) ? data.drastc : null;
+  const updated = formatRefreshedAt(new Date(data.generatedAtMs).toISOString(), locale);
+
+  return (
+    <div className="min-h-dvh text-zinc-950 dark:text-white">
+      <header className="relative -mx-6 -mt-6 overflow-hidden border-zinc-950/10 border-b bg-zinc-950 text-white lg:-mx-10 lg:-mt-10 lg:rounded-t-lg dark:border-white/10">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_80%_0%,rgba(37,99,235,.28),transparent_42%),radial-gradient(circle_at_20%_100%,rgba(124,58,237,.18),transparent_38%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 py-7 sm:px-6 sm:py-10 lg:px-8">
+          <Link
+            href="/combat-lab/rankings"
+            className="inline-flex items-center gap-1.5 font-medium text-sm text-zinc-400 transition hover:text-white"
+          >
+            <ArrowLeftIcon className="size-4" /> {t("Back to Combat Lab")}
+          </Link>
+          <div className="mt-8 flex items-center gap-3">
+            <div className="flex">
+              <CommanderIcon
+                id={data.pairing.primaryCommanderId}
+                alt={data.pairing.primaryCommanderName}
+                awakened
+                className="size-14 sm:size-16"
+                loading="eager"
+                sizes="64px"
+              />
+              <CommanderIcon
+                id={data.pairing.secondaryCommanderId}
+                alt={data.pairing.secondaryCommanderName}
+                awakened
+                className="-ml-3 size-14 sm:size-16"
+                loading="eager"
+                sizes="64px"
+              />
+            </div>
+            <div>
+              <h1 className="font-semibold text-2xl tracking-tight sm:text-4xl">
+                {data.pairing.primaryCommanderName} <span className="text-zinc-500">/</span>{" "}
+                {data.pairing.secondaryCommanderName}
+              </h1>
+              <Text className="mt-1 !text-sm/5 !text-zinc-400 sm:!text-base/6">
+                {t("Updated at {date}", { date: updated })}
+              </Text>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="z-20 -mx-6 border-zinc-950/10 border-b bg-white/95 backdrop-blur lg:sticky lg:top-0 lg:-mx-10 dark:border-white/10 dark:bg-zinc-950/90">
+        <div className="mx-auto grid max-w-7xl gap-4 px-4 py-4 sm:px-6 lg:grid-cols-2 lg:items-center lg:px-8">
+          <FilterGroup
+            label={t("Time range")}
+            options={combatLabPreviewRangeKeys}
+            labels={rangeLabels}
+            selected={rangeKey}
+            onSelect={setRangeKey}
+          />
+          <FilterGroup
+            label={t("Scenario")}
+            options={combatLabPreviewScenarioKeys}
+            labels={scenarioLabels}
+            selected={scenarioKey}
+            onSelect={setScenarioKey}
+          />
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-7xl space-y-10 px-4 py-7 sm:px-6 sm:py-10 lg:px-8">
+        {drastc ? (
+          <div className="rounded-md border border-amber-300/60 bg-amber-50 px-4 py-3 text-amber-950 dark:border-amber-300/20 dark:bg-amber-400/10 dark:text-amber-100">
+            <div className="flex items-center gap-3">
+              <InformationCircleIcon className="size-5 shrink-0 text-amber-600 dark:text-amber-300" />
+              <Text className="!text-sm/5 !text-amber-950 dark:!text-amber-100">
+                <strong>{t("Changing the filters will not change the DRASTC results.")}</strong>{" "}
+                {t("DRASTC uses the most recent year of open-field battle reports.")}
+              </Text>
+            </div>
+          </div>
+        ) : null}
+
+        <section aria-labelledby="combat-breakdown-title">
+          <Heading id="combat-breakdown-title" level={2} className="mb-4">
+            {t("Combat breakdown")}
+          </Heading>
+          {hasCombatSummary ? (
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              <MetricCard
+                available={hasSummaryMetric("battles")}
+                label={t("Battle reports")}
+                value={formatCount(summary.battles, compactFormatter, numberFormatter)}
+                exactValue={numberFormatter.format(summary.battles)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("killPointsGained")}
+                label={t("Kill points gained")}
+                value={formatCount(summary.killPointsGained, compactFormatter, numberFormatter)}
+                exactValue={numberFormatter.format(Math.round(summary.killPointsGained))}
+                accent="text-blue-600 dark:text-blue-400"
+              />
+              <MetricCard
+                available={hasSummaryMetric("killPointsLost")}
+                label={t("Kill points lost")}
+                value={formatCount(summary.killPointsLost, compactFormatter, numberFormatter)}
+                exactValue={numberFormatter.format(Math.round(summary.killPointsLost))}
+                accent="text-rose-600 dark:text-rose-400"
+              />
+              <MetricCard
+                available={hasSummaryMetric("weightedTradePercent")}
+                label={t("Trade percentage")}
+                value={`${decimalFormatter.format(summary.weightedTradePercent)}%`}
+                accent="text-emerald-700 dark:text-emerald-400"
+              />
+              <MetricCard
+                available={hasSummaryMetric("averageBattleDurationSeconds")}
+                label={t("Avg. battle duration")}
+                value={formatDuration(summary.averageBattleDurationSeconds, decimalFormatter)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("uniqueGovernors")}
+                label={t("Governors")}
+                value={formatCount(summary.uniqueGovernors, compactFormatter, numberFormatter)}
+                exactValue={numberFormatter.format(summary.uniqueGovernors)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("severelyWoundedInflicted")}
+                label={t("Severely wounded inflicted")}
+                value={formatCount(
+                  summary.severelyWoundedInflicted,
+                  compactFormatter,
+                  numberFormatter
+                )}
+                exactValue={numberFormatter.format(Math.round(summary.severelyWoundedInflicted))}
+              />
+              <MetricCard
+                available={hasSummaryMetric("severelyWoundedTaken")}
+                label={t("Severely wounded taken")}
+                value={formatCount(summary.severelyWoundedTaken, compactFormatter, numberFormatter)}
+                exactValue={numberFormatter.format(Math.round(summary.severelyWoundedTaken))}
+              />
+              <MetricCard
+                available={hasSummaryMetric("dps")}
+                label={t("Damage per second (DPS)")}
+                value={decimalFormatter.format(summary.dps)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("sps")}
+                label={t("Sevs per second (SPS)")}
+                value={decimalFormatter.format(summary.sps)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("tps")}
+                label={t("Sevs taken per second (TPS)")}
+                value={decimalFormatter.format(summary.tps)}
+              />
+              <MetricCard
+                available={hasSummaryMetric("hps")}
+                label={t("Healing per second (HPS)")}
+                value={decimalFormatter.format(summary.hps)}
+              />
+            </div>
+          ) : (
+            <CombatLabPreviewEmptyState
+              message={t("No combat summary was observed for this time range and scenario.")}
+            />
+          )}
+        </section>
+
+        <section aria-labelledby="trends-title">
+          <Heading id="trends-title" level={2} className="mb-4">
+            {t("Combat performance")}
+          </Heading>
+          <CombatLabPreviewCharts rangeKey={rangeKey} trends={trends} />
+        </section>
+
+        {drastc ? <CombatLabPreviewDrastc score={drastc} /> : null}
+
+        <CombatLabPreviewLoadouts
+          formationUsage={formationUsage}
+          loadouts={selected?.loadouts}
+          rangeKey={rangeKey}
+        />
+      </div>
+    </div>
+  );
+}
+
+function FilterGroup<T extends string>({
+  label,
+  labels,
+  onSelect,
+  options,
+  selected,
+}: {
+  label: string;
+  labels: Record<T, string>;
+  onSelect: (value: T) => void;
+  options: readonly T[];
+  selected: T;
+}) {
+  return (
+    <fieldset className="min-w-0">
+      <legend className="mb-1.5 font-semibold text-xs uppercase tracking-wider text-zinc-500">
+        {label}
+      </legend>
+      <div className="flex gap-1 overflow-x-auto rounded-lg bg-zinc-950/5 p-1 dark:bg-white/5">
+        {options.map((option) => (
+          <button
+            key={option}
+            aria-pressed={selected === option}
+            className="shrink-0 rounded-md px-3 py-1.5 font-medium text-sm text-zinc-600 transition hover:text-zinc-950 aria-pressed:bg-white aria-pressed:text-zinc-950 dark:text-zinc-300 dark:hover:text-white dark:aria-pressed:bg-zinc-700 dark:aria-pressed:text-white"
+            onClick={() => onSelect(option)}
+            type="button"
+          >
+            {labels[option]}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function MetricCard({
+  accent = "text-zinc-950 dark:text-white",
+  available = true,
+  exactValue,
+  label,
+  value,
+}: {
+  accent?: string;
+  available?: boolean;
+  exactValue?: string;
+  label: string;
+  value: string;
+}) {
+  const t = useExtracted();
+
+  return (
+    <article className="rounded-md border border-zinc-950/10 bg-white/70 px-4 py-3.5 dark:border-white/10 dark:bg-white/[.035]">
+      <Text className="!text-sm/5">{label}</Text>
+      <div
+        className={`mt-1.5 font-semibold text-2xl tracking-tight tabular-nums ${available ? accent : "text-zinc-400 dark:text-zinc-500"}`}
+        title={available ? exactValue : undefined}
+      >
+        {available ? value : t("No data")}
+      </div>
+    </article>
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function normalizeSummary(summary: CombatLabPreviewSummary | undefined): CombatLabPreviewSummary {
+  return {
+    battles: isFiniteNumber(summary?.battles) ? summary.battles : 0,
+    uniqueGovernors: isFiniteNumber(summary?.uniqueGovernors) ? summary.uniqueGovernors : 0,
+    killPointsGained: isFiniteNumber(summary?.killPointsGained) ? summary.killPointsGained : 0,
+    killPointsLost: isFiniteNumber(summary?.killPointsLost) ? summary.killPointsLost : 0,
+    severelyWoundedInflicted: isFiniteNumber(summary?.severelyWoundedInflicted)
+      ? summary.severelyWoundedInflicted
+      : 0,
+    severelyWoundedTaken: isFiniteNumber(summary?.severelyWoundedTaken)
+      ? summary.severelyWoundedTaken
+      : 0,
+    averageBattleDurationSeconds: isFiniteNumber(summary?.averageBattleDurationSeconds)
+      ? summary.averageBattleDurationSeconds
+      : 0,
+    weightedTradePercent: isFiniteNumber(summary?.weightedTradePercent)
+      ? summary.weightedTradePercent
+      : 0,
+    dps: isFiniteNumber(summary?.dps) ? summary.dps : 0,
+    sps: isFiniteNumber(summary?.sps) ? summary.sps : 0,
+    tps: isFiniteNumber(summary?.tps) ? summary.tps : 0,
+    hps: isFiniteNumber(summary?.hps) ? summary.hps : 0,
+  };
+}
+
+function isCompleteDrastc(score: DrastcData | null | undefined): score is DrastcData {
+  return Boolean(
+    score &&
+      isFiniteNumber(score.overall) &&
+      isFiniteNumber(score.samples) &&
+      isFiniteNumber(score.confidence?.score) &&
+      isFiniteNumber(score.confidence?.unique_governors) &&
+      drastcCategoryKeys.every((key) => isFiniteNumber(score.breakdown?.[key]?.score))
+  );
+}
+
+function formatCount(
+  value: number,
+  compactFormatter: Intl.NumberFormat,
+  numberFormatter: Intl.NumberFormat
+) {
+  return Math.abs(value) >= 1_000
+    ? compactFormatter.format(value)
+    : numberFormatter.format(Math.round(value));
+}
+
+function formatDuration(totalSeconds: number, formatter: Intl.NumberFormat) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0
+    ? `${formatter.format(minutes)}m ${formatter.format(seconds)}s`
+    : `${formatter.format(seconds)}s`;
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="grid animate-pulse gap-5 xl:grid-cols-2">
+      {["kill-points", "battle-tempo"].map((chart) => (
+        <div
+          className="overflow-hidden rounded-md border border-zinc-950/10 bg-white dark:border-white/10 dark:bg-zinc-900"
+          key={chart}
+        >
+          <div className="border-zinc-950/10 border-b px-5 py-4 dark:border-white/10">
+            <SkeletonBlock className="h-5 w-28" />
+            <SkeletonBlock className="mt-4 h-9 w-full max-w-sm" />
+          </div>
+          <div className="flex h-72 items-end gap-4 px-6 pt-8 pb-6">
+            {skeletonChartBarHeights.map((height) => (
+              <SkeletonBlock
+                className="flex-1"
+                key={`${chart}-bar-${height}`}
+                style={{ height: `${height}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SkeletonBlock({ className = "", style }: { className?: string; style?: CSSProperties }) {
+  return <div className={`rounded bg-zinc-200 dark:bg-zinc-800 ${className}`} style={style} />;
+}

--- a/packages/site/src/components/commander-icon.tsx
+++ b/packages/site/src/components/commander-icon.tsx
@@ -7,6 +7,7 @@ type CommanderIconProps = {
   alt: string;
   awakened?: boolean | null;
   className?: string;
+  loading?: "eager" | "lazy";
   sizes?: string;
 };
 
@@ -15,6 +16,7 @@ export function CommanderIcon({
   alt,
   awakened = false,
   className,
+  loading = "lazy",
   sizes = "32px",
 }: CommanderIconProps) {
   const spriteUrls = getCommanderSprites(id, awakened === true);
@@ -38,7 +40,7 @@ export function CommanderIcon({
           alt=""
           className="object-contain"
           fill
-          loading="lazy"
+          loading={loading}
           sizes={sizes}
           src={spriteUrl}
           unoptimized

--- a/packages/site/src/components/platform-layout.tsx
+++ b/packages/site/src/components/platform-layout.tsx
@@ -43,6 +43,8 @@ type PlatformLayoutProps = {
   initialUser?: CurrentUser | null;
 };
 
+const fullWidthRoutes = new Set(["/combat-lab/new"]);
+
 export function PlatformLayout({ children, initialUser }: PlatformLayoutProps) {
   const t = useExtracted();
   const pathname = usePathname();
@@ -82,6 +84,7 @@ export function PlatformLayout({ children, initialUser }: PlatformLayoutProps) {
 
   return (
     <SidebarLayout
+      fullWidth={fullWidthRoutes.has(pathname)}
       navbar={<Navbar />}
       sidebar={
         <Sidebar>

--- a/packages/site/src/components/ui/sidebar-layout.tsx
+++ b/packages/site/src/components/ui/sidebar-layout.tsx
@@ -6,6 +6,7 @@ import {
   DialogBackdrop as HeadlessDialogBackdrop,
   DialogPanel as HeadlessDialogPanel,
 } from "@headlessui/react";
+import { cn } from "cnfast";
 import type React from "react";
 import { useState } from "react";
 import { NavbarItem } from "@/components/ui/navbar";
@@ -58,7 +59,12 @@ export function SidebarLayout({
   navbar,
   sidebar,
   children,
-}: React.PropsWithChildren<{ navbar: React.ReactNode; sidebar: React.ReactNode }>) {
+  fullWidth = false,
+}: React.PropsWithChildren<{
+  navbar: React.ReactNode;
+  sidebar: React.ReactNode;
+  fullWidth?: boolean;
+}>) {
   const [showSidebar, setShowSidebar] = useState(false);
 
   return (
@@ -84,7 +90,7 @@ export function SidebarLayout({
       {/* Content */}
       <main className="flex flex-1 flex-col pb-2 lg:min-w-0 lg:pt-2 lg:pr-2 lg:pl-64">
         <div className="grow p-6 lg:rounded-lg lg:bg-white lg:p-10 lg:shadow-xs lg:ring-1 lg:ring-zinc-950/5 dark:lg:bg-zinc-900 dark:lg:ring-white/10">
-          <div className="mx-auto max-w-6xl">{children}</div>
+          <div className={cn("mx-auto w-full", !fullWidth && "max-w-6xl")}>{children}</div>
         </div>
       </main>
     </div>

--- a/packages/site/src/hooks/use-equipment-name.ts
+++ b/packages/site/src/hooks/use-equipment-name.ts
@@ -5,10 +5,12 @@ import { defaultLocale } from "@/i18n/config";
 import { resolveLocale } from "@/i18n/locale";
 
 const equipmentMap = equipmentData.equipment.item;
+const equipmentSlotMap = equipmentData.equipment.slot;
 
 type EquipmentIdKey = keyof typeof equipmentMap;
 type EquipmentEntry = (typeof equipmentMap)[EquipmentIdKey];
 type EquipmentLocale = keyof EquipmentEntry["name"];
+type EquipmentSlotIdKey = keyof typeof equipmentSlotMap;
 
 export function getEquipmentName(id: number | null | undefined, locale?: string) {
   if (typeof id !== "number" || !Number.isFinite(id)) {
@@ -24,5 +26,14 @@ export function getEquipmentName(id: number | null | undefined, locale?: string)
   return (
     (equipment.name as Record<string, string | undefined>)[requestedLocale] ??
     equipment.name[defaultLocale as EquipmentLocale]
+  );
+}
+
+export function getEquipmentSlotName(slot: number, locale?: string): string {
+  const names = equipmentSlotMap[String(slot) as EquipmentSlotIdKey];
+  const requestedLocale = resolveLocale(locale);
+  return (
+    (names as Record<string, string | undefined>)[requestedLocale] ??
+    names[defaultLocale as keyof typeof names]
   );
 }

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -506,6 +506,7 @@ msgstr "No loot in this date range."
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr "All"
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr "General"
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr "Governors"
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr "Open Field"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr "Swarming"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr "Rally"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr "Learn more"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr "Damage"
 
@@ -841,6 +847,7 @@ msgstr "Assist/Support"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr "Sustainability"
 
@@ -851,6 +858,7 @@ msgstr "Trade Efficiency"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr "Consistency"
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr "DRASTC scoring"
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr "Overall score"
 
@@ -893,12 +902,373 @@ msgid "EU4z3x"
 msgstr "No formation data available."
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr "Count"
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
 msgstr "Usage"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr "Damage dealt"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr "Severely wounded inflicted"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr "Severely wounded taken"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr "Healing"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr "No kill-point history was observed for these filters."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr "Kill points"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr "No per-second combat metrics were observed for these filters."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr "Battle tempo"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr "Gained"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr "Lost"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr "Formation {id}"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr "Formation usage"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr "No formations were observed for these filters."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr "Unknown formation"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr "Special"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr "Rare"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr "Common"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr "Special + Common"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr "Rare + Common"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr "Common + Common"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr "Buff {id}"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr "No armaments were observed for these filters."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr "Inscription usage"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr "Inscription"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr "Buff rolls"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr "No buff rolls observed."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr "Average roll"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr "Buff"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr "Max roll usage"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr "Iconic"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr "Item {id}"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr "No iconic"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr "No special talent"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr "Other pieces"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr "Special talent"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr "Other pairings"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr "No equipment was observed for these filters."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr "Piece usage"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr "Equipment"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr "Iconic level distribution among legendary equipment"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr "legendary"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr "No legendary pieces observed."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr "Iconic levels"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr "Special talent usage across equipment"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr "special talent"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr "No talent data observed."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr "Most common order-agnostic accessory pairings"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr "pairings"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr "No complete accessory pairings observed."
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr "Accessory pairings"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr "{count, plural, one {# piece of equipment was excluded from iconic levels because it was not legendary.} other {# pieces of equipment were excluded from iconic levels because they were not legendary.}}"
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr "Rage"
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr "Assist"
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr "Trade"
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr "DRASTC"
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr "Based on {battles} battle reports and {governors} governors."
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr "Breakdown"
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr "No data available"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr "Scroll"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr "Instrument"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr "Flag"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr "Emblem"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr "Build breakdown"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr "Armament: {slot}"
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr "Equipment: {slot}"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr "1 year"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr "6 months"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr "1 month"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr "7 days"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr "Open field"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr "Back to Combat Lab"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr "Updated at {date}"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr "Time range"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr "Scenario"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr "Changing the filters will not change the DRASTC results."
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr "DRASTC uses the most recent year of open-field battle reports."
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr "Combat breakdown"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr "Battle reports"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr "Kill points gained"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr "Kill points lost"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr "Trade percentage"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr "Avg. battle duration"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr "Damage per second (DPS)"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr "Sevs per second (SPS)"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr "Sevs taken per second (TPS)"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr "Healing per second (HPS)"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr "No combat summary was observed for this time range and scenario."
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr "Combat performance"
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
+msgstr "No data"
 
 #: src/components/commander-loadout-row.tsx
 msgid "XoCgY-"
@@ -1414,10 +1784,6 @@ msgstr "UTC "
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
 msgstr "Battle summary"
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
-msgstr "Equipment"
 
 #: src/components/report/report-equipment-slot.tsx
 msgid "JqXZrY"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr "Todo"
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr "Gobernadores"
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr "Equipamiento"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1414,10 +1784,6 @@ msgstr ""
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
 msgstr "Resumen de la batalla"
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
-msgstr "Equipamiento"
 
 #: src/components/report/report-equipment-slot.tsx
 msgid "JqXZrY"

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -515,6 +515,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -593,6 +594,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr "Gouverneurs"
 
@@ -748,11 +750,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -760,6 +764,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -835,6 +840,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -850,6 +856,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -860,6 +867,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -872,6 +880,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -902,11 +911,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1422,10 +1792,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr "전체"
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr "일반"
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr "지도자"
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr "장비"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1414,10 +1784,6 @@ msgstr ""
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
 msgstr "전투 요약"
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
-msgstr "장비"
 
 #: src/components/report/report-equipment-slot.tsx
 msgid "JqXZrY"

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -515,6 +515,7 @@ msgstr "Không có chiến lợi phẩm nào trong khoảng thời gian này."
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr "Tất cả"
@@ -593,6 +594,7 @@ msgid "1iEPTM"
 msgstr "Tổng quan"
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr "Thống đốc"
 
@@ -748,11 +750,13 @@ msgid "cHoIky"
 msgstr "Ngoài đồng"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr "Swarming"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -760,6 +764,7 @@ msgid "RJ-ZIh"
 msgstr "Tập kết"
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -835,6 +840,7 @@ msgstr "Tìm hiểu thêm"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr "Sát thương"
 
@@ -850,6 +856,7 @@ msgstr "Hỗ trợ"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr "Tính bền vững"
 
@@ -860,6 +867,7 @@ msgstr "Hiệu suất trao đổi"
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr "Tính nhất quán"
 
@@ -872,6 +880,7 @@ msgid "cjd1MY"
 msgstr "Chấm điểm DRASTC"
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr "Điểm tổng thể"
 
@@ -902,12 +911,373 @@ msgid "EU4z3x"
 msgstr "Không có dữ liệu về đội hình."
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr "Số lượng"
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
 msgstr "Tần suất sử dụng"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr "Trang bị"
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
+msgstr ""
 
 #: src/components/commander-loadout-row.tsx
 msgid "XoCgY-"
@@ -1423,10 +1793,6 @@ msgstr "UTC "
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
 msgstr "Tổng quan trận chiến"
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
-msgstr "Trang bị"
 
 #: src/components/report/report-equipment-slot.tsx
 msgid "JqXZrY"

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -506,6 +506,7 @@ msgstr ""
 
 #: src/components/account-loot/personal-loot-filters.tsx
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/loot-explorer/loot-explorer-filters.tsx
 msgid "zQvVDJ"
 msgstr ""
@@ -584,6 +585,7 @@ msgid "1iEPTM"
 msgstr ""
 
 #: src/components/account/account-settings-nav.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 msgid "q5TmbN"
 msgstr ""
 
@@ -739,11 +741,13 @@ msgid "cHoIky"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 msgid "hAEZYZ"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/report/report-participant-card.tsx
 #: src/components/reports/reports-filter-dialog.tsx
@@ -751,6 +755,7 @@ msgid "RJ-ZIh"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-summary-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
 #: src/components/my-pairings/pairings-filters.tsx
 #: src/components/reports/reports-filter-dialog.tsx
 msgid "2pQ4w5"
@@ -826,6 +831,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "T807D4"
 msgstr ""
 
@@ -841,6 +847,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "14P-1u"
 msgstr ""
 
@@ -851,6 +858,7 @@ msgstr ""
 
 #: src/components/combat-lab/drastc-info.tsx
 #: src/components/combat-lab/drastc-radar.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "Mxwl9f"
 msgstr ""
 
@@ -863,6 +871,7 @@ msgid "cjd1MY"
 msgstr ""
 
 #: src/components/combat-lab/drastc-section.tsx
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
 msgid "AAkx6U"
 msgstr ""
 
@@ -893,11 +902,372 @@ msgid "EU4z3x"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "Aujn2T"
 msgstr ""
 
 #: src/components/combat-lab/formation-breakdown.tsx
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
 msgid "wbsq7O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "3UfoyS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "a8wkKu"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "nHRTeq"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6nP3O3"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "CR1jqj"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bHc-kK"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "6XQ7TN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "4LmEJw"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bi2p6K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FL6lKX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "pQyHNd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "et90bv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "d1hB-Y"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "P0CCi6"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "gTB0E8"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n-kv74"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "n96a21"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "kBCJ1h"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "LGFrbW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "zI4pec"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "sWUO6d"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A11sVS"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "A8WChX"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Lf9G-H"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "EQ64I9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "YYAOkZ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "Q5MUc_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "f3OK0O"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "5GHMUY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "FFUeRn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "bLl42R"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "1fK0HA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OpOCgf"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JA1cOg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "GAykkl"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "HsQkt_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "dhWdgY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "lQnI9c"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+#: src/components/report/report-equipment-section.tsx
+msgid "r80fiF"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "OuXBmU"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "WIUHfr"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "jNS_xO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yFbpA7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "M6AncG"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "a3iU9_"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "8KYwzg"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "JSmL_0"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "-cr1mW"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "yWTdUP"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "SiC_-B"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-charts.tsx
+msgid "DHR_nV"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "zOo6e-"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "For9ib"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "90axO4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "5lfH9K"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "GudWSn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-drastc.tsx
+msgid "uqe58g"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-empty-state.tsx
+msgid "wOFJFO"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "SxCvYA"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "wduJme"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "bSCV9J"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "v8Ts9G"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "z5UrIH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "9qO4Xm"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview-loadouts.tsx
+msgid "VcxUDs"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "rwIPgH"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "AwuN57"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "p1dNds"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FrAoo9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "w0fenY"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "57mpWo"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "spcNSp"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "74vgSJ"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "5m4j06"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "lJifFN"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "Xm3-B9"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "FGfOI7"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "H3G-_A"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "T6fLvD"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "4dEukv"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "RwXuHc"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "PI-sR4"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "pTywiR"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "X5d0pn"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "LgMoVb"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "gl_xty"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "VRbbGy"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "7SRayd"
+msgstr ""
+
+#: src/components/combat-lab/new/combat-lab-preview.tsx
+msgid "UG5qoS"
 msgstr ""
 
 #: src/components/commander-loadout-row.tsx
@@ -1413,10 +1783,6 @@ msgstr ""
 
 #: src/components/report/report-entry-card.tsx
 msgid "eKTCWw"
-msgstr ""
-
-#: src/components/report/report-equipment-section.tsx
-msgid "r80fiF"
 msgstr ""
 
 #: src/components/report/report-equipment-slot.tsx

--- a/packages/site/src/lib/combat-lab/format.ts
+++ b/packages/site/src/lib/combat-lab/format.ts
@@ -46,6 +46,17 @@ export function formatDuration(valueMillis: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
-export function formatRefreshedAt(value: string): string {
-  return `${dateFormatter.format(new Date(value)).replace(",", "")} UTC`;
+export function formatRefreshedAt(value: string, locale = "en-US"): string {
+  const formatter =
+    locale === "en-US"
+      ? dateFormatter
+      : new Intl.DateTimeFormat(locale, {
+          day: "2-digit",
+          hour: "2-digit",
+          hourCycle: "h23",
+          minute: "2-digit",
+          month: "2-digit",
+          timeZone: "UTC",
+        });
+  return `${formatter.format(new Date(value)).replace(",", "")} UTC`;
 }

--- a/packages/site/src/lib/combat-lab/preview-api.ts
+++ b/packages/site/src/lib/combat-lab/preview-api.ts
@@ -1,0 +1,357 @@
+import "server-only";
+
+import { notFound } from "next/navigation";
+import {
+  type CombatLabPreviewData,
+  type CombatLabPreviewRangeKey,
+  type CombatLabPreviewScenario,
+  type CombatLabPreviewScenarioKey,
+  combatLabPreviewRangeKeys,
+  combatLabPreviewScenarioKeys,
+} from "@/lib/combat-lab/preview-types";
+import { getCommanderName } from "@/lib/commander";
+
+type WireDrastc = Omit<NonNullable<CombatLabPreviewData["drastc"]>, "confidence"> & {
+  confidence: {
+    score: number;
+    uniqueGovernors: number;
+    effectiveGovernors: number;
+  };
+};
+
+type CombatLabV2Wire = {
+  generatedAtMs: number;
+  pairing: {
+    primaryCommanderId: number;
+    secondaryCommanderId: number;
+  };
+  drastc?: WireDrastc | null;
+  summaries: number[][];
+  performance: number[][];
+  loadouts: Array<Array<number | number[]>>;
+  armamentMaximums: Record<string, number>;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const rangeDays: Record<CombatLabPreviewRangeKey, number> = {
+  "1y": 365,
+  "6m": 183,
+  "1m": 30,
+  "7d": 7,
+};
+
+export async function fetchCombatLabPreview(options: {
+  primary: number;
+  secondary: number;
+  locale?: string;
+}): Promise<CombatLabPreviewData> {
+  const params = new URLSearchParams({
+    primary: options.primary.toString(),
+    secondary: options.secondary.toString(),
+  });
+  const apiUrl = process.env.API_URL || "http://localhost:8001";
+  const response = await fetch(`${apiUrl.replace(/\/$/, "")}/v2/global/combat-lab?${params}`, {
+    cache: "no-store",
+  });
+  if (response.status === 404) notFound();
+  if (!response.ok) {
+    throw new Error(`Could not load Combat Lab data (${response.status})`);
+  }
+  const wire = (await response.json()) as CombatLabV2Wire;
+  return expandWireData(wire, options.locale);
+}
+
+function expandWireData(wire: CombatLabV2Wire, locale?: string): CombatLabPreviewData {
+  const ranges = Object.fromEntries(
+    combatLabPreviewRangeKeys.map((range) => [
+      range,
+      {
+        scenarios: Object.fromEntries(
+          combatLabPreviewScenarioKeys.map((scenario) => [scenario, emptyScenario()])
+        ),
+      },
+    ])
+  ) as CombatLabPreviewData["ranges"];
+  const cutoffs = Object.fromEntries(
+    combatLabPreviewRangeKeys.map((range) => [
+      range,
+      wire.generatedAtMs - rangeDays[range] * DAY_MS,
+    ])
+  ) as Record<CombatLabPreviewRangeKey, number>;
+
+  for (const tuple of wire.summaries ?? []) {
+    const range = combatLabPreviewRangeKeys[tuple[0]];
+    const scenario = combatLabPreviewScenarioKeys[tuple[1]];
+    const output = range && scenario ? ranges[range]?.scenarios?.[scenario] : undefined;
+    if (!output) continue;
+    const battles = finite(tuple[2]);
+    const killPointsGained = finite(tuple[4]);
+    const killPointsLost = finite(tuple[5]);
+    const durationMs = finite(tuple[8]);
+    const rateDurationMs = finite(tuple[9]);
+    output.summary = {
+      battles,
+      uniqueGovernors: finite(tuple[3]),
+      killPointsGained,
+      killPointsLost,
+      severelyWoundedInflicted: finite(tuple[6]),
+      severelyWoundedTaken: finite(tuple[7]),
+      averageBattleDurationSeconds: divide(durationMs, battles) / 1000,
+      weightedTradePercent: tradePercent(killPointsGained, killPointsLost),
+      dps: perSecond(finite(tuple[10]), rateDurationMs),
+      sps: perSecond(finite(tuple[6]), rateDurationMs),
+      tps: perSecond(finite(tuple[7]), rateDurationMs),
+      hps: perSecond(finite(tuple[11]), rateDurationMs),
+    };
+  }
+
+  for (const tuple of wire.performance ?? []) {
+    const day = finite(tuple[0]);
+    const scenario = combatLabPreviewScenarioKeys[tuple[1]];
+    if (!scenario) continue;
+    forEachMatchingRange(day, cutoffs, (range) => {
+      const output = ranges[range]?.scenarios?.[scenario];
+      if (!output) return;
+      const rateDurationMs = finite(tuple[8]);
+      output.trends.push({
+        bucketStartMs: day,
+        battles: finite(tuple[2]),
+        killPointsGained: finite(tuple[3]),
+        killPointsLost: finite(tuple[4]),
+        dps: perSecond(finite(tuple[9]), rateDurationMs),
+        sps: perSecond(finite(tuple[5]), rateDurationMs),
+        tps: perSecond(finite(tuple[6]), rateDurationMs),
+        hps: perSecond(finite(tuple[10]), rateDurationMs),
+      });
+    });
+  }
+
+  const accessoryAggregates = new Map<
+    string,
+    {
+      sampleSize: number;
+      pairs: Map<string, { firstItemId: number; secondItemId: number; count: number }>;
+    }
+  >();
+  for (const tuple of wire.loadouts ?? []) {
+    const kind = finite(tuple[0] as number);
+    const day = finite(tuple[1] as number);
+    const scenario = combatLabPreviewScenarioKeys[finite(tuple[2] as number)];
+    if (!scenario) continue;
+    forEachMatchingRange(day, cutoffs, (range) => {
+      const output = ranges[range]?.scenarios?.[scenario];
+      if (!output) return;
+      if (kind === 0) addFormation(output, tuple);
+      if (kind === 1) addArmament(output, tuple, wire.armamentMaximums ?? {});
+      if (kind === 2) addEquipment(output, tuple);
+      if (kind === 3) addAccessory(accessoryAggregates, range, scenario, tuple);
+    });
+  }
+  for (const range of combatLabPreviewRangeKeys) {
+    for (const scenario of combatLabPreviewScenarioKeys) {
+      const output = ranges[range]?.scenarios?.[scenario];
+      output?.trends.sort((left, right) => left.bucketStartMs - right.bucketStartMs);
+      output?.formationUsage.sort((left, right) => left.bucketStartMs - right.bucketStartMs);
+      for (const slot of output?.loadouts.armaments.slots ?? []) {
+        slot.points.sort((left, right) => left.bucketStartMs - right.bucketStartMs);
+      }
+      for (const slot of output?.loadouts.equipment.slots ?? []) {
+        slot.points.sort((left, right) => left.bucketStartMs - right.bucketStartMs);
+      }
+      const aggregate = accessoryAggregates.get(`${range}:${scenario}`);
+      const equipment = output?.loadouts.equipment;
+      if (!aggregate || !equipment) continue;
+      equipment.accessoryPairings = {
+        sampleSize: aggregate.sampleSize,
+        pairings: [...aggregate.pairs.values()].sort((left, right) => right.count - left.count),
+      };
+    }
+  }
+
+  return {
+    generatedAtMs: wire.generatedAtMs,
+    pairing: {
+      primaryCommanderId: wire.pairing.primaryCommanderId,
+      primaryCommanderName:
+        getCommanderName(wire.pairing.primaryCommanderId, locale) ??
+        wire.pairing.primaryCommanderId.toString(),
+      secondaryCommanderId: wire.pairing.secondaryCommanderId,
+      secondaryCommanderName:
+        getCommanderName(wire.pairing.secondaryCommanderId, locale) ??
+        wire.pairing.secondaryCommanderId.toString(),
+    },
+    drastc: wire.drastc
+      ? {
+          ...wire.drastc,
+          confidence: {
+            score: wire.drastc.confidence.score,
+            unique_governors: wire.drastc.confidence.uniqueGovernors,
+            effective_governors: wire.drastc.confidence.effectiveGovernors,
+          },
+        }
+      : null,
+    ranges,
+  };
+}
+
+function emptyScenario(): CombatLabPreviewScenario {
+  return {
+    summary: {
+      battles: 0,
+      uniqueGovernors: 0,
+      killPointsGained: 0,
+      killPointsLost: 0,
+      severelyWoundedInflicted: 0,
+      severelyWoundedTaken: 0,
+      averageBattleDurationSeconds: 0,
+      weightedTradePercent: 0,
+      dps: 0,
+      sps: 0,
+      tps: 0,
+      hps: 0,
+    },
+    trends: [],
+    formationUsage: [],
+    loadouts: {
+      armaments: { slots: [1, 2, 3, 4].map((slot) => ({ slot, points: [] })) },
+      equipment: {
+        slots: [1, 2, 3, 4, 5, 6, 7].map((slot) => ({ slot, points: [] })),
+        accessoryPairings: { sampleSize: 0, pairings: [] },
+      },
+    },
+  };
+}
+
+function addFormation(output: CombatLabPreviewScenario, tuple: Array<number | number[]>) {
+  const formations = pairValues(tuple.slice(4) as number[]).map(([id, count]) => ({ id, count }));
+  output.formationUsage.push({
+    bucketStartMs: finite(tuple[1] as number),
+    sampleSize: finite(tuple[3] as number),
+    formations,
+  });
+}
+
+function addArmament(
+  output: CombatLabPreviewScenario,
+  tuple: Array<number | number[]>,
+  maximums: Record<string, number>
+) {
+  const slotId = finite(tuple[3] as number);
+  const sampleSize = finite(tuple[4] as number);
+  const slot = output.loadouts.armaments.slots.find((item) => item.slot === slotId);
+  if (!slot) return;
+  const metric = (index: number) => {
+    const count = finite(tuple[index] as number);
+    return { count, percent: divide(count, sampleSize) * 100 };
+  };
+  const buffs = tuple[11];
+  slot.points.push({
+    bucketStartMs: finite(tuple[1] as number),
+    sampleSize,
+    inscriptions: {
+      special: metric(5),
+      rare: metric(6),
+      common: metric(7),
+      specialCommon: metric(8),
+      rareCommon: metric(9),
+      commonCommon: metric(10),
+    },
+    buffs: groups(Array.isArray(buffs) ? buffs : [], 4).map(
+      ([id, observations, totalRoll, maxRollCount]) => ({
+        id,
+        observations,
+        usagePercent: divide(observations, sampleSize) * 100,
+        averageRoll: divide(totalRoll, observations),
+        maximumRoll: finite(maximums[id.toString()]),
+        maxRollCount,
+        maxRollPercent: divide(maxRollCount, observations) * 100,
+      })
+    ),
+  });
+}
+
+function addEquipment(output: CombatLabPreviewScenario, tuple: Array<number | number[]>) {
+  const slotId = finite(tuple[3] as number);
+  const slot = output.loadouts.equipment.slots.find((item) => item.slot === slotId);
+  if (!slot) return;
+  const legendaryCount = finite(tuple[4] as number);
+  const nonLegendaryCount = finite(tuple[5] as number);
+  slot.points.push({
+    bucketStartMs: finite(tuple[1] as number),
+    sampleSize: legendaryCount + nonLegendaryCount,
+    legendaryCount,
+    nonLegendaryCount,
+    specialTalentCount: finite(tuple[6] as number),
+    noSpecialTalentCount: finite(tuple[7] as number),
+    items: pairValues(Array.isArray(tuple[8]) ? tuple[8] : []).map(([id, count]) => ({
+      id,
+      count,
+    })),
+    iconicLevels: pairValues(Array.isArray(tuple[9]) ? tuple[9] : []).map(([level, count]) => ({
+      level,
+      count,
+    })),
+  });
+}
+
+function addAccessory(
+  aggregates: Map<
+    string,
+    {
+      sampleSize: number;
+      pairs: Map<string, { firstItemId: number; secondItemId: number; count: number }>;
+    }
+  >,
+  range: CombatLabPreviewRangeKey,
+  scenario: CombatLabPreviewScenarioKey,
+  tuple: Array<number | number[]>
+) {
+  const key = `${range}:${scenario}`;
+  const aggregate = aggregates.get(key) ?? { sampleSize: 0, pairs: new Map() };
+  aggregate.sampleSize += finite(tuple[3] as number);
+  const values = Array.isArray(tuple[4]) ? tuple[4] : [];
+  for (const [firstItemId, secondItemId, count] of groups(values, 3)) {
+    const pairKey = `${firstItemId}:${secondItemId}`;
+    const current = aggregate.pairs.get(pairKey) ?? { firstItemId, secondItemId, count: 0 };
+    current.count += count;
+    aggregate.pairs.set(pairKey, current);
+  }
+  aggregates.set(key, aggregate);
+}
+
+function forEachMatchingRange(
+  day: number,
+  cutoffs: Record<CombatLabPreviewRangeKey, number>,
+  visit: (range: CombatLabPreviewRangeKey) => void
+) {
+  for (const range of combatLabPreviewRangeKeys) if (day >= cutoffs[range]) visit(range);
+}
+
+function groups(values: number[], size: number): number[][] {
+  const output: number[][] = [];
+  for (let index = 0; index + size <= values.length; index += size) {
+    output.push(values.slice(index, index + size).map(finite));
+  }
+  return output;
+}
+
+function pairValues(values: number[]): number[][] {
+  return groups(values, 2);
+}
+
+function finite(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function divide(numerator: number, denominator: number): number {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function perSecond(total: number, durationMs: number): number {
+  return divide(total, durationMs / 1000);
+}
+
+function tradePercent(gained: number, lost: number): number {
+  if (gained === lost) return 100;
+  return lost > 0 ? (gained / lost) * 100 : 0;
+}

--- a/packages/site/src/lib/combat-lab/preview-types.ts
+++ b/packages/site/src/lib/combat-lab/preview-types.ts
@@ -1,0 +1,172 @@
+export const combatLabPreviewRangeKeys = ["1y", "6m", "1m", "7d"] as const;
+export type CombatLabPreviewRangeKey = (typeof combatLabPreviewRangeKeys)[number];
+
+export const combatLabPreviewScenarioKeys = [
+  "all",
+  "openField",
+  "swarming",
+  "rally",
+  "garrison",
+] as const;
+export type CombatLabPreviewScenarioKey = (typeof combatLabPreviewScenarioKeys)[number];
+
+export type CombatLabPreviewCategoryScore = {
+  value: number;
+  p10: number;
+  p90: number;
+  score: number;
+};
+
+export type CombatLabPreviewDrastc = {
+  samples: number;
+  breakdown: {
+    damage: CombatLabPreviewCategoryScore;
+    rage: CombatLabPreviewCategoryScore;
+    assist: CombatLabPreviewCategoryScore;
+    sustainability: CombatLabPreviewCategoryScore;
+    trade: CombatLabPreviewCategoryScore;
+    consistency: CombatLabPreviewCategoryScore;
+  };
+  overall: number;
+  confidence: {
+    score: number;
+    unique_governors: number;
+    effective_governors: number;
+  };
+};
+
+export type CombatLabPreviewSummary = {
+  battles: number;
+  uniqueGovernors: number;
+  killPointsGained: number;
+  killPointsLost: number;
+  severelyWoundedInflicted: number;
+  severelyWoundedTaken: number;
+  averageBattleDurationSeconds: number;
+  weightedTradePercent: number;
+  dps: number;
+  sps: number;
+  tps: number;
+  hps: number;
+};
+
+export type CombatLabPreviewTrend = {
+  bucketStartMs: number;
+  battles: number;
+  killPointsGained: number;
+  killPointsLost: number;
+  dps: number;
+  sps: number;
+  tps: number;
+  hps: number;
+};
+
+export type CombatLabPreviewFormationUsagePoint = {
+  bucketStartMs: number;
+  sampleSize: number;
+  formations: Array<{
+    id: number;
+    count: number;
+  }>;
+};
+
+export type CombatLabPreviewArmamentSlot = {
+  slot: number;
+  points: CombatLabPreviewArmamentUsagePoint[];
+};
+
+export type CombatLabPreviewUsageMetric = {
+  count: number;
+  percent: number;
+};
+
+export type CombatLabPreviewArmamentBuff = {
+  id: number;
+  observations: number;
+  usagePercent: number;
+  averageRoll: number;
+  maximumRoll: number;
+  maxRollCount: number;
+  maxRollPercent: number;
+};
+
+export type CombatLabPreviewArmamentUsagePoint = {
+  bucketStartMs: number;
+  sampleSize: number;
+  inscriptions: {
+    special: CombatLabPreviewUsageMetric;
+    rare: CombatLabPreviewUsageMetric;
+    common: CombatLabPreviewUsageMetric;
+    specialCommon: CombatLabPreviewUsageMetric;
+    rareCommon: CombatLabPreviewUsageMetric;
+    commonCommon: CombatLabPreviewUsageMetric;
+  };
+  buffs: CombatLabPreviewArmamentBuff[];
+};
+
+export type CombatLabPreviewEquipmentSlot = {
+  slot: number;
+  points: CombatLabPreviewEquipmentUsagePoint[];
+};
+
+export type CombatLabPreviewEquipmentUsagePoint = {
+  bucketStartMs: number;
+  sampleSize: number;
+  items: Array<{
+    id: number;
+    count: number;
+  }>;
+  legendaryCount: number;
+  nonLegendaryCount: number;
+  iconicLevels: Array<{
+    level: number;
+    count: number;
+  }>;
+  specialTalentCount: number;
+  noSpecialTalentCount: number;
+};
+
+export type CombatLabPreviewAccessoryPairings = {
+  sampleSize: number;
+  pairings: Array<{
+    firstItemId: number;
+    secondItemId: number;
+    count: number;
+  }>;
+};
+
+export type CombatLabPreviewLoadouts = {
+  armaments: {
+    slots: CombatLabPreviewArmamentSlot[];
+  };
+  equipment: {
+    slots: CombatLabPreviewEquipmentSlot[];
+    accessoryPairings: CombatLabPreviewAccessoryPairings;
+  };
+};
+
+export type CombatLabPreviewScenario = {
+  summary: CombatLabPreviewSummary;
+  trends: CombatLabPreviewTrend[];
+  formationUsage: CombatLabPreviewFormationUsagePoint[];
+  loadouts: CombatLabPreviewLoadouts;
+};
+
+export type CombatLabPreviewData = {
+  generatedAtMs: number;
+  pairing: {
+    primaryCommanderId: number;
+    primaryCommanderName: string;
+    secondaryCommanderId: number;
+    secondaryCommanderName: string;
+  };
+  drastc?: CombatLabPreviewDrastc | null;
+  ranges: Partial<
+    Record<
+      CombatLabPreviewRangeKey,
+      {
+        scenarios: Partial<Record<CombatLabPreviewScenarioKey, CombatLabPreviewScenario>>;
+      }
+    >
+  >;
+};


### PR DESCRIPTION
## Summary

- add the `/v2/global/combat-lab` API for reading complete, published combat-lab generations
- add the localized `/combat-lab/new` experience with time-range and scenario filters
- visualize combat performance, formations, armaments, equipment, DRASTC, and confidence
- resolve commander, formation, armament, equipment, and slot IDs through the canonical datasets
- update Combat Lab rankings links to the new pairing route
- return the real Next.js 404 boundary when a pairing has no published combat data

## Why

The v2 scheduler stores compact combat summaries and loadout data across multiple documents. This PR exposes only a completed generation through the API and presents that data in a visual, localized Combat Lab experience.

## User impact

Users can explore one year, six months, one month, or seven days of combat data across open field, swarming, rally, garrison, or all scenarios. DRASTC remains fixed to the latest year of open-field reports.

## Validation

- `pnpm --dir packages/site generate:messages`
- `pnpm --dir packages/site typecheck`
- `pnpm --dir packages/site build`
- targeted Biome checks and `git diff --check`
- React Doctor changed-scope scan: no issues
- runtime validation: published pairing returns 200, unavailable pairing returns 404, and browser/Next.js diagnostics report no errors
- existing Rust API checks completed while developing the v2 route

## Stack

Depends on #832 (`feat(jobs): add combat lab v2 precompute`).