### PR TITLE
refactor(dns-resolver): remove relay IPv6 support

### DIFF
--- a/crates/apps/rokbattles-dns-resolver/src/config.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{
     env,
-    net::{Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{Ipv4Addr, SocketAddr},
 };
 
 use hickory_proto::rr::Name;
@@ -15,12 +15,10 @@ const DEFAULT_BIND_ADDR: &str = "0.0.0.0:8053";
 pub struct Config {
     /// Address on which the HTTP server listens.
     pub bind_addr: SocketAddr,
-    /// The only hostname for which the resolver returns relay addresses.
+    /// The only hostname for which the resolver returns the relay address.
     pub target_hostname: String,
     /// IPv4 address returned for the target hostname.
     pub relay_ipv4: Ipv4Addr,
-    /// Optional IPv6 address returned for the target hostname.
-    pub relay_ipv6: Option<Ipv6Addr>,
     /// DoH resolver used for non-target queries received from Intra.
     pub intra_upstream_doh_url: Url,
 }
@@ -64,15 +62,13 @@ impl Config {
             "RELAY_IPV4",
             lookup("RELAY_IPV4").ok_or(ConfigError::Missing { key: "RELAY_IPV4" })?,
         )?;
-        let relay_ipv6 =
-            lookup("RELAY_IPV6").map(|value| parse("RELAY_IPV6", value)).transpose()?;
         let intra_upstream_doh_url = parse_upstream_url(
             "INTRA_UPSTREAM_DOH_URL",
             lookup("INTRA_UPSTREAM_DOH_URL")
                 .ok_or(ConfigError::Missing { key: "INTRA_UPSTREAM_DOH_URL" })?,
         )?;
 
-        Ok(Self { bind_addr, target_hostname, relay_ipv4, relay_ipv6, intra_upstream_doh_url })
+        Ok(Self { bind_addr, target_hostname, relay_ipv4, intra_upstream_doh_url })
     }
 }
 
@@ -132,7 +128,6 @@ mod tests {
                 bind_addr: "0.0.0.0:8053".parse().expect("fixture should be valid"),
                 target_hostname: "example.com".to_string(),
                 relay_ipv4: Ipv4Addr::new(203, 0, 113, 10),
-                relay_ipv6: None,
                 intra_upstream_doh_url: Url::parse(TEST_UPSTREAM_DOH_URL)
                     .expect("upstream URL fixture should be valid"),
             }
@@ -234,33 +229,6 @@ mod tests {
         assert_eq!(
             error,
             ConfigError::Invalid { key: "RELAY_IPV4", value: "2001:db8::1".to_string() }
-        );
-    }
-
-    #[test]
-    fn configured_relay_ipv6_should_be_loaded() {
-        let config = Config::from_lookup(lookup_with_upstream(HashMap::from([
-            ("TARGET_HOSTNAME", "example.com"),
-            ("RELAY_IPV4", "203.0.113.10"),
-            ("RELAY_IPV6", "2001:db8::10"),
-        ])))
-        .expect("configuration should be valid");
-
-        assert_eq!(config.relay_ipv6, Some(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10)));
-    }
-
-    #[test]
-    fn invalid_relay_ipv6_should_be_rejected() {
-        let error = Config::from_lookup(lookup_with_upstream(HashMap::from([
-            ("TARGET_HOSTNAME", "example.com"),
-            ("RELAY_IPV4", "203.0.113.10"),
-            ("RELAY_IPV6", "203.0.113.11"),
-        ])))
-        .expect_err("relay address should not be IPv4");
-
-        assert_eq!(
-            error,
-            ConfigError::Invalid { key: "RELAY_IPV6", value: "203.0.113.11".to_string() }
         );
     }
 

--- a/crates/apps/rokbattles-dns-resolver/src/http.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/http.rs
@@ -155,7 +155,7 @@ fn decode_dns_parameter(encoded: &str) -> Result<Vec<u8>, HttpError> {
 #[cfg(test)]
 mod tests {
     use std::{
-        net::{Ipv4Addr, Ipv6Addr},
+        net::Ipv4Addr,
         sync::mpsc::{self, Receiver, Sender, TryRecvError},
         time::Duration,
     };
@@ -168,10 +168,7 @@ mod tests {
     };
     use hickory_proto::{
         op::{Message, MessageType, OpCode, Query, ResponseCode},
-        rr::{
-            Name, RData, Record, RecordType,
-            rdata::{A, AAAA},
-        },
+        rr::{Name, RData, Record, RecordType, rdata::A},
     };
     use reqwest::Url;
     use tokio::task::JoinHandle;
@@ -181,7 +178,6 @@ mod tests {
 
     const TARGET_HOSTNAME: &str = "example.com";
     const RELAY_IPV4: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 10);
-    const RELAY_IPV6: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10);
     const UPSTREAM_IPV4: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 42);
 
     #[derive(Clone)]
@@ -236,7 +232,7 @@ mod tests {
     }
 
     fn app_with_upstream(upstream_url: Url, timeout: Duration) -> Router {
-        let resolver = Resolver::new(TARGET_HOSTNAME, RELAY_IPV4, None);
+        let resolver = Resolver::new(TARGET_HOSTNAME, RELAY_IPV4);
         let forwarder = DoHForwarder::with_test_timeout(upstream_url, timeout)
             .expect("forwarder fixture should build");
         router(resolver, forwarder)
@@ -367,14 +363,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn intra_target_aaaa_query_should_return_configured_local_answer() {
-        let resolver = Resolver::new(TARGET_HOSTNAME, RELAY_IPV4, Some(RELAY_IPV6));
-        let forwarder = DoHForwarder::new(
-            Url::parse("http://127.0.0.1:9/dns-query").expect("fixture URL should be valid"),
-        )
-        .expect("forwarder fixture should build");
+    async fn intra_target_aaaa_query_should_return_nodata() {
         let response = send_post(
-            router(resolver, forwarder),
+            app(),
             "/intra",
             dns_query_for(TARGET_HOSTNAME, RecordType::AAAA),
             DNS_MEDIA_TYPE,
@@ -383,8 +374,8 @@ mod tests {
         let message = decode_dns_response(response).await;
 
         assert_eq!(
-            message.answers.first().map(|answer| &answer.data),
-            Some(&RData::AAAA(AAAA(RELAY_IPV6)))
+            (message.metadata.response_code, message.answers.is_empty()),
+            (ResponseCode::NoError, true)
         );
     }
 

--- a/crates/apps/rokbattles-dns-resolver/src/main.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/main.rs
@@ -26,11 +26,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bind_addr = %config.bind_addr,
         target_hostname = %config.target_hostname,
         relay_ipv4 = %config.relay_ipv4,
-        relay_ipv6 = ?config.relay_ipv6,
         intra_upstream_doh_url = %config.intra_upstream_doh_url,
         "starting DNS-over-HTTPS resolver"
     );
-    let resolver = Resolver::new(config.target_hostname, config.relay_ipv4, config.relay_ipv6);
+    let resolver = Resolver::new(config.target_hostname, config.relay_ipv4);
     let forwarder = DoHForwarder::new(config.intra_upstream_doh_url)?;
     let app = router(resolver, forwarder);
 

--- a/crates/apps/rokbattles-dns-resolver/src/resolver.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/resolver.rs
@@ -1,24 +1,20 @@
 //! DNS wire-format request handling for the configured target hostname.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::Ipv4Addr;
 
 use hickory_proto::{
     op::{Message, MessageType, OpCode, ResponseCode},
-    rr::{
-        DNSClass, RData, Record, RecordType,
-        rdata::{A, AAAA},
-    },
+    rr::{DNSClass, RData, Record, RecordType, rdata::A},
     serialize::binary::DecodeError,
 };
 
 const DNS_TTL_SECONDS: u32 = 60;
 
-/// A non-recursive resolver that synthesizes configured A and AAAA records.
+/// A non-recursive resolver that synthesizes a configured A record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Resolver {
     target_hostname: String,
     relay_ipv4: Ipv4Addr,
-    relay_ipv6: Option<Ipv6Addr>,
 }
 
 /// Failures decoding or encoding DNS wire-format messages.
@@ -43,16 +39,11 @@ enum Resolution {
 }
 
 impl Resolver {
-    /// Create a resolver for `target_hostname` that returns `relay_ipv4` and,
-    /// when present, `relay_ipv6`.
+    /// Create a resolver for `target_hostname` that returns `relay_ipv4`.
     #[must_use]
-    pub fn new(
-        target_hostname: impl Into<String>,
-        relay_ipv4: Ipv4Addr,
-        relay_ipv6: Option<Ipv6Addr>,
-    ) -> Self {
+    pub fn new(target_hostname: impl Into<String>, relay_ipv4: Ipv4Addr) -> Self {
         let target_hostname = target_hostname.into().trim_end_matches('.').to_ascii_lowercase();
-        Self { target_hostname, relay_ipv4, relay_ipv6 }
+        Self { target_hostname, relay_ipv4 }
     }
 
     /// Resolve one DNS wire-format request into a DNS wire-format response.
@@ -115,7 +106,6 @@ impl Resolver {
 
         let answer = match query.query_type() {
             RecordType::A => Some(RData::A(A(self.relay_ipv4))),
-            RecordType::AAAA => self.relay_ipv6.map(|address| RData::AAAA(AAAA(address))),
             _ => None,
         };
         if let Some(answer) = answer {
@@ -151,10 +141,9 @@ mod tests {
 
     const TARGET_HOSTNAME: &str = "example.com";
     const RELAY_IPV4: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 10);
-    const RELAY_IPV6: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0x10);
 
     fn resolver() -> Resolver {
-        Resolver::new(TARGET_HOSTNAME, RELAY_IPV4, Some(RELAY_IPV6))
+        Resolver::new(TARGET_HOSTNAME, RELAY_IPV4)
     }
 
     fn query(name: &str, record_type: RecordType) -> Message {
@@ -185,20 +174,8 @@ mod tests {
     }
 
     #[test]
-    fn aaaa_query_should_return_configured_relay_address_and_ttl() {
+    fn aaaa_query_should_return_nodata() {
         let message = resolve(resolver(), &query(TARGET_HOSTNAME, RecordType::AAAA));
-        let answer = message.answers.first().expect("AAAA answer should be present");
-
-        assert_eq!(
-            (message.metadata.response_code, answer.ttl, &answer.data),
-            (ResponseCode::NoError, DNS_TTL_SECONDS, &RData::AAAA(AAAA(RELAY_IPV6)))
-        );
-    }
-
-    #[test]
-    fn aaaa_query_should_return_nodata_without_configured_ipv6() {
-        let resolver = Resolver::new(TARGET_HOSTNAME, RELAY_IPV4, None);
-        let message = resolve(resolver, &query(TARGET_HOSTNAME, RecordType::AAAA));
 
         assert_eq!(
             (message.metadata.response_code, message.answers.is_empty()),


### PR DESCRIPTION
## Summary

- remove the optional `RELAY_IPV6` configuration
- simplify the target resolver to synthesize only its configured A record
- preserve valid `NOERROR` responses with no answers for target AAAA queries

## Why

The deployed relay is IPv4-only. Keeping an unused relay IPv6 override added configuration and branching without changing current behavior.

## Impact

Deployments no longer need or read `RELAY_IPV6`. A queries and non-target Intra forwarding are unchanged; AAAA queries for the target continue to receive NODATA.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rokbattles-dns-resolver --locked`
- `cargo clippy -p rokbattles-dns-resolver --all-targets --all-features --locked -- -D warnings`