### PR TITLE
fix(ingress): stop storing relay network entity

### DIFF
--- a/crates/apps/rokbattles-ingress/src/handlers.rs
+++ b/crates/apps/rokbattles-ingress/src/handlers.rs
@@ -111,16 +111,9 @@ pub async fn upload(
         )));
     }
 
-    let action = store_compressed_raw_mail(
-        &state,
-        &buffer,
-        None,
-        &decoded,
-        &mail_id,
-        &mail_type,
-        &user_agent,
-    )
-    .await?;
+    let action =
+        store_compressed_raw_mail(&state, &buffer, &decoded, &mail_id, &mail_type, &user_agent)
+            .await?;
 
     let (status, label) = match action {
         UploadAction::Insert => (StatusCode::CREATED, "stored"),
@@ -206,9 +199,7 @@ pub async fn upload_relay(
     for (index, entry) in entries.into_iter().enumerate() {
         let result = match state.mail_reconstructor.reconstruct(&entry, context) {
             Ok(mail) => {
-                match store_reconstructed_mail(&state, &mail.bytes, &entry, &mail.id, &user_agent)
-                    .await
-                {
+                match store_reconstructed_mail(&state, &mail.bytes, &mail.id, &user_agent).await {
                     Ok(action) => RelayMailResult {
                         index,
                         status: action_label(action).to_string(),
@@ -242,7 +233,6 @@ pub async fn upload_relay(
 async fn store_reconstructed_mail(
     state: &AppState,
     bytes: &[u8],
-    network_entity: &[u8],
     mail_id: &str,
     user_agent: &str,
 ) -> Result<UploadAction, ApiError> {
@@ -254,16 +244,7 @@ async fn store_reconstructed_mail(
         return Err(ApiError::bad_request("reconstructed mail id mismatch"));
     }
     let mail_type = extract_mail_type(&decoded)?;
-    store_compressed_raw_mail(
-        state,
-        bytes,
-        Some(network_entity),
-        &decoded,
-        mail_id,
-        &mail_type,
-        user_agent,
-    )
-    .await
+    store_compressed_raw_mail(state, bytes, &decoded, mail_id, &mail_type, user_agent).await
 }
 
 fn action_label(action: UploadAction) -> &'static str {
@@ -300,7 +281,6 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
 async fn store_compressed_raw_mail(
     state: &AppState,
     buffer: &[u8],
-    network_entity: Option<&[u8]>,
     decoded: &Value,
     mail_id: &str,
     mail_type: &str,
@@ -318,17 +298,6 @@ async fn store_compressed_raw_mail(
     let action = decide_compressed_raw_action(existing.as_ref(), &checksum, buffer.len());
 
     if matches!(action, UploadAction::Skip) {
-        if let (Some(entity), Some(existing)) = (network_entity, existing.as_ref())
-            && existing.checksum.as_deref() == Some(checksum.as_str())
-            && !existing.has_network_entity
-        {
-            let compressed_entity = raw_mail::compress_raw_mail(entity, state.config.zstd_level)?;
-            state
-                .storage
-                .store_network_entity_if_missing(mail_id, compressed_entity)
-                .await
-                .map_err(|error| ApiError::database(error.to_string()))?;
-        }
         return Ok(action);
     }
 
@@ -340,7 +309,6 @@ async fn store_compressed_raw_mail(
     };
     let doc = raw_mail::build_raw_mail_doc(RawMailDocumentInput {
         original_bytes: buffer,
-        network_entity,
         user_agent,
         checksum: &checksum,
         mail: &mail,
@@ -796,11 +764,7 @@ mod tests {
         checksum: &str,
         size: Option<usize>,
     ) -> crate::storage::ExistingCompressedRawMail {
-        crate::storage::ExistingCompressedRawMail {
-            checksum: Some(checksum.to_string()),
-            size,
-            has_network_entity: false,
-        }
+        crate::storage::ExistingCompressedRawMail { checksum: Some(checksum.to_string()), size }
     }
 
     #[test]

--- a/crates/apps/rokbattles-ingress/src/raw_mail.rs
+++ b/crates/apps/rokbattles-ingress/src/raw_mail.rs
@@ -24,7 +24,7 @@ pub fn build_raw_mail_doc(input: RawMailDocumentInput<'_>) -> Result<Document, A
         .map_err(|_| ApiError::internal("mail binary is too large to store size"))?;
     let compressed = compress_raw_mail(input.original_bytes, input.zstd_level)?;
 
-    let mut document = doc! {
+    let document = doc! {
         "metadata": {
             "userAgent": input.user_agent,
             "checksum": input.checksum,
@@ -45,18 +45,6 @@ pub fn build_raw_mail_doc(input: RawMailDocumentInput<'_>) -> Result<Document, A
         "updatedAt": input.now,
     };
 
-    if let Some(entity) = input.network_entity {
-        document.insert(
-            "network",
-            doc! {
-                "entity": Bson::Binary(Binary {
-                    subtype: BinarySubtype::Generic,
-                    bytes: compress_raw_mail(entity, input.zstd_level)?,
-                }),
-            },
-        );
-    }
-
     Ok(document)
 }
 
@@ -64,7 +52,6 @@ pub fn build_raw_mail_doc(input: RawMailDocumentInput<'_>) -> Result<Document, A
 #[derive(Debug, Clone, Copy)]
 pub struct RawMailDocumentInput<'a> {
     pub original_bytes: &'a [u8],
-    pub network_entity: Option<&'a [u8]>,
     pub user_agent: &'a str,
     pub checksum: &'a str,
     pub mail: &'a RawMailMetadata,
@@ -207,7 +194,6 @@ mod tests {
         };
         let doc = build_raw_mail_doc(RawMailDocumentInput {
             original_bytes: b"raw-binary",
-            network_entity: None,
             user_agent: "ROKBattles/0.1.0",
             checksum: "checksum",
             mail: &mail,
@@ -233,36 +219,6 @@ mod tests {
         assert!(matches!(doc.get_document("mail").unwrap().get("binary"), Some(Bson::Binary(_))));
         assert!(!doc.contains_key("network"));
         assert_eq!(doc.get_str("status").unwrap(), "pending");
-    }
-
-    #[test]
-    fn builds_relay_document_with_compressed_network_entity() {
-        let now = DateTime::now();
-        let mail = RawMailMetadata {
-            id: "12345".to_string(),
-            time: 1772127772844751,
-            receiver: "player_71738515".to_string(),
-        };
-        let network_entity = b"raw network MailEntity";
-        let doc = build_raw_mail_doc(RawMailDocumentInput {
-            original_bytes: b"reconstructed-binary",
-            network_entity: Some(network_entity),
-            user_agent: "ROKBattles/0.1.0 (Relay)",
-            checksum: "checksum",
-            mail: &mail,
-            status: "pending",
-            now,
-            zstd_level: 3,
-        })
-        .expect("doc");
-
-        let compressed_entity = doc
-            .get_document("network")
-            .expect("network document")
-            .get_binary_generic("entity")
-            .expect("network entity");
-
-        assert_eq!(decompress(compressed_entity), network_entity);
     }
 
     #[test]

--- a/crates/apps/rokbattles-ingress/src/storage.rs
+++ b/crates/apps/rokbattles-ingress/src/storage.rs
@@ -2,7 +2,7 @@
 
 use mongodb::{
     Collection, IndexModel,
-    bson::{Binary, Bson, Document, doc, spec::BinarySubtype},
+    bson::{Bson, Document, doc},
     options::IndexOptions,
 };
 
@@ -17,7 +17,6 @@ pub struct Storage {
 pub struct ExistingCompressedRawMail {
     pub checksum: Option<String>,
     pub size: Option<usize>,
-    pub has_network_entity: bool,
 }
 
 impl Storage {
@@ -44,7 +43,6 @@ impl Storage {
             .projection(doc! {
                 "metadata.checksum": 1,
                 "metadata.size": 1,
-                "network.entity": 1,
             })
             .await?;
         Ok(doc.and_then(parse_existing_compressed_raw))
@@ -53,31 +51,6 @@ impl Storage {
     /// Insert a new V2 raw compressed mail document.
     pub async fn insert_compressed_raw(&self, doc: Document) -> mongodb::error::Result<()> {
         self.compressed_raw.insert_one(doc).await?;
-        Ok(())
-    }
-
-    /// Attach a compressed relay entity to an existing mail that does not have one.
-    pub async fn store_network_entity_if_missing(
-        &self,
-        mail_id: &str,
-        compressed_entity: Vec<u8>,
-    ) -> mongodb::error::Result<()> {
-        self.compressed_raw
-            .update_one(
-                doc! {
-                    "mail.id": mail_id,
-                    "network.entity": { "$exists": false },
-                },
-                doc! {
-                    "$set": {
-                        "network.entity": Bson::Binary(Binary {
-                            subtype: BinarySubtype::Generic,
-                            bytes: compressed_entity,
-                        }),
-                    },
-                },
-            )
-            .await?;
         Ok(())
     }
 
@@ -115,12 +88,7 @@ fn parse_existing_compressed_raw(doc: Document) -> Option<ExistingCompressedRawM
             _ => None,
         })
         .and_then(|size| usize::try_from(size).ok());
-    let has_network_entity = doc
-        .get_document("network")
-        .ok()
-        .and_then(|network| network.get("entity"))
-        .is_some_and(|entity| matches!(entity, Bson::Binary(_)));
-    Some(ExistingCompressedRawMail { checksum, size, has_network_entity })
+    Some(ExistingCompressedRawMail { checksum, size })
 }
 
 fn compressed_raw_update_filter(mail_id: &str, checksum: &str, size: i64) -> Document {
@@ -149,21 +117,11 @@ mod tests {
                 "checksum": "abc123",
                 "size": 42_i64,
             },
-            "network": {
-                "entity": Bson::Binary(Binary {
-                    subtype: BinarySubtype::Generic,
-                    bytes: vec![1, 2, 3],
-                }),
-            },
         };
         let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
         assert_eq!(
             existing,
-            ExistingCompressedRawMail {
-                checksum: Some("abc123".to_string()),
-                size: Some(42),
-                has_network_entity: true,
-            }
+            ExistingCompressedRawMail { checksum: Some("abc123".to_string()), size: Some(42) }
         );
     }
 
@@ -172,7 +130,6 @@ mod tests {
         let doc = doc! { "metadata": { "checksum": "abc123" } };
         let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
         assert_eq!(existing.size, None);
-        assert!(!existing.has_network_entity);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stop persisting relay ingress packets under `network.entity`
- remove the duplicate-upload backfill and related storage metadata
- leave existing database records untouched for manual cleanup

## Validation

- `cargo test -p rokbattles-ingress --locked`
- `cargo clippy -p rokbattles-ingress --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all -- --check`