### PR TITLE
feat: document and benchmark DJB2 SIMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,12 @@ checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -644,6 +659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +748,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -932,6 +980,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1037,16 @@ version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -2116,6 +2209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +2714,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -3623,6 +3736,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "open"
 version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3802,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3859,6 +3988,34 @@ dependencies = [
  "quick-xml",
  "serde",
  "time",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -4174,6 +4331,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4612,9 @@ dependencies = [
 [[package]]
 name = "rokbattles-djb2-simd"
 version = "1.6.1"
+dependencies = [
+ "criterion",
+]
 
 [[package]]
 name = "rokbattles-dns-resolver"
@@ -6162,6 +6342,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sentry = { version = "0.48.5", default-features = false }
 tokio-cron-scheduler = "0.15.1"
 hickory-proto = { version = "0.26.1", default-features = false }
 tower = "0.5.3"
+criterion = "0.8.2"
 
 [profile.release]
 opt-level = "z"

--- a/crates/common/rokbattles-djb2-simd/Cargo.toml
+++ b/crates/common/rokbattles-djb2-simd/Cargo.toml
@@ -4,8 +4,15 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
 [lints]
 workspace = true
 
 [lib]
 doctest = false
+
+[[bench]]
+name = "checksum"
+harness = false

--- a/crates/common/rokbattles-djb2-simd/benches/checksum.rs
+++ b/crates/common/rokbattles-djb2-simd/benches/checksum.rs
@@ -1,0 +1,87 @@
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+#[path = "../src/scalar.rs"]
+mod scalar;
+
+const SEED: u64 = 5_381;
+const INPUT_SIZES: [usize; 6] = [8, 16, 64, 1_024, 64 * 1_024, 1_024 * 1_024];
+
+fn checksum_byte_at_a_time(mut hash: u64, bytes: &[u8]) -> u64 {
+    for &byte in bytes {
+        hash = hash.wrapping_mul(33).wrapping_add(u64::from(byte));
+    }
+    hash
+}
+
+fn make_input(size: usize) -> Vec<u8> {
+    (0..size).map(|index| (index.wrapping_mul(197).wrapping_add(101) & 0xff) as u8).collect()
+}
+
+fn runtime_backend() -> &'static str {
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            "NEON"
+        } else {
+            "scalar (NEON unavailable)"
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") {
+            "AVX2"
+        } else {
+            "scalar (AVX2 unavailable)"
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        "scalar (no SIMD implementation for this architecture)"
+    }
+}
+
+fn benchmark_checksums(criterion: &mut Criterion) {
+    println!("Runtime-dispatched backend: {}", runtime_backend());
+
+    let mut group = criterion.benchmark_group("djb2");
+    for size in INPUT_SIZES {
+        let input = make_input(size);
+        let expected = checksum_byte_at_a_time(SEED, &input);
+        assert_eq!(scalar::checksum(SEED, &input), expected);
+        assert_eq!(rokbattles_djb2_simd::checksum(SEED, &input), expected);
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("byte_at_a_time", size),
+            &input,
+            |bencher, input| {
+                bencher
+                    .iter(|| black_box(checksum_byte_at_a_time(SEED, black_box(input.as_slice()))));
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("scalar_four_at_a_time", size),
+            &input,
+            |bencher, input| {
+                bencher.iter(|| black_box(scalar::checksum(SEED, black_box(input.as_slice()))));
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("runtime_dispatch", size),
+            &input,
+            |bencher, input| {
+                bencher.iter(|| {
+                    black_box(rokbattles_djb2_simd::checksum(SEED, black_box(input.as_slice())))
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_checksums);
+criterion_main!(benches);

--- a/crates/common/rokbattles-djb2-simd/src/lib.rs
+++ b/crates/common/rokbattles-djb2-simd/src/lib.rs
@@ -1,32 +1,49 @@
-//! Runtime-dispatched SIMD and portable scalar implementations of wrapping DJB2.
+//! A runtime-dispatched implementation of 64-bit wrapping DJB2.
+//!
+//! This crate advances a caller-provided hash state over a byte slice. On `x86_64` it uses AVX2
+//! when the running CPU supports it, and on `aarch64` it uses NEON when available. All other cases
+//! use the equivalent portable scalar implementation.
+//!
+//! DJB2 is a non-cryptographic hash. Do not rely on it for collision resistance or other security
+//! properties.
+//!
+//! # Example
+//!
+//! ```
+//! let hash = rokbattles_djb2_simd::checksum(5_381, b"hello");
+//!
+//! assert_eq!(hash, 210_714_636_441);
+//! ```
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
-const MULTIPLIER: u64 = 33;
-const MULTIPLIER_2: u64 = MULTIPLIER * MULTIPLIER;
-const MULTIPLIER_3: u64 = MULTIPLIER_2 * MULTIPLIER;
-const MULTIPLIER_4: u64 = MULTIPLIER_3 * MULTIPLIER;
+mod scalar;
 
-/// Extend a wrapping DJB2 checksum with `bytes`, using an available SIMD implementation or the
-/// equivalent scalar fallback.
+#[cfg(test)]
+use scalar::MULTIPLIER;
+use scalar::{MULTIPLIER_4, checksum as checksum_scalar};
+
+/// Extends `hash` with `bytes` using 64-bit wrapping DJB2.
+///
+/// For each byte `b`, the hash state is updated as `hash = hash * 33 + b`, modulo `2^64`. The
+/// caller supplies the initial state; use `5_381` for the conventional DJB2 seed. Supplying an
+/// empty slice returns `hash` unchanged.
+///
+/// Calls can be chained to hash data in separate chunks. Runtime SIMD dispatch is transparent:
+/// every supported implementation produces the same result as the scalar recurrence.
+///
+/// # Example
+///
+/// ```
+/// let first = rokbattles_djb2_simd::checksum(5_381, b"hel");
+/// let chunked = rokbattles_djb2_simd::checksum(first, b"lo");
+/// let contiguous = rokbattles_djb2_simd::checksum(5_381, b"hello");
+///
+/// assert_eq!(chunked, contiguous);
+/// ```
 #[must_use]
 pub fn checksum(hash: u64, bytes: &[u8]) -> u64 {
     platform::checksum(hash, bytes)
-}
-
-fn checksum_scalar(mut hash: u64, bytes: &[u8]) -> u64 {
-    let (chunks, remainder) = bytes.as_chunks::<4>();
-    for &[byte_0, byte_1, byte_2, byte_3] in chunks {
-        let contribution = u64::from(byte_0) * MULTIPLIER_3
-            + u64::from(byte_1) * MULTIPLIER_2
-            + u64::from(byte_2) * MULTIPLIER
-            + u64::from(byte_3);
-        hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(contribution);
-    }
-    for &byte in remainder {
-        hash = hash.wrapping_mul(MULTIPLIER).wrapping_add(u64::from(byte));
-    }
-    hash
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -38,12 +55,13 @@ mod platform {
 
     use super::{MULTIPLIER_4, checksum_scalar};
 
+    // Coefficients for a four-byte expansion, ordered from the oldest byte to the newest.
     const WEIGHTS: [u16; 4] = [35_937, 1_089, 33, 1];
 
     pub(super) fn checksum(hash: u64, bytes: &[u8]) -> u64 {
         if std::arch::is_aarch64_feature_detected!("neon") {
-            // SAFETY: Runtime detection guarantees NEON is available. The implementation only
-            // performs unaligned reads within `bytes` and writes to a local array.
+            // SAFETY: Runtime detection satisfies `checksum_neon`'s NEON requirement. Its memory
+            // operations derive their bounds from `bytes` and local arrays.
             unsafe { checksum_neon(hash, bytes) }
         } else {
             checksum_scalar(hash, bytes)
@@ -52,13 +70,16 @@ mod platform {
 
     #[target_feature(enable = "neon")]
     unsafe fn checksum_neon(mut hash: u64, bytes: &[u8]) -> u64 {
-        // SAFETY: `WEIGHTS.as_ptr()` points to four contiguous initialized `u16` values, matching
-        // the load width.
+        // SAFETY: `WEIGHTS` contains the four initialized `u16` values read by `vld1_u16`.
         let weights: uint16x4_t = unsafe { vld1_u16(WEIGHTS.as_ptr()) };
         let (chunks, remainder) = bytes.as_chunks::<16>();
         for chunk in chunks {
-            // SAFETY: `as_chunks::<16>()` guarantees 16 readable bytes.
+            // SAFETY: Each `chunk` contains the 16 initialized bytes read by `vld1q_u8`; the
+            // intrinsic permits an unaligned address.
             let input = unsafe { vld1q_u8(chunk.as_ptr()) };
+
+            // Multiply four consecutive four-byte groups by the expansion coefficients, then
+            // reduce each group to one contribution. The resulting lanes remain in input order.
             let low = vmovl_u8(vget_low_u8(input));
             let high = vmovl_u8(vget_high_u8(input));
             let products_0 = vmull_u16(vget_low_u16(low), weights);
@@ -69,7 +90,8 @@ mod platform {
             let pairs_23 = vpaddq_u32(products_2, products_3);
             let sums = vpaddq_u32(pairs_01, pairs_23);
             let mut contributions = [0_u32; 4];
-            // SAFETY: `contributions` has space for all four lanes.
+            // SAFETY: `contributions` provides writable storage for the four `u32` lanes written
+            // by `vst1q_u32`.
             unsafe { vst1q_u32(contributions.as_mut_ptr(), sums) };
 
             for contribution in contributions {
@@ -92,8 +114,8 @@ mod platform {
 
     pub(super) fn checksum(hash: u64, bytes: &[u8]) -> u64 {
         if std::arch::is_x86_feature_detected!("avx2") {
-            // SAFETY: Runtime detection guarantees AVX2 is available. The implementation only
-            // performs unaligned reads within `bytes` and writes to a local array.
+            // SAFETY: Runtime detection satisfies `checksum_avx2`'s AVX2 requirement. Its memory
+            // operations derive their bounds from `bytes` and local arrays.
             unsafe { checksum_avx2(hash, bytes) }
         } else {
             checksum_scalar(hash, bytes)
@@ -102,10 +124,12 @@ mod platform {
 
     #[target_feature(enable = "avx2")]
     unsafe fn checksum_avx2(mut hash: u64, bytes: &[u8]) -> u64 {
+        // Repeat the four expansion coefficients in both 128-bit halves of the AVX2 vector.
         let weights = _mm256_setr_epi32(35_937, 1_089, 33, 1, 35_937, 1_089, 33, 1);
         let (chunks, remainder) = bytes.as_chunks::<16>();
         for chunk in chunks {
-            // SAFETY: `as_chunks::<16>()` guarantees 16 readable bytes.
+            // SAFETY: Each `chunk` contains the 16 initialized bytes read by `_mm_loadu_si128`;
+            // the intrinsic permits an unaligned address.
             let input = unsafe { _mm_loadu_si128(chunk.as_ptr().cast::<__m128i>()) };
             let low = _mm256_cvtepu8_epi32(input);
             let high = _mm256_cvtepu8_epi32(_mm_srli_si128::<8>(input));
@@ -114,9 +138,12 @@ mod platform {
             let pairs = _mm256_hadd_epi32(products_low, products_high);
             let sums = _mm256_hadd_epi32(pairs, pairs);
             let mut lanes = [0_u32; 8];
-            // SAFETY: `lanes` has space for all eight lanes.
+            // SAFETY: `lanes` provides writable storage for the eight `u32` lanes written by
+            // `_mm256_storeu_si256`; the intrinsic permits an unaligned address.
             unsafe { _mm256_storeu_si256(lanes.as_mut_ptr().cast::<__m256i>(), sums) };
 
+            // Horizontal additions operate within each 128-bit half. After two reductions the
+            // four input-order contributions occupy lanes 0, 4, 1, and 5, respectively.
             let [sum_0, sum_2, _, _, sum_1, sum_3, _, _] = lanes;
             for contribution in [sum_0, sum_1, sum_2, sum_3] {
                 hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(u64::from(contribution));
@@ -138,6 +165,7 @@ mod platform {
 mod tests {
     use super::*;
 
+    // Keep the oracle byte-at-a-time so it does not reproduce the optimized four-byte recurrence.
     fn checksum_reference(mut hash: u64, bytes: &[u8]) -> u64 {
         for &byte in bytes {
             hash = hash.wrapping_mul(MULTIPLIER).wrapping_add(u64::from(byte));
@@ -147,6 +175,9 @@ mod tests {
 
     #[test]
     fn checksum_matches_reference_for_varied_lengths_and_values() {
+        // Because 197 is odd, this affine sequence visits every byte value before repeating. The
+        // dense lengths exercise every scalar and SIMD tail; the larger cases straddle powers of
+        // two and cover the complete input buffer.
         let bytes = (0..=u16::MAX)
             .map(|value| (value.wrapping_mul(197).wrapping_add(101) & 0xff) as u8)
             .collect::<Vec<_>>();
@@ -162,6 +193,8 @@ mod tests {
 
     #[test]
     fn scalar_checksum_matches_reference_for_varied_lengths_and_values() {
+        // Use the same varied input matrix while bypassing runtime dispatch, so the portable
+        // implementation remains independently covered on SIMD-capable development machines.
         let bytes = (0..=u16::MAX)
             .map(|value| (value.wrapping_mul(197).wrapping_add(101) & 0xff) as u8)
             .collect::<Vec<_>>();

--- a/crates/common/rokbattles-djb2-simd/src/scalar.rs
+++ b/crates/common/rokbattles-djb2-simd/src/scalar.rs
@@ -1,0 +1,25 @@
+pub(crate) const MULTIPLIER: u64 = 33;
+
+// Expanding four DJB2 rounds gives
+// `h' = h * 33^4 + b0 * 33^3 + b1 * 33^2 + b2 * 33 + b3`.
+// Its largest byte contribution is 9_450_300, so the SIMD reductions fit in `u32` lanes.
+const MULTIPLIER_2: u64 = MULTIPLIER * MULTIPLIER;
+const MULTIPLIER_3: u64 = MULTIPLIER_2 * MULTIPLIER;
+pub(crate) const MULTIPLIER_4: u64 = MULTIPLIER_3 * MULTIPLIER;
+
+pub(crate) fn checksum(mut hash: u64, bytes: &[u8]) -> u64 {
+    // Use the same four-round expansion as the SIMD implementations, then apply the original
+    // recurrence to the tail.
+    let (chunks, remainder) = bytes.as_chunks::<4>();
+    for &[byte_0, byte_1, byte_2, byte_3] in chunks {
+        let contribution = u64::from(byte_0) * MULTIPLIER_3
+            + u64::from(byte_1) * MULTIPLIER_2
+            + u64::from(byte_2) * MULTIPLIER
+            + u64::from(byte_3);
+        hash = hash.wrapping_mul(MULTIPLIER_4).wrapping_add(contribution);
+    }
+    for &byte in remainder {
+        hash = hash.wrapping_mul(MULTIPLIER).wrapping_add(u64::from(byte));
+    }
+    hash
+}


### PR DESCRIPTION
## Summary

- expand crate and API documentation with wrapping semantics, runtime dispatch behavior, examples, and security guidance
- document the scalar recurrence, SIMD reductions, lane ordering, unsafe preconditions, and test strategy
- share the scalar implementation through a private module and add Criterion benchmarks for byte-at-a-time, scalar, and runtime-dispatched implementations across 8 B through 1 MiB inputs
- report byte throughput and the runtime-selected backend while checking all implementations agree before measurement

## Validation

- cargo fmt --check
- cargo test -p rokbattles-djb2-simd
- cargo clippy -p rokbattles-djb2-simd --all-targets -- -D warnings
- cargo bench -p rokbattles-djb2-simd --bench checksum --no-run
- cargo bench -p rokbattles-djb2-simd --bench checksum -- --quick (18 measurements; NEON selected locally)
- cargo rustdoc -p rokbattles-djb2-simd --lib -- -D warnings