### PR TITLE
fix(territory-planner): use four-character alliance tags

### DIFF
--- a/packages/site/src/components/territory-planner/planner-settings-drawer.tsx
+++ b/packages/site/src/components/territory-planner/planner-settings-drawer.tsx
@@ -170,11 +170,12 @@ export function PlannerSettingsDrawer({
             }}
           >
             <Field>
-              <Label htmlFor="planner-alliance-name">{t("Alliance name")}</Label>
+              <Label htmlFor="planner-alliance-tag">{t("Alliance tag")}</Label>
               <Input
                 className="mt-2 [&_input]:rounded-md"
-                id="planner-alliance-name"
-                placeholder={t("Alliance name")}
+                id="planner-alliance-tag"
+                placeholder={t("Alliance tag")}
+                maxLength={4}
                 value={name}
                 onChange={(event) => setName(event.target.value)}
               />

--- a/packages/site/src/components/territory-planner/territory-planner.tsx
+++ b/packages/site/src/components/territory-planner/territory-planner.tsx
@@ -111,9 +111,7 @@ export function TerritoryPlanner({ maps }: { maps: TerritoryMapIndexRow[] }) {
   const t = useExtracted();
   const numberFormatter = useCompactNumberFormatter();
   const { mapLabel, resourceLabel, toolLabel } = useTerritoryPlannerLabels();
-  const [document, setDocument] = useState<PlannerDocument>(() =>
-    initialDocument(maps, t("Alliance 1"))
-  );
+  const [document, setDocument] = useState<PlannerDocument>(() => initialDocument(maps, "ROKB"));
   const [loadedDataSource, setLoadedDataSource] = useState<TerritoryDataSource | null>(null);
   const [dataVersion, setDataVersion] = useState(0);
   const [loading, setLoading] = useState(true);

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -2598,9 +2598,9 @@ msgid "Delete {name}"
 msgstr "Delete {name}"
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
-msgstr "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
+msgstr "Alliance tag"
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
 msgctxt "7s5xbv"
@@ -2647,11 +2647,6 @@ msgstr "Covered alliance resource plots"
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr "Locate {building} {number} on map"
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
-msgstr "Alliance 1"
 
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -2607,8 +2607,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2655,11 +2655,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -2607,8 +2607,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2655,11 +2655,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -2598,8 +2598,8 @@ msgid "Delete {name}"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
-msgctxt "PrwHjk"
-msgid "Alliance name"
+msgctxt "G-eSlG"
+msgid "Alliance tag"
 msgstr ""
 
 #: src/components/territory-planner/planner-settings-drawer.tsx
@@ -2646,11 +2646,6 @@ msgstr ""
 #: src/components/territory-planner/territory-breakdown.tsx
 msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
-msgstr ""
-
-#: src/components/territory-planner/territory-planner.tsx
-msgctxt "T86Fnb"
-msgid "Alliance 1"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx


### PR DESCRIPTION
The territory planner now labels the alliance field and placeholder “Alliance tag” and limits input to four characters. New planners start with `ROKB` as the default tag. Updated the translation catalogs to match the new copy and remove the unused default-name message.

Validation: site typecheck, Biome, and diff checks pass. Browser verification confirmed that entering `ABCDEF` leaves `ABCD`. React Doctor reports one existing complexity warning in `TerritoryPlanner`.
