### PR TITLE
feat(territory-planner): support within-cell placement

### DIFF
--- a/packages/site/src/components/territory-planner/planner-canvas.tsx
+++ b/packages/site/src/components/territory-planner/planner-canvas.tsx
@@ -12,10 +12,13 @@ import {
 } from "@/lib/territory/assets";
 import type { TerritoryDataSource, WorldBounds } from "@/lib/territory/data-source";
 import {
+  alignBuildingPoint,
   buildingRules,
   buildTerritoryOverviewFromCells,
   buildTerritoryOverviewsFromOwnership,
+  snapTerritoryPoint,
   structureTerritoryCells,
+  TERRITORY_UNIT,
   type TerritoryOverview,
   type TerritoryState,
   territoryBounds,
@@ -665,10 +668,9 @@ export function PlannerCanvas({
     const hover = hoverRef.current;
     if (hover && tool !== "select" && tool !== "draw") {
       const legal = isPlacementLegal(tool, hover.x, hover.y);
-      const rule = buildingRules[tool];
-      const half = rule.territorySide / 2;
-      const topLeft = worldToScreen(hover.x - half, hover.y + half);
-      const bottomRight = worldToScreen(hover.x + half, hover.y - half);
+      const footprint = territoryBounds({ kind: tool, x: hover.x, y: hover.y });
+      const topLeft = worldToScreen(footprint.minX, footprint.maxY);
+      const bottomRight = worldToScreen(footprint.maxX, footprint.minY);
       context.fillStyle = legal ? "rgba(34, 197, 94, 0.22)" : "rgba(239, 68, 68, 0.25)";
       context.strokeStyle = legal ? "#22c55e" : "#ef4444";
       context.lineWidth = 2;
@@ -681,6 +683,44 @@ export function PlannerCanvas({
         bottomRight.y - topLeft.y
       );
       context.setLineDash([]);
+      const cellCenter = snapTerritoryPoint(hover.x, hover.y);
+      const cellTopLeft = worldToScreen(
+        cellCenter.x - TERRITORY_UNIT / 2,
+        cellCenter.y + TERRITORY_UNIT / 2
+      );
+      const cellBottomRight = worldToScreen(
+        cellCenter.x + TERRITORY_UNIT / 2,
+        cellCenter.y - TERRITORY_UNIT / 2
+      );
+      context.strokeStyle = legal ? "rgba(255, 255, 255, 0.9)" : "rgba(254, 202, 202, 0.9)";
+      context.lineWidth = 1;
+      context.strokeRect(
+        cellTopLeft.x,
+        cellTopLeft.y,
+        cellBottomRight.x - cellTopLeft.x,
+        cellBottomRight.y - cellTopLeft.y
+      );
+      const anchor = worldToScreen(hover.x, hover.y);
+      context.beginPath();
+      context.arc(
+        anchor.x,
+        anchor.y,
+        buildingRules[tool].baseClearance * view.scale,
+        0,
+        Math.PI * 2
+      );
+      context.fillStyle = legal ? "rgba(34, 197, 94, 0.2)" : "rgba(239, 68, 68, 0.24)";
+      context.fill();
+      context.strokeStyle = legal ? "#22c55e" : "#ef4444";
+      context.lineWidth = 1;
+      context.stroke();
+      context.beginPath();
+      context.arc(anchor.x, anchor.y, 2, 0, Math.PI * 2);
+      context.fillStyle = legal ? "#22c55e" : "#ef4444";
+      context.fill();
+      context.strokeStyle = "white";
+      context.lineWidth = 1;
+      context.stroke();
     }
     if (boundaryPathsPending) requestDraw();
   }, [
@@ -987,10 +1027,7 @@ export function PlannerCanvas({
           }
           updateCoordinateHud(point);
           const world = screenToWorld(point.x, point.y);
-          hoverRef.current = {
-            x: Math.floor(world.x / 18) * 18 + 9,
-            y: Math.floor(world.y / 18) * 18 + 9,
-          };
+          hoverRef.current = alignBuildingPoint(world.x, world.y);
           requestDraw();
         }}
         onPointerUp={(event) => {
@@ -1014,11 +1051,8 @@ export function PlannerCanvas({
           if (pointer?.dragged) return;
           const world = screenToWorld(point.x, point.y);
           if (tool !== "select" && tool !== "draw") {
-            const snapped = {
-              x: Math.floor(world.x / 18) * 18 + 9,
-              y: Math.floor(world.y / 18) * 18 + 9,
-            };
-            onPlace(tool, snapped.x, snapped.y);
+            const aligned = alignBuildingPoint(world.x, world.y);
+            onPlace(tool, aligned.x, aligned.y);
             return;
           }
           const hitRadius = 14 / viewRef.current.scale;

--- a/packages/site/src/components/territory-planner/territory-planner.tsx
+++ b/packages/site/src/components/territory-planner/territory-planner.tsx
@@ -30,6 +30,7 @@ import {
 import { TerritoryDataSource, type WorldBounds } from "@/lib/territory/data-source";
 import { decodePlan, encodePlan, normalizePlannerDocument } from "@/lib/territory/document";
 import {
+  alignBuildingPoint,
   boundaryCollision,
   buildingRules,
   buildTerritoryState,
@@ -41,7 +42,6 @@ import {
   isProvinceRestricted,
   mapStructureCollision,
   plannedBuildingCollision,
-  snapTerritoryPoint,
 } from "@/lib/territory/geometry";
 import { LOST_KINGDOM_TERRITORY_COLORS } from "@/lib/territory/presentation";
 import { deleteSelectedPlannerItems, updatePlannerSelection } from "@/lib/territory/selection";
@@ -258,13 +258,13 @@ export function TerritoryPlanner({ maps }: { maps: TerritoryMapIndexRow[] }) {
         source.buildings
       );
       if (progress.built >= progress.limit) return false;
-      const { x, y } = snapTerritoryPoint(rawX, rawY);
+      const { x, y } = alignBuildingPoint(rawX, rawY);
       const imageBounds = source.config.imageBounds;
       if (
         x < imageBounds.minX ||
-        x > imageBounds.maxX ||
+        x >= imageBounds.maxX ||
         y < imageBounds.minY ||
-        y > imageBounds.maxY
+        y >= imageBounds.maxY
       ) {
         return false;
       }
@@ -308,7 +308,7 @@ export function TerritoryPlanner({ maps }: { maps: TerritoryMapIndexRow[] }) {
     async (kind: BuildingKind, rawX: number, rawY: number) => {
       const source = sourceRef.current;
       if (!source) return;
-      const { x, y } = snapTerritoryPoint(rawX, rawY);
+      const { x, y } = alignBuildingPoint(rawX, rawY);
       const clearance = buildingRules[kind].baseClearance;
       try {
         await source.ensureBounds(

--- a/packages/site/src/lib/territory/geometry.ts
+++ b/packages/site/src/lib/territory/geometry.ts
@@ -10,6 +10,7 @@ import type {
 } from "./types";
 
 export const TERRITORY_UNIT = 18;
+export const BUILD_POSITION_ALIGNMENT = 0.01;
 
 export type TerritoryFillRect = {
   minX: number;
@@ -81,6 +82,15 @@ export function snapTerritoryPoint(x: number, y: number): { x: number; y: number
   return { x: snapTerritoryCoordinate(x), y: snapTerritoryCoordinate(y) };
 }
 
+export function alignBuildingCoordinate(value: number): number {
+  const aligned = Math.floor(value / BUILD_POSITION_ALIGNMENT + 0.5) * BUILD_POSITION_ALIGNMENT;
+  return Number(aligned.toFixed(2));
+}
+
+export function alignBuildingPoint(x: number, y: number): { x: number; y: number } {
+  return { x: alignBuildingCoordinate(x), y: alignBuildingCoordinate(y) };
+}
+
 export function provinceIdAt(
   grid: ProvinceRestrictionGrid | null,
   x: number,
@@ -107,12 +117,13 @@ export function isProvinceRestricted(
 }
 
 export function territoryBounds(building: Pick<PlannedBuilding, "kind" | "x" | "y">) {
+  const center = snapTerritoryPoint(building.x, building.y);
   const half = buildingRules[building.kind].territorySide / 2;
   return {
-    minX: building.x - half,
-    minY: building.y - half,
-    maxX: building.x + half,
-    maxY: building.y + half,
+    minX: center.x - half,
+    minY: center.y - half,
+    maxX: center.x + half,
+    maxY: center.y + half,
   };
 }
 
@@ -156,14 +167,12 @@ export function structureTerritoryCells(
 export function territoryCells(
   building: Pick<PlannedBuilding, "kind" | "x" | "y">
 ): TerritoryCell[] {
-  const bounds = territoryBounds(building);
-  const minColumn = Math.round(bounds.minX / TERRITORY_UNIT);
-  const maxColumn = Math.round(bounds.maxX / TERRITORY_UNIT);
-  const minRow = Math.round(bounds.minY / TERRITORY_UNIT);
-  const maxRow = Math.round(bounds.maxY / TERRITORY_UNIT);
+  const centerColumn = Math.floor(building.x / TERRITORY_UNIT);
+  const centerRow = Math.floor(building.y / TERRITORY_UNIT);
+  const radius = (buildingRules[building.kind].territorySide / TERRITORY_UNIT - 1) / 2;
   const cells: TerritoryCell[] = [];
-  for (let row = minRow; row < maxRow; row += 1) {
-    for (let column = minColumn; column < maxColumn; column += 1) {
+  for (let row = centerRow - radius; row <= centerRow + radius; row += 1) {
+    for (let column = centerColumn - radius; column <= centerColumn + radius; column += 1) {
       cells.push({ column, row });
     }
   }


### PR DESCRIPTION
Allow territory buildings to be placed within a cell at 0.01-unit increments instead of forcing their anchors to cell centers. Keep territory footprints aligned to the containing cell while using the actual building anchor for placement and collision checks.

Update the placement preview to show the territory footprint, containing cell, and physical clearance circle. Server-side collision padding remains unknown.

Validation:
- Rebased onto the latest `main` without conflicts.
- Biome CI passed for the changed TypeScript files.
- `pnpm -F @rokbattles/site typecheck` passed.
- `git diff --check` passed after removing the placement evidence Markdown file; TypeScript code is unchanged from the validated version.
