### PR TITLE
fix(ingress): gate mail updates on mutable metadata

### DIFF
--- a/crates/apps/rokbattles-ingress/src/handlers.rs
+++ b/crates/apps/rokbattles-ingress/src/handlers.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use crate::{
     clamav::{ScanStatus, scan_zstream},
     error::ApiError,
+    mail_update::mutable_metadata_differs,
     raw_mail::{self, RawMailDocumentInput},
     state::AppState,
 };
@@ -71,7 +72,7 @@ pub async fn health() -> StatusCode {
     StatusCode::OK
 }
 
-/// Store a mail report when it is new or newer than the saved copy.
+/// Store a mail report when it is new or has updated mutable metadata.
 pub async fn upload(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -287,15 +288,48 @@ async fn store_compressed_raw_mail(
     user_agent: &str,
 ) -> Result<UploadAction, ApiError> {
     let checksum = raw_mail::sha256_hex(buffer);
-    let binary_size = i64::try_from(buffer.len())
-        .map_err(|_| ApiError::internal("mail binary is too large to store size"))?;
     let existing = state
         .storage
         .find_existing_compressed_raw(mail_id)
         .await
         .map_err(|error| ApiError::database(error.to_string()))?;
 
-    let action = decide_compressed_raw_action(existing.as_ref(), &checksum, buffer.len());
+    let metadata_differs = match existing.as_ref() {
+        Some(existing) if existing.checksum.as_deref() != Some(checksum.as_str()) => {
+            let Some(compressed) = state
+                .storage
+                .find_compressed_raw_binary(mail_id, existing.checksum.as_deref())
+                .await
+                .map_err(|error| ApiError::database(error.to_string()))?
+            else {
+                return Ok(UploadAction::Skip);
+            };
+            let expected_size =
+                existing.size.ok_or_else(|| ApiError::internal("stored mail size is missing"))?;
+            if existing.algorithm.as_deref() != Some("zstd") {
+                return Err(ApiError::internal("stored mail compression is unsupported"));
+            }
+            let existing_bytes = raw_mail::decompress_raw_mail(
+                &compressed,
+                expected_size,
+                state.config.max_upload_bytes,
+            )?;
+            if existing
+                .checksum
+                .as_deref()
+                .is_some_and(|expected| raw_mail::sha256_hex(&existing_bytes) != expected)
+            {
+                return Err(ApiError::internal("stored mail checksum does not match its binary"));
+            }
+            let existing_decoded =
+                rokbattles_mail_decoder::decode(&existing_bytes).map_err(|error| {
+                    ApiError::internal(format!("stored mail decode failed: {error}"))
+                })?;
+            mutable_metadata_differs(&existing_decoded, decoded)?
+        }
+        _ => false,
+    };
+    let action = decide_compressed_raw_action(existing.as_ref(), &checksum, metadata_differs);
 
     if matches!(action, UploadAction::Skip) {
         return Ok(action);
@@ -323,11 +357,20 @@ async fn store_compressed_raw_mail(
             .insert_compressed_raw(doc)
             .await
             .map_err(|error| ApiError::database(error.to_string()))?,
-        UploadAction::Update => state
-            .storage
-            .update_compressed_raw(mail_id, &checksum, binary_size, doc)
-            .await
-            .map_err(|error| ApiError::database(error.to_string()))?,
+        UploadAction::Update => {
+            let updated = state
+                .storage
+                .update_compressed_raw(
+                    mail_id,
+                    existing.as_ref().and_then(|mail| mail.checksum.as_deref()),
+                    doc,
+                )
+                .await
+                .map_err(|error| ApiError::database(error.to_string()))?;
+            if !updated {
+                return Ok(UploadAction::Skip);
+            }
+        }
         UploadAction::Skip => {}
     }
 
@@ -492,14 +535,12 @@ fn is_probably_json(bytes: &[u8]) -> bool {
 fn decide_compressed_raw_action(
     existing: Option<&crate::storage::ExistingCompressedRawMail>,
     checksum: &str,
-    size: usize,
+    metadata_differs: bool,
 ) -> UploadAction {
     match existing {
         None => UploadAction::Insert,
         Some(existing) if existing.checksum.as_deref() == Some(checksum) => UploadAction::Skip,
-        Some(existing) if existing.size.is_some_and(|existing_size| size > existing_size) => {
-            UploadAction::Update
-        }
+        Some(_) if metadata_differs => UploadAction::Update,
         Some(_) => UploadAction::Skip,
     }
 }
@@ -760,37 +801,38 @@ mod tests {
         assert_eq!(extract_mail_id(&decoded).as_deref(), Some("meta-1"));
     }
 
-    fn existing_compressed_raw(
-        checksum: &str,
-        size: Option<usize>,
-    ) -> crate::storage::ExistingCompressedRawMail {
-        crate::storage::ExistingCompressedRawMail { checksum: Some(checksum.to_string()), size }
+    fn existing_compressed_raw(checksum: &str) -> crate::storage::ExistingCompressedRawMail {
+        crate::storage::ExistingCompressedRawMail {
+            checksum: Some(checksum.to_string()),
+            size: Some(100),
+            algorithm: Some("zstd".to_string()),
+        }
     }
 
     #[test]
     fn compressed_raw_action_inserts_when_missing() {
-        let action = decide_compressed_raw_action(None, "new", 100);
+        let action = decide_compressed_raw_action(None, "new", false);
         assert!(matches!(action, UploadAction::Insert));
     }
 
     #[test]
     fn compressed_raw_action_skips_matching_checksum() {
-        let existing = existing_compressed_raw("same", Some(50));
-        let action = decide_compressed_raw_action(Some(&existing), "same", 100);
+        let existing = existing_compressed_raw("same");
+        let action = decide_compressed_raw_action(Some(&existing), "same", true);
         assert!(matches!(action, UploadAction::Skip));
     }
 
     #[test]
-    fn compressed_raw_action_updates_different_larger_binary() {
-        let existing = existing_compressed_raw("old", Some(99));
-        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+    fn compressed_raw_action_updates_different_checksum_and_metadata() {
+        let existing = existing_compressed_raw("old");
+        let action = decide_compressed_raw_action(Some(&existing), "new", true);
         assert!(matches!(action, UploadAction::Update));
     }
 
     #[test]
-    fn compressed_raw_action_skips_different_equal_size_binary() {
-        let existing = existing_compressed_raw("old", Some(100));
-        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
+    fn compressed_raw_action_skips_different_checksum_without_metadata_change() {
+        let existing = existing_compressed_raw("old");
+        let action = decide_compressed_raw_action(Some(&existing), "new", false);
         assert!(matches!(action, UploadAction::Skip));
     }
 
@@ -801,20 +843,6 @@ mod tests {
 
         assert!(authorize_relay(&headers, "secret").is_ok());
         assert!(matches!(authorize_relay(&headers, "different"), Err(ApiError::Unauthorized)));
-    }
-
-    #[test]
-    fn compressed_raw_action_skips_different_smaller_binary() {
-        let existing = existing_compressed_raw("old", Some(101));
-        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
-        assert!(matches!(action, UploadAction::Skip));
-    }
-
-    #[test]
-    fn compressed_raw_action_skips_when_stored_size_is_missing() {
-        let existing = existing_compressed_raw("old", None);
-        let action = decide_compressed_raw_action(Some(&existing), "new", 100);
-        assert!(matches!(action, UploadAction::Skip));
     }
 
     #[test]

--- a/crates/apps/rokbattles-ingress/src/mail_update.rs
+++ b/crates/apps/rokbattles-ingress/src/mail_update.rs
@@ -1,0 +1,132 @@
+//! Mutable mail fields used to decide whether an existing raw mail should be replaced.
+
+use rokbattles_mail_registry::normalize_mail_root;
+use serde_json::Value;
+
+use crate::error::ApiError;
+
+const MUTABLE_FIELDS: [&str; 8] = [
+    "unread",
+    "box",
+    "prevBox",
+    "reportMerge",
+    "holdTag",
+    "addition",
+    "lastViewTs",
+    "needPopupTips",
+];
+
+pub(crate) fn mutable_metadata_differs(
+    existing: &Value,
+    incoming: &Value,
+) -> Result<bool, ApiError> {
+    let existing = normalize_mail_root(existing)
+        .ok_or_else(|| ApiError::internal("stored mail has an invalid root"))?;
+    let incoming = normalize_mail_root(incoming)
+        .ok_or_else(|| ApiError::bad_request("incoming mail has an invalid root"))?;
+
+    Ok(MUTABLE_FIELDS.iter().any(|field| existing.get(*field) != incoming.get(*field))
+        || attachment_statuses(existing) != attachment_statuses(incoming))
+}
+
+fn attachment_statuses(mail: &Value) -> Vec<Option<&Value>> {
+    mail.get("attachments")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .map(|attachment| attachment.get("status"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::*;
+
+    fn mail() -> Value {
+        json!({
+            "id": "mail-1",
+            "unread": true,
+            "attachments": [{ "id": 1, "loot": [{ "type": 2 }], "status": 0 }],
+            "box": "Report",
+            "prevBox": "",
+            "reportMerge": 0,
+            "holdTag": 0,
+            "addition": "",
+            "lastViewTs": 0,
+            "needPopupTips": false,
+            "body": {
+                "content": {
+                    "Attacks": {
+                        "attack-1": {
+                            "Damage": { "Death": 10 },
+                            "attack_idt_key": "attack-1"
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn detects_each_allowlisted_top_level_field_change() {
+        let existing = mail();
+        let cases = [
+            ("unread", json!(false)),
+            ("box", json!("Archive")),
+            ("prevBox", json!("Report")),
+            ("reportMerge", json!(1)),
+            ("holdTag", json!(1)),
+            ("addition", json!("updated")),
+            ("lastViewTs", json!(1234)),
+            ("needPopupTips", json!(true)),
+        ];
+
+        for (field, value) in cases {
+            let mut incoming = mail();
+            incoming[field] = value;
+
+            assert!(
+                mutable_metadata_differs(&existing, &incoming).expect("compare metadata"),
+                "{field} should be treated as mutable"
+            );
+        }
+    }
+
+    #[test]
+    fn detects_attachment_status_change() {
+        let existing = mail();
+        let mut incoming = mail();
+        incoming["attachments"][0]["status"] = json!(1);
+
+        assert!(mutable_metadata_differs(&existing, &incoming).expect("compare metadata"));
+    }
+
+    #[test]
+    fn ignores_non_status_attachment_changes() {
+        let existing = mail();
+        let mut incoming = mail();
+        incoming["attachments"][0]["loot"][0]["type"] = json!(9);
+
+        assert!(!mutable_metadata_differs(&existing, &incoming).expect("compare metadata"));
+    }
+
+    #[test]
+    fn ignores_substantive_battle_changes() {
+        let existing = mail();
+        let mut incoming = mail();
+        incoming["body"]["content"]["Attacks"]["attack-1"]["Damage"]["Death"] = json!(99);
+
+        assert!(!mutable_metadata_differs(&existing, &incoming).expect("compare metadata"));
+    }
+
+    #[test]
+    fn ignores_viewer_derived_battle_changes() {
+        let existing = mail();
+        let mut incoming = mail();
+        incoming["body"]["content"]["Attacks"]["attack-1"]["attack_idt_key"] = json!("derived-key");
+
+        assert!(!mutable_metadata_differs(&existing, &incoming).expect("compare metadata"));
+    }
+}

--- a/crates/apps/rokbattles-ingress/src/main.rs
+++ b/crates/apps/rokbattles-ingress/src/main.rs
@@ -8,6 +8,7 @@ mod clamav;
 mod config;
 mod error;
 mod handlers;
+mod mail_update;
 mod raw_mail;
 mod state;
 mod storage;

--- a/crates/apps/rokbattles-ingress/src/raw_mail.rs
+++ b/crates/apps/rokbattles-ingress/src/raw_mail.rs
@@ -1,6 +1,6 @@
 //! V2 raw binary mail storage helpers.
 
-use std::io::Cursor;
+use std::io::{Cursor, Read};
 
 use mongodb::bson::{Binary, Bson, DateTime, Document, doc, spec::BinarySubtype};
 use serde_json::Value;
@@ -99,6 +99,38 @@ pub fn compress_raw_mail(bytes: &[u8], zstd_level: i32) -> Result<Vec<u8>, ApiEr
         .map_err(|error| ApiError::internal(error.to_string()))
 }
 
+/// Decompress a stored raw mail while enforcing its recorded and configured sizes.
+pub fn decompress_raw_mail(
+    compressed: &[u8],
+    expected_size: usize,
+    max_size: usize,
+) -> Result<Vec<u8>, ApiError> {
+    if expected_size > max_size {
+        return Err(ApiError::internal("stored mail exceeds the configured upload limit"));
+    }
+
+    let read_limit = u64::try_from(expected_size)
+        .ok()
+        .and_then(|size| size.checked_add(1))
+        .ok_or_else(|| ApiError::internal("stored mail size is out of range"))?;
+    let decoder = zstd::stream::read::Decoder::new(Cursor::new(compressed))
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let mut bytes = Vec::with_capacity(expected_size);
+    decoder
+        .take(read_limit)
+        .read_to_end(&mut bytes)
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+
+    if bytes.len() != expected_size {
+        return Err(ApiError::internal(format!(
+            "stored mail size mismatch: expected {expected_size} bytes, decoded {}",
+            bytes.len()
+        )));
+    }
+
+    Ok(bytes)
+}
+
 fn extract_receiver_identity(object: &serde_json::Map<String, Value>) -> Result<String, ApiError> {
     object
         .get("receiver")
@@ -149,6 +181,24 @@ mod tests {
         let compressed = compress_raw_mail(raw, 3).expect("compress");
 
         assert_eq!(decompress(&compressed), raw);
+    }
+
+    #[test]
+    fn bounded_decompression_roundtrips() {
+        let raw = b"small mail payload";
+        let compressed = compress_raw_mail(raw, 3).expect("compress");
+
+        assert_eq!(
+            decompress_raw_mail(&compressed, raw.len(), raw.len()).expect("decompress"),
+            raw
+        );
+    }
+
+    #[test]
+    fn bounded_decompression_rejects_oversized_stored_mail() {
+        let compressed = compress_raw_mail(b"mail", 3).expect("compress");
+
+        assert!(decompress_raw_mail(&compressed, 4, 3).is_err());
     }
 
     #[test]

--- a/crates/apps/rokbattles-ingress/src/storage.rs
+++ b/crates/apps/rokbattles-ingress/src/storage.rs
@@ -12,11 +12,12 @@ pub struct Storage {
     compressed_raw: Collection<Document>,
 }
 
-/// V2 raw binary mail metadata needed to decide whether an upload is larger.
+/// V2 raw binary mail metadata needed to compare a duplicate upload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExistingCompressedRawMail {
     pub checksum: Option<String>,
     pub size: Option<usize>,
+    pub algorithm: Option<String>,
 }
 
 impl Storage {
@@ -32,7 +33,7 @@ impl Storage {
         Ok(())
     }
 
-    /// Load V2 checksum and uncompressed size metadata, if this mail was already uploaded.
+    /// Load V2 comparison metadata, if this mail was already uploaded.
     pub async fn find_existing_compressed_raw(
         &self,
         mail_id: &str,
@@ -43,9 +44,24 @@ impl Storage {
             .projection(doc! {
                 "metadata.checksum": 1,
                 "metadata.size": 1,
+                "metadata.algo": 1,
             })
             .await?;
         Ok(doc.and_then(parse_existing_compressed_raw))
+    }
+
+    /// Load the compressed binary for an existing V2 mail.
+    pub async fn find_compressed_raw_binary(
+        &self,
+        mail_id: &str,
+        checksum: Option<&str>,
+    ) -> mongodb::error::Result<Option<Vec<u8>>> {
+        let doc = self
+            .compressed_raw
+            .find_one(compressed_raw_version_filter(mail_id, checksum))
+            .projection(doc! { "mail.binary": 1 })
+            .await?;
+        Ok(doc.and_then(parse_compressed_raw_binary))
     }
 
     /// Insert a new V2 raw compressed mail document.
@@ -54,18 +70,17 @@ impl Storage {
         Ok(())
     }
 
-    /// Replace an existing V2 document only when its checksum differs and stored size is smaller.
+    /// Replace the V2 document only if it is still the version the caller compared.
     pub async fn update_compressed_raw(
         &self,
         mail_id: &str,
-        checksum: &str,
-        size: i64,
+        existing_checksum: Option<&str>,
         mut doc: Document,
-    ) -> mongodb::error::Result<()> {
+    ) -> mongodb::error::Result<bool> {
         doc.remove("createdAt");
-        let filter = compressed_raw_update_filter(mail_id, checksum, size);
-        self.compressed_raw.update_one(filter, doc! { "$set": doc }).await?;
-        Ok(())
+        let filter = compressed_raw_version_filter(mail_id, existing_checksum);
+        let result = self.compressed_raw.update_one(filter, doc! { "$set": doc }).await?;
+        Ok(result.modified_count == 1)
     }
 }
 
@@ -88,19 +103,38 @@ fn parse_existing_compressed_raw(doc: Document) -> Option<ExistingCompressedRawM
             _ => None,
         })
         .and_then(|size| usize::try_from(size).ok());
-    Some(ExistingCompressedRawMail { checksum, size })
+    let algorithm = metadata.and_then(|metadata| metadata.get_str("algo").ok()).map(str::to_string);
+    Some(ExistingCompressedRawMail { checksum, size, algorithm })
 }
 
-fn compressed_raw_update_filter(mail_id: &str, checksum: &str, size: i64) -> Document {
-    doc! {
-        "mail.id": mail_id,
-        "metadata.checksum": { "$ne": checksum },
-        "metadata.size": { "$lt": size },
+fn parse_compressed_raw_binary(mut doc: Document) -> Option<Vec<u8>> {
+    let mut mail = match doc.remove("mail")? {
+        Bson::Document(mail) => mail,
+        _ => return None,
+    };
+    match mail.remove("binary")? {
+        Bson::Binary(binary) => Some(binary.bytes),
+        _ => None,
+    }
+}
+
+fn compressed_raw_version_filter(mail_id: &str, checksum: Option<&str>) -> Document {
+    match checksum {
+        Some(checksum) => doc! {
+            "mail.id": mail_id,
+            "metadata.checksum": checksum,
+        },
+        None => doc! {
+            "mail.id": mail_id,
+            "metadata.checksum": { "$exists": false },
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use mongodb::bson::{Binary, spec::BinarySubtype};
+
     use super::*;
 
     #[test]
@@ -116,12 +150,17 @@ mod tests {
             "metadata": {
                 "checksum": "abc123",
                 "size": 42_i64,
+                "algo": "zstd",
             },
         };
         let existing = parse_existing_compressed_raw(doc).expect("existing compressed mail");
         assert_eq!(
             existing,
-            ExistingCompressedRawMail { checksum: Some("abc123".to_string()), size: Some(42) }
+            ExistingCompressedRawMail {
+                checksum: Some("abc123".to_string()),
+                size: Some(42),
+                algorithm: Some("zstd".to_string()),
+            }
         );
     }
 
@@ -140,14 +179,39 @@ mod tests {
     }
 
     #[test]
-    fn compressed_raw_update_filter_requires_different_checksum_and_smaller_stored_size() {
-        let filter = compressed_raw_update_filter("mail-1", "new", 100);
+    fn parses_compressed_raw_binary() {
+        let doc = doc! {
+            "mail": {
+                "binary": Bson::Binary(Binary {
+                    subtype: BinarySubtype::Generic,
+                    bytes: vec![1, 2, 3],
+                }),
+            },
+        };
+
+        assert_eq!(parse_compressed_raw_binary(doc), Some(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn compressed_raw_version_filter_matches_known_checksum() {
+        let filter = compressed_raw_version_filter("mail-1", Some("old"));
         assert_eq!(
             filter,
             doc! {
                 "mail.id": "mail-1",
-                "metadata.checksum": { "$ne": "new" },
-                "metadata.size": { "$lt": 100_i64 },
+                "metadata.checksum": "old",
+            }
+        );
+    }
+
+    #[test]
+    fn compressed_raw_version_filter_matches_missing_checksum() {
+        let filter = compressed_raw_version_filter("mail-1", None);
+        assert_eq!(
+            filter,
+            doc! {
+                "mail.id": "mail-1",
+                "metadata.checksum": { "$exists": false },
             }
         );
     }


### PR DESCRIPTION
Replace the ingress mail-size heuristic with a comparison of mutable metadata. When a checksum differs, decode the stored mail and update only if an allowlisted metadata field or attachment status changed. Differences confined to battle content or other attachment fields no longer trigger replacement.

Bound stored-mail decompression, validate its compression and checksum, and condition database updates on the version compared to avoid overwriting a concurrent update.

Validation: `cargo test -p rokbattles-ingress --locked` passed after rebasing (72 passed, 1 ignored). Ingress formatting and staged diff checks passed.
