### PR TITLE
feat(territory-planner): add XLSX export

### DIFF
--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
     "recharts": "^3.10.1",
+    "write-excel-file": "^4.1.1",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/packages/site/src/components/territory-planner/territory-export-button.tsx
+++ b/packages/site/src/components/territory-planner/territory-export-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ArrowDownTrayIcon } from "@heroicons/react/20/solid";
+import { useExtracted } from "next-intl";
+import { useState } from "react";
+import { useTerritoryPlannerLabels } from "@/components/territory-planner/use-territory-planner-labels";
+import { Button } from "@/components/ui/button";
+import type { PlannerDocument } from "@/lib/territory/types";
+
+export function TerritoryExportButton({ document }: { document: PlannerDocument }) {
+  const t = useExtracted();
+  const { toolLabel } = useTerritoryPlannerLabels();
+  const [error, setError] = useState("");
+  const [isExporting, setIsExporting] = useState(false);
+
+  async function exportPlan() {
+    setIsExporting(true);
+    setError("");
+    try {
+      const { exportTerritoryPlan } = await import("@/lib/territory/export");
+      await exportTerritoryPlan(document, {
+        mainFortress: toolLabel("mainFortress"),
+        subFortress: toolLabel("subFortress"),
+        horse: toolLabel("horse"),
+        flag: toolLabel("flag"),
+      });
+    } catch {
+      setError(t("The plan could not be exported. Please try again."));
+    } finally {
+      setIsExporting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button className="rounded-md" disabled={isExporting} onClick={exportPlan}>
+        <ArrowDownTrayIcon /> {t("Export")}
+      </Button>
+      {error ? <p role="alert">{error}</p> : null}
+    </>
+  );
+}

--- a/packages/site/src/components/territory-planner/territory-planner.tsx
+++ b/packages/site/src/components/territory-planner/territory-planner.tsx
@@ -17,6 +17,7 @@ import {
 import { PlannerSettingsDrawer } from "@/components/territory-planner/planner-settings-drawer";
 import { ResourceMetric } from "@/components/territory-planner/resource-metric";
 import { TerritoryBreakdown } from "@/components/territory-planner/territory-breakdown";
+import { TerritoryExportButton } from "@/components/territory-planner/territory-export-button";
 import { useCompactNumberFormatter } from "@/components/territory-planner/use-compact-number-formatter";
 import { useTerritoryPlannerLabels } from "@/components/territory-planner/use-territory-planner-labels";
 import { Button } from "@/components/ui/button";
@@ -520,9 +521,10 @@ export function TerritoryPlanner({ maps }: { maps: TerritoryMapIndexRow[] }) {
               </ListboxOption>
             ))}
           </Listbox>
-          <Button className="rounded-md" color="blue" onClick={share}>
-            <ClipboardDocumentIcon /> {t("Share")}
+          <Button className="rounded-md" onClick={share}>
+            <ClipboardDocumentIcon /> {t("Copy URL")}
           </Button>
+          <TerritoryExportButton document={document} />
           <span aria-live="polite" className="sr-only" role="status">
             {shareStatus}
           </span>

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -1945,7 +1945,6 @@ msgstr "تم النسخ"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -1945,7 +1945,6 @@ msgstr "Kopiert"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -1945,7 +1945,6 @@ msgstr "Copied"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr "Share"
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr "Locate {building} {number} on map"
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr "The plan could not be exported. Please try again."
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr "Export"
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2672,6 +2681,11 @@ msgstr "No maps are available."
 msgctxt "zuqMfZ"
 msgid "Map"
 msgstr "Map"
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
+msgstr "Copy URL"
 
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "DwFieO"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -1945,7 +1945,6 @@ msgstr "Copiado"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr "Compartir"
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -1954,7 +1954,6 @@ msgstr "Copié"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2657,6 +2656,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2680,6 +2689,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -1945,7 +1945,6 @@ msgstr "Disalin"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -1945,7 +1945,6 @@ msgstr "Copiato"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -1945,7 +1945,6 @@ msgstr "コピー済み"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -1945,7 +1945,6 @@ msgstr "복사 완료"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr "공유"
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -1945,7 +1945,6 @@ msgstr "Disalin"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -1945,7 +1945,6 @@ msgstr "Skopiowano"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -1945,7 +1945,6 @@ msgstr "Copiado"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -1945,7 +1945,6 @@ msgstr "Скопировано"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -1945,7 +1945,6 @@ msgstr "คัดลอกแล้ว"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -1945,7 +1945,6 @@ msgstr "Kopyalandı"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -1954,7 +1954,6 @@ msgstr "Đã Sao Chép"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr "Chia sẻ"
@@ -2657,6 +2656,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2680,6 +2689,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -1945,7 +1945,6 @@ msgstr "已复制"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -1945,7 +1945,6 @@ msgstr "已複製"
 
 #: src/components/olympian-arena/duel-report-view.tsx
 #: src/components/report/report-view.tsx
-#: src/components/territory-planner/territory-planner.tsx
 msgctxt "OKhRC6"
 msgid "Share"
 msgstr ""
@@ -2648,6 +2647,16 @@ msgctxt "NyxynW"
 msgid "Locate {building} {number} on map"
 msgstr ""
 
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "YHmxQm"
+msgid "The plan could not be exported. Please try again."
+msgstr ""
+
+#: src/components/territory-planner/territory-export-button.tsx
+msgctxt "SVwJTM"
+msgid "Export"
+msgstr ""
+
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "JM6RlW"
 msgid "The map data could not be loaded."
@@ -2671,6 +2680,11 @@ msgstr ""
 #: src/components/territory-planner/territory-planner.tsx
 msgctxt "zuqMfZ"
 msgid "Map"
+msgstr ""
+
+#: src/components/territory-planner/territory-planner.tsx
+msgctxt "P8QaSQ"
+msgid "Copy URL"
 msgstr ""
 
 #: src/components/territory-planner/territory-planner.tsx

--- a/packages/site/src/lib/territory/export.ts
+++ b/packages/site/src/lib/territory/export.ts
@@ -1,0 +1,48 @@
+import type { Cell, SheetData } from "write-excel-file/browser";
+import { realToGamePoint } from "@/lib/territory/presentation";
+import type { BuildingKind, PlannerDocument } from "@/lib/territory/types";
+
+export function createTerritorySpreadsheet(
+  document: PlannerDocument,
+  labels: Record<BuildingKind, string>
+) {
+  const allianceColumns = document.alliances.map((alliance) => {
+    const buildings = document.buildings.filter((building) => building.allianceId === alliance.id);
+    const column: Cell[] = [{ type: String, value: alliance.name, fontWeight: "bold" }, null];
+
+    for (const kind of ["mainFortress", "subFortress", "horse", "flag"] as const) {
+      const placed = buildings.filter((building) => building.kind === kind);
+      if (kind === "flag" && placed.length > 0 && column.length > 2) column.push(null);
+      placed.forEach((building, index) => {
+        const label =
+          kind === "flag" || kind === "subFortress" ? `${labels[kind]} ${index + 1}` : labels[kind];
+        const { x, y } = realToGamePoint(building);
+        column.push({ type: String, value: `${label}: (${x}, ${y})` });
+      });
+    }
+
+    return column;
+  });
+
+  const data: SheetData = Array.from(
+    { length: Math.max(0, ...allianceColumns.map((column) => column.length)) },
+    (_, row) =>
+      allianceColumns.flatMap((column, index) =>
+        index === 0 ? [column[row] ?? null] : [null, column[row] ?? null]
+      )
+  );
+  const columns = document.alliances.flatMap((_, index) =>
+    index === 0 ? [{ width: 40 }] : [{ width: 4 }, { width: 40 }]
+  );
+
+  return { data, columns };
+}
+
+export async function exportTerritoryPlan(
+  document: PlannerDocument,
+  labels: Record<BuildingKind, string>
+) {
+  const { default: writeExcelFile } = await import("write-excel-file/browser");
+  const { data, columns } = createTerritorySpreadsheet(document, labels);
+  await writeExcelFile(data, { columns }).toFile(`territory-plan-${document.mapSlug}.xlsx`);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       recharts:
         specifier: ^3.10.1
         version: 3.10.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react-is@19.2.7)(react@19.2.8)(redux@5.0.1)
+      write-excel-file:
+        specifier: ^4.1.1
+        version: 4.1.1
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -2538,6 +2541,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -3814,6 +3820,10 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  write-excel-file@4.1.1:
+    resolution: {integrity: sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==}
+    engines: {node: '>=18'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -5872,6 +5882,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.7
 
+  fflate@0.8.3: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -7524,6 +7536,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  write-excel-file@4.1.1:
+    dependencies:
+      fflate: 0.8.3
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
Adds an XLSX download to the territory planner so alliances can share their planned building locations in a spreadsheet. Each alliance gets a column separated by a blank column, with placed fortresses, Horse, and numbered flags in game coordinates. Unplaced structures are omitted.

Adds an Export button with a Heroicons download icon beside Copy URL (previously Share), using default neutral styling for both buttons. The spreadsheet library loads on demand, and export failures show a retry message.

Validation:
- Verified browser downloads for empty and multi-alliance plans, including spreadsheet cell contents, spacing, numbering, omitted structures, and coordinate conversion.
- Verified Copy URL and toolbar behavior in the running app; Next.js reported no compilation or runtime errors.
- Type checking, Biome, and frozen-lockfile installation passed.
- React Doctor comparison found no new warnings; existing planner complexity warnings remain.
