### PR TITLE
chore(common): inherit workspace lints and fix clippy findings

### DIFF
--- a/crates/common/rokbattles-drastc/Cargo.toml
+++ b/crates/common/rokbattles-drastc/Cargo.toml
@@ -9,3 +9,6 @@ serde = { workspace = true, features = ["derive"] }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-drastc/src/confidence.rs
+++ b/crates/common/rokbattles-drastc/src/confidence.rs
@@ -144,7 +144,7 @@ mod tests {
     fn confidence_is_zero_without_identified_governors() {
         let confidence = DrastcConfidence::from_governor_distribution(100, 0, 10_000.0);
 
-        assert_eq!(confidence.score, 0.0);
+        assert_eq!(confidence.score.to_bits(), 0.0_f64.to_bits());
     }
 
     #[test]

--- a/crates/common/rokbattles-drastc/src/lib.rs
+++ b/crates/common/rokbattles-drastc/src/lib.rs
@@ -368,8 +368,8 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.rage.score, 0.0);
-        assert_eq!(score.breakdown.assist.score, 0.0);
+        assert_eq!(score.breakdown.rage.score.to_bits(), 0.0_f64.to_bits());
+        assert_eq!(score.breakdown.assist.score.to_bits(), 0.0_f64.to_bits());
     }
 
     #[test]
@@ -422,8 +422,8 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.rage.value, 8.5);
-        assert_eq!(score.breakdown.assist.value, 0.73125);
+        assert!((score.breakdown.rage.value - 8.5).abs() < 1e-12);
+        assert!((score.breakdown.assist.value - 0.73125).abs() < 1e-12);
     }
 
     #[test]
@@ -436,7 +436,7 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.rage.value, 6.0);
+        assert!((score.breakdown.rage.value - 6.0).abs() < 1e-12);
     }
 
     #[test]
@@ -546,10 +546,10 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.damage.p10, reference_ranges.damage.p10);
-        assert_eq!(score.breakdown.damage.p90, reference_ranges.damage.p90);
-        assert_eq!(score.breakdown.trade.p10, reference_ranges.trade.p10);
-        assert_eq!(score.breakdown.trade.p90, reference_ranges.trade.p90);
+        assert_eq!(score.breakdown.damage.p10.to_bits(), reference_ranges.damage.p10.to_bits());
+        assert_eq!(score.breakdown.damage.p90.to_bits(), reference_ranges.damage.p90.to_bits());
+        assert_eq!(score.breakdown.trade.p10.to_bits(), reference_ranges.trade.p10.to_bits());
+        assert_eq!(score.breakdown.trade.p90.to_bits(), reference_ranges.trade.p90.to_bits());
         assert!(score.breakdown.damage.score > 5.0);
     }
 
@@ -560,7 +560,7 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.consistency.value, 0.5);
+        assert!((score.breakdown.consistency.value - 0.5).abs() < 1e-12);
     }
 
     #[test]
@@ -570,7 +570,7 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.trade.score, 5.0);
+        assert!((score.breakdown.trade.score - 5.0).abs() < 1e-12);
     }
 
     #[test]
@@ -580,7 +580,7 @@ mod tests {
 
         let score = model.evaluate().expect("score");
 
-        assert_eq!(score.breakdown.trade.score, 10.0);
+        assert!((score.breakdown.trade.score - 10.0).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/common/rokbattles-drastc/src/reference.rs
+++ b/crates/common/rokbattles-drastc/src/reference.rs
@@ -104,6 +104,7 @@ mod tests {
         assert_eq!(percentile(&values, 0.90), 4.6);
     }
 
+    #[expect(clippy::cast_sign_loss, reason = "Clamped percentile ranks are nonnegative.")]
     fn percentile(sorted_values: &[f64], percentile: f64) -> f64 {
         match sorted_values {
             [] => 0.0,

--- a/crates/common/rokbattles-drastc/src/reference.rs
+++ b/crates/common/rokbattles-drastc/src/reference.rs
@@ -100,8 +100,8 @@ mod tests {
     fn percentile_interpolates_sorted_values() {
         let values = [1.0, 2.0, 3.0, 4.0, 5.0];
 
-        assert_eq!(percentile(&values, 0.10), 1.4);
-        assert_eq!(percentile(&values, 0.90), 4.6);
+        assert!((percentile(&values, 0.10) - 1.4).abs() < 1e-12);
+        assert!((percentile(&values, 0.90) - 4.6).abs() < 1e-12);
     }
 
     #[expect(clippy::cast_sign_loss, reason = "Clamped percentile ranks are nonnegative.")]

--- a/crates/common/rokbattles-mail-cli/Cargo.toml
+++ b/crates/common/rokbattles-mail-cli/Cargo.toml
@@ -18,3 +18,6 @@ tempfile = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-decoder/Cargo.toml
+++ b/crates/common/rokbattles-mail-decoder/Cargo.toml
@@ -11,3 +11,6 @@ thiserror = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-decoder/src/decoder.rs
+++ b/crates/common/rokbattles-mail-decoder/src/decoder.rs
@@ -30,17 +30,18 @@ use crate::{
 ///
 /// See [`decode`] for an example of reading a complete file.
 pub fn validate_file(buffer: &[u8]) -> Result<(), DecodeError> {
-    if buffer.len() < FILE_HEADER_LEN {
+    let Some((&marker, checksum)) = buffer.get(..FILE_HEADER_LEN).and_then(<[u8]>::split_first)
+    else {
         return Err(DecodeError::HeaderTooShort {
             required: FILE_HEADER_LEN,
             actual: buffer.len(),
         });
-    }
-    if buffer[0] != FILE_MARKER {
-        return Err(DecodeError::InvalidFileMarker { expected: FILE_MARKER, found: buffer[0] });
+    };
+    if marker != FILE_MARKER {
+        return Err(DecodeError::InvalidFileMarker { expected: FILE_MARKER, found: marker });
     }
 
-    let stored = u64::from_le_bytes(bytes8(&buffer[1..FILE_HEADER_LEN])?);
+    let stored = u64::from_le_bytes(bytes8(checksum)?);
     let computed = file_checksum(buffer);
     if stored != computed {
         return Err(DecodeError::ChecksumMismatch { stored, computed });
@@ -73,7 +74,10 @@ pub fn validate_file(buffer: &[u8]) -> Result<(), DecodeError> {
 /// ```
 pub fn decode(buffer: &[u8]) -> Result<Value, DecodeError> {
     validate_file(buffer)?;
-    decode_value_at(&buffer[FILE_HEADER_LEN..], FILE_HEADER_LEN)
+    let payload = buffer
+        .get(FILE_HEADER_LEN..)
+        .ok_or(DecodeError::HeaderTooShort { required: FILE_HEADER_LEN, actual: buffer.len() })?;
+    decode_value_at(payload, FILE_HEADER_LEN)
 }
 
 /// Decodes exactly one headerless `Persistent.Mail` value into a JSON value.
@@ -222,7 +226,7 @@ impl<'a> Decoder<'a> {
         let bytes = self.read_exact(length)?;
         std::str::from_utf8(bytes)
             .map(str::to_owned)
-            .map_err(|_| DecodeError::InvalidUtf8 { offset: start })
+            .map_err(|_utf8_error| DecodeError::InvalidUtf8 { offset: start })
     }
 
     fn read_u32_le(&mut self) -> Result<u32, DecodeError> {
@@ -242,13 +246,12 @@ impl<'a> Decoder<'a> {
 
     fn read_exact(&mut self, len: usize) -> Result<&'a [u8], DecodeError> {
         let end = self.pos.saturating_add(len);
-        if end > self.buffer.len() {
-            return Err(DecodeError::UnexpectedEof { needed: len, remaining: self.remaining() });
-        }
-
-        let start = self.pos;
+        let bytes = self
+            .buffer
+            .get(self.pos..end)
+            .ok_or(DecodeError::UnexpectedEof { needed: len, remaining: self.remaining() })?;
         self.pos = end;
-        Ok(&self.buffer[start..end])
+        Ok(bytes)
     }
 
     fn peek_u8(&self) -> Option<u8> {
@@ -258,45 +261,44 @@ impl<'a> Decoder<'a> {
 
 fn bytes4(bytes: &[u8]) -> Result<[u8; 4], DecodeError> {
     <[u8; 4]>::try_from(bytes)
-        .map_err(|_| DecodeError::UnexpectedEof { needed: 4, remaining: bytes.len() })
+        .map_err(|_length_error| DecodeError::UnexpectedEof { needed: 4, remaining: bytes.len() })
 }
 
 fn bytes8(bytes: &[u8]) -> Result<[u8; 8], DecodeError> {
     <[u8; 8]>::try_from(bytes)
-        .map_err(|_| DecodeError::UnexpectedEof { needed: 8, remaining: bytes.len() })
+        .map_err(|_length_error| DecodeError::UnexpectedEof { needed: 8, remaining: bytes.len() })
 }
 
 fn number_value(value: f64) -> Result<Value, DecodeError> {
     if !value.is_finite() {
         return Err(DecodeError::NonFiniteNumber { value });
     }
-    Ok(Value::Number(normalize_number(value)))
+    normalize_number(value).map(Value::Number)
 }
 
 // Callers reject non-finite values before normalization. Integer numbers also let
 // table classification recognize array indices through `Number::as_u64`.
-fn normalize_number(value: f64) -> Number {
+fn normalize_number(value: f64) -> Result<Number, DecodeError> {
     // Collapse both signs of zero to the same JSON number and table key.
     if value == 0.0 {
-        return Number::from(0);
+        return Ok(Number::from(0));
     }
 
     if value.fract() == 0.0 {
         if value.is_sign_positive() {
             if let Some(int) = to_u64_exact(value) {
-                return Number::from(int);
+                return Ok(Number::from(int));
             }
         } else if let Some(int) = to_i64_exact(value) {
-            return Number::from(int);
+            return Ok(Number::from(int));
         }
     }
 
-    let Some(number) = Number::from_f64(value) else {
-        unreachable!("finite f64 is a JSON number");
-    };
-    number
+    Number::from_f64(value).ok_or(DecodeError::NonFiniteNumber { value })
 }
 
+#[expect(clippy::cast_sign_loss, reason = "Negative values are rejected before casting.")]
+#[expect(clippy::float_cmp, reason = "Integer normalization requires an exact round trip.")]
 fn to_u64_exact(value: f64) -> Option<u64> {
     if value < 0.0 || value > u64::MAX as f64 {
         return None;
@@ -306,6 +308,7 @@ fn to_u64_exact(value: f64) -> Option<u64> {
     ((int as f64) == value).then_some(int)
 }
 
+#[expect(clippy::float_cmp, reason = "Integer normalization requires an exact round trip.")]
 fn to_i64_exact(value: f64) -> Option<i64> {
     if value < i64::MIN as f64 || value > i64::MAX as f64 {
         return None;

--- a/crates/common/rokbattles-mail-decoder/src/value.rs
+++ b/crates/common/rokbattles-mail-decoder/src/value.rs
@@ -55,6 +55,10 @@ fn sequential(items: Vec<Value>) -> ClassifiedTable {
 fn string_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, DecodeError> {
     let mut map = Map::with_capacity(items.len() / 2);
     for (key, value) in owned_pairs(items) {
+        #[expect(
+            clippy::unreachable,
+            reason = "table key types were classified before conversion."
+        )]
         let Value::String(key) = key else {
             unreachable!("table key types were classified before conversion");
         };
@@ -83,7 +87,9 @@ fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, 
             let Some(key) = pair[0].as_u64().and_then(|key| usize::try_from(key).ok()) else {
                 return false;
             };
-            key > 0 && key <= pair_count && !std::mem::replace(&mut keys[key - 1], true)
+            key.checked_sub(1)
+                .and_then(|index| keys.get_mut(index))
+                .is_some_and(|seen| !std::mem::replace(seen, true))
         })
     };
 
@@ -91,6 +97,10 @@ fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, 
         // Numeric ordering maps the file's one-based keys to zero-based array positions.
         let mut values = BTreeMap::new();
         for (key, value) in owned_pairs(items) {
+            #[expect(
+                clippy::unreachable,
+                reason = "sequential numeric keys were validated before conversion."
+            )]
             let Some(key) = key.as_u64().and_then(|key| usize::try_from(key).ok()) else {
                 unreachable!("sequential numeric keys were validated before conversion");
             };
@@ -101,6 +111,10 @@ fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, 
 
     let mut map = Map::with_capacity(pair_count);
     for (key, value) in owned_pairs(items) {
+        #[expect(
+            clippy::unreachable,
+            reason = "table key types were classified before conversion."
+        )]
         let Value::Number(key) = key else {
             unreachable!("table key types were classified before conversion");
         };
@@ -127,6 +141,7 @@ fn owned_pairs(items: Vec<Value>) -> impl Iterator<Item = (Value, Value)> {
     let mut items = items.into_iter();
     std::iter::from_fn(move || {
         let key = items.next()?;
+        #[expect(clippy::unreachable, reason = "pair iterator requires an even item count.")]
         let Some(value) = items.next() else {
             unreachable!("pair iterator requires an even item count");
         };

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-battle-info/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-battle-info/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-battle-results/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-battle-results/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-individual-results/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-individual-results/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-barcanyonkillboss/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-barcanyonkillboss/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-battle/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-battle/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-battle/src/opponents.rs
+++ b/crates/common/rokbattles-mail-processor-battle/src/opponents.rs
@@ -51,10 +51,11 @@ impl Extractor for OpponentsExtractor {
             }
 
             for handle in handles {
-                let result = handle.join().map_err(|_| ExtractError::InvalidFieldType {
-                    field: "Attacks",
-                    expected: "non-panicking extraction",
-                })?;
+                let result =
+                    handle.join().map_err(|_panic_payload| ExtractError::InvalidFieldType {
+                        field: "Attacks",
+                        expected: "non-panicking extraction",
+                    })?;
                 results.push(result?);
             }
             Ok::<(), ExtractError>(())
@@ -82,18 +83,8 @@ fn require_attacks(content: &Map<String, Value>) -> Result<&Map<String, Value>, 
 /// Suffixes are allowed and retained separately; a key without leading digits
 /// or with an overflowing prefix fails extraction.
 fn parse_attack_id(attack_id: &str) -> Result<u64, ExtractError> {
-    let end = attack_id
-        .char_indices()
-        .find(|&(_, ch)| !ch.is_ascii_digit())
-        .map(|(idx, _)| idx)
-        .unwrap_or_else(|| attack_id.len());
-    if end == 0 {
-        return Err(ExtractError::InvalidFieldType {
-            field: "Attacks",
-            expected: "numeric object key",
-        });
-    }
-    attack_id[..end].parse::<u64>().map_err(|_| ExtractError::InvalidFieldType {
+    let prefix = attack_id.split(|ch: char| !ch.is_ascii_digit()).next().unwrap_or_default();
+    prefix.parse::<u64>().map_err(|_parse_error| ExtractError::InvalidFieldType {
         field: "Attacks",
         expected: "numeric object key",
     })
@@ -528,6 +519,20 @@ mod tests {
         assert_eq!(parse_attack_id("79272307").unwrap(), 79272307);
         assert_eq!(parse_attack_id("79272307_1").unwrap(), 79272307);
         assert_eq!(parse_attack_id("79272307_extra").unwrap(), 79272307);
+        assert_eq!(parse_attack_id("79272307敵").unwrap(), 79272307);
+    }
+
+    #[test]
+    fn parse_attack_id_rejects_missing_or_overflowing_prefixes() {
+        for key in ["", "敵79272307", "-1", "18446744073709551616"] {
+            assert_eq!(
+                parse_attack_id(key),
+                Err(ExtractError::InvalidFieldType {
+                    field: "Attacks",
+                    expected: "numeric object key",
+                }),
+            );
+        }
     }
 
     #[test]

--- a/crates/common/rokbattles-mail-processor-battle/src/participants.rs
+++ b/crates/common/rokbattles-mail-processor-battle/src/participants.rs
@@ -61,9 +61,10 @@ pub(crate) fn extract_participants(
 }
 
 fn parse_participant_id(participant_id: &str, field: &'static str) -> Result<i64, ExtractError> {
-    participant_id
-        .parse::<i64>()
-        .map_err(|_| ExtractError::InvalidFieldType { field, expected: "numeric object key" })
+    participant_id.parse::<i64>().map_err(|_parse_error| ExtractError::InvalidFieldType {
+        field,
+        expected: "numeric object key",
+    })
 }
 
 #[cfg(test)]

--- a/crates/common/rokbattles-mail-processor-battle/src/player.rs
+++ b/crates/common/rokbattles-mail-processor-battle/src/player.rs
@@ -154,7 +154,9 @@ fn extract_app_identity(
 }
 
 fn parse_app_uid_number(value: &str, expected: &'static str) -> Result<u64, ExtractError> {
-    value.parse::<u64>().map_err(|_| ExtractError::InvalidFieldType { field: "AppUid", expected })
+    value
+        .parse::<u64>()
+        .map_err(|_parse_error| ExtractError::InvalidFieldType { field: "AppUid", expected })
 }
 
 /// Reads `AppUid` as a string when it is present.
@@ -341,7 +343,7 @@ fn optional_armaments_field(
 
     let mut entries = Vec::with_capacity(map.len());
     for (key, value) in map {
-        let id = key.parse::<u64>().map_err(|_| ExtractError::InvalidFieldType {
+        let id = key.parse::<u64>().map_err(|_parse_error| ExtractError::InvalidFieldType {
             field,
             expected: "numeric object key",
         })?;

--- a/crates/common/rokbattles-mail-processor-duelbattle2/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-duelbattle2/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-eventmemberlootreport/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-eventmemberlootreport/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-eventmemberlootreport/src/boss.rs
+++ b/crates/common/rokbattles-mail-processor-eventmemberlootreport/src/boss.rs
@@ -242,6 +242,6 @@ mod tests {
     #[test]
     fn rejects_unknown_boss() {
         let input = json!({"body": {"content": {"subTitle": "Unknown defeated"}}});
-        assert!(BossExtractor::new().extract(&input).is_err());
+        BossExtractor::new().extract(&input).expect_err("unknown boss");
     }
 }

--- a/crates/common/rokbattles-mail-processor-rss/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-rss/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-system-barbarianfort/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-system-barbarianfort/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-processor-system-barbarianfort/src/body.rs
+++ b/crates/common/rokbattles-mail-processor-system-barbarianfort/src/body.rs
@@ -114,23 +114,20 @@ fn match_template(
     for (index, token) in tokens.iter().enumerate() {
         match token {
             TemplateToken::Literal(literal) => {
-                if !remaining.starts_with(literal) {
-                    return None;
-                }
-                remaining = &remaining[literal.len()..];
+                remaining = remaining.strip_prefix(*literal)?;
             }
             TemplateToken::Placeholder(name) => {
                 // Capture up to the next literal so localized placeholder order
                 // can vary without changing the field mapping below.
-                let next_literal = tokens[index + 1..].iter().find_map(|token| match token {
+                let next_literal = tokens.iter().skip(index + 1).find_map(|token| match token {
                     TemplateToken::Literal(literal) if !literal.is_empty() => Some(*literal),
                     TemplateToken::Literal(_) | TemplateToken::Placeholder(_) => None,
                 });
                 let capture = match next_literal {
                     Some(literal) => {
                         let end = remaining.find(literal)?;
-                        let capture = &remaining[..end];
-                        remaining = &remaining[end..];
+                        let (capture, rest) = remaining.split_at_checked(end)?;
+                        remaining = rest;
                         capture
                     }
                     None => {
@@ -166,20 +163,16 @@ fn tokenize_template(template: &str) -> Vec<TemplateToken<'_>> {
     let mut tokens = Vec::new();
     let mut remaining = template;
 
-    while let Some(start) = remaining.find('{') {
-        let literal = &remaining[..start];
+    while let Some((literal, after_start)) = remaining.split_once('{') {
+        let Some((name, rest)) = after_start.split_once('}') else {
+            // An unmatched opening brace is literal text.
+            break;
+        };
         if !literal.is_empty() {
             tokens.push(TemplateToken::Literal(literal));
         }
-
-        let after_start = &remaining[start + 1..];
-        let Some(end) = after_start.find('}') else {
-            tokens.push(TemplateToken::Literal(&remaining[start..]));
-            return tokens;
-        };
-
-        tokens.push(TemplateToken::Placeholder(&after_start[..end]));
-        remaining = &after_start[end + 1..];
+        tokens.push(TemplateToken::Placeholder(name));
+        remaining = rest;
     }
 
     if !remaining.is_empty() {
@@ -215,9 +208,9 @@ fn parse_level(value: &str) -> Option<u64> {
     }
 
     let start = trimmed.find(|character: char| character.is_ascii_digit())?;
-    let digits = &trimmed[start..];
+    let digits = trimmed.get(start..)?;
     let end = digits.find(|character: char| !character.is_ascii_digit()).unwrap_or(digits.len());
-    digits[..end].parse::<u64>().ok()
+    digits.get(..end)?.parse::<u64>().ok()
 }
 
 #[cfg(test)]
@@ -228,6 +221,23 @@ mod tests {
     use serde_json::{Value, json};
 
     use super::*;
+
+    #[test]
+    fn template_matching_handles_unicode_and_unmatched_braces() {
+        let params =
+            match_template("城{p2}級：{p3}％、階{p4}。未完{", "城12級：25％、階3。未完{", 0, "")
+                .expect("localized template with a literal opening brace");
+        assert_eq!(
+            params,
+            ContentParams {
+                percentage: Number::from_f64(25.0).expect("finite number"),
+                tier: 3,
+                level: 12,
+            }
+        );
+        assert_eq!(parse_level("城12級"), Some(12));
+        assert_eq!(parse_level("城級"), None);
+    }
 
     #[test]
     fn body_extractor_reads_fields() {

--- a/crates/common/rokbattles-mail-processor-system-kahartreasure/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-system-kahartreasure/Cargo.toml
@@ -10,3 +10,6 @@ serde_json = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-registry/Cargo.toml
+++ b/crates/common/rokbattles-mail-registry/Cargo.toml
@@ -36,3 +36,6 @@ rokbattles-mail-processor-system-kahartreasure = { path = "../rokbattles-mail-pr
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-sdk/Cargo.toml
+++ b/crates/common/rokbattles-mail-sdk/Cargo.toml
@@ -11,3 +11,6 @@ thiserror = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-mail-sdk/src/extract.rs
+++ b/crates/common/rokbattles-mail-sdk/src/extract.rs
@@ -478,7 +478,7 @@ mod tests {
         let object = value.as_object().expect("object");
 
         assert_eq!(require_i64_field(object, "negative"), Ok(-7));
-        assert!(require_i64_field(object, "positive").is_err());
+        require_i64_field(object, "positive").expect_err("out-of-range unsigned value");
     }
 
     #[test]
@@ -488,7 +488,7 @@ mod tests {
 
         assert_eq!(require_u64_or_string_field(object, "number"), Ok(7));
         assert_eq!(require_u64_or_string_field(object, "string"), Ok(8));
-        assert!(require_u64_or_string_field(object, "invalid").is_err());
+        require_u64_or_string_field(object, "invalid").expect_err("non-integer string");
     }
 
     #[test]

--- a/crates/common/rokbattles-mail-sdk/src/processor.rs
+++ b/crates/common/rokbattles-mail-sdk/src/processor.rs
@@ -86,8 +86,9 @@ impl Processor {
 
             // Preserve registration order for errors even when workers finish out of order.
             for (section, handle) in handles {
-                let result =
-                    handle.join().map_err(|_| ProcessError::ExtractorPanicked { section })?;
+                let result = handle
+                    .join()
+                    .map_err(|_panic_payload| ProcessError::ExtractorPanicked { section })?;
                 results.push((section, result));
             }
 
@@ -186,6 +187,7 @@ mod tests {
             "panic"
         }
 
+        #[expect(clippy::panic_in_result_fn, reason = "Exercises extractor panic handling.")]
         fn extract(&self, _input: &Value) -> Result<Section, ExtractError> {
             panic!("boom");
         }

--- a/crates/common/rokbattles-mail-sdk/src/types.rs
+++ b/crates/common/rokbattles-mail-sdk/src/types.rs
@@ -52,6 +52,10 @@ impl Section {
     /// # Panics
     ///
     /// Panics if the section is backed by an array.
+    #[expect(
+        clippy::panic,
+        reason = "Preserves the documented panic for inserting into an array section."
+    )]
     pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
         match &mut self.data {
             SectionData::Object(fields) => fields.insert(key.into(), value),


### PR DESCRIPTION
Fifteen common crates did not inherit the workspace Clippy policy. Add `[lints] workspace = true` to their manifests so all 19 crates under `crates/common` use the shared lints.

Resolve the resulting findings with checked slice and string operations, explicit error mappings, and clearer error assertions. Document narrowly scoped lint expectations for intentional panics, validated invariants, and exact numeric conversions. Add regression coverage for Unicode parsing and invalid attack ID prefixes.

Validation across all 19 common crates:

- `cargo fmt` with `--check` passes.
- `cargo clippy --all-targets --all-features --locked -- -D warnings` passes.
- `cargo test --all-features --locked`: 422 passed, 0 failed, 0 ignored.

Each Cargo command selected the common crates with explicit `-p` arguments.
