### PR TITLE
fix(territory-planner): repaint canvas after context restoration

### DIFF
--- a/packages/site/src/components/territory-planner/planner-canvas.tsx
+++ b/packages/site/src/components/territory-planner/planner-canvas.tsx
@@ -855,6 +855,14 @@ export function PlannerCanvas({
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+    // Restoring a lost drawing surface clears its pixels without changing its size,
+    // so neither ResizeObserver nor a completed map load will necessarily repaint it.
+    const onContextRestored = () => {
+      boundaryPatternRef.current = null;
+      provincePatternRef.current = null;
+      requestDraw();
+    };
+    canvas.addEventListener("contextrestored", onContextRestored);
     const observer = new ResizeObserver(([entry]) => {
       const width = Math.max(1, Math.floor(entry.contentRect.width));
       const height = Math.max(1, Math.floor(entry.contentRect.height));
@@ -887,6 +895,7 @@ export function PlannerCanvas({
     canvas.addEventListener("wheel", onWheel, { passive: false });
     return () => {
       observer.disconnect();
+      canvas.removeEventListener("contextrestored", onContextRestored);
       canvas.removeEventListener("wheel", onWheel);
     };
   }, [


### PR DESCRIPTION
When the browser restores a lost canvas drawing surface, its pixels are cleared but the planner may have already finished loading and its size may be unchanged. The map can therefore stay blank until another interaction requests a draw.

Handle `contextrestored` by clearing cached boundary patterns and requesting a repaint, and remove the listener during effect cleanup. This PR changes only the planner canvas component.

Validation: simulated canvas restoration failed without the fix and passed with it in Firefox and Chromium. Repeated initial loads and map switches passed in both browsers. Typechecking, Biome, and the React Doctor regression check passed.

The spontaneous failure reported by users was not reproduced; this fixes a confirmed recovery gap but does not establish what triggered the original incidents.
