### PR TITLE
perf(container): accelerate decoding with AVX2 and NEON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4592,13 +4592,19 @@ name = "rokbattles-container"
 version = "1.6.1"
 dependencies = [
  "crc32fast",
+ "criterion",
  "js-sys",
+ "rokbattles-container-simd",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
  "thiserror 2.0.20",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rokbattles-container-simd"
+version = "1.6.1"
 
 [[package]]
 name = "rokbattles-desktop"

--- a/crates/common/rokbattles-container-simd/Cargo.toml
+++ b/crates/common/rokbattles-container-simd/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rokbattles-container-simd"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-container-simd/src/avx2.rs
+++ b/crates/common/rokbattles-container-simd/src/avx2.rs
@@ -1,0 +1,86 @@
+use std::arch::x86_64::*;
+
+use crate::schedule::jump;
+
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Fixed batches bound lanes to 0..8 and schedule rows to 0..63"
+)]
+#[target_feature(enable = "avx2")]
+pub(super) unsafe fn decode_blocks(payload: &mut [u8], mut state: u32) -> (usize, u32) {
+    let mut processed = 0;
+    for batch in payload.as_chunks_mut::<256>().0 {
+        let mut seeds = [0_u32; 8];
+        for seed in &mut seeds {
+            *seed = state;
+            state = jump(state);
+        }
+        let mut schedule = [[0_u32; 8]; 63];
+        // SAFETY: `seeds` contains eight initialized u32s; the load permits an
+        // unaligned address. AVX2 is required by this function.
+        let mut states = unsafe { _mm256_loadu_si256(seeds.as_ptr().cast()) };
+        for row in &mut schedule {
+            states = _mm256_xor_si256(states, _mm256_slli_epi32::<13>(states));
+            states = _mm256_xor_si256(states, _mm256_srli_epi32::<17>(states));
+            states = _mm256_xor_si256(states, _mm256_slli_epi32::<5>(states));
+            // SAFETY: The row holds eight initialized u32 lanes and permits an unaligned store.
+            unsafe { _mm256_storeu_si256(row.as_mut_ptr().cast(), states) };
+        }
+        for (lane, block) in batch.as_chunks_mut::<32>().0.iter_mut().enumerate() {
+            let keys = std::array::from_fn(|index| schedule[index][lane]);
+            // Rows 32..63 hold choices for indices 31..1. Replay them in reverse.
+            for index in 1..32 {
+                block.swap(index, schedule[63 - index][lane] as usize % (index + 1));
+            }
+            // SAFETY: AVX2 is enabled; block and keys are complete initialized arrays.
+            unsafe { transform(block, &keys) };
+        }
+        processed += batch.len();
+    }
+    (processed, state)
+}
+
+#[target_feature(enable = "avx2")]
+unsafe fn transform(block: &mut [u8; 32], keys: &[u32; 32]) {
+    let mut add = [0_u8; 32];
+    let mut xor = [0_u8; 32];
+    let mut rotation = [0_u8; 32];
+    for (((add, xor), rotation), key) in add.iter_mut().zip(&mut xor).zip(&mut rotation).zip(keys) {
+        let bytes = key.to_le_bytes();
+        *add = bytes[0];
+        *xor = bytes[1];
+        *rotation = bytes[2];
+    }
+    let mut previous = [0_u8; 32];
+    previous[1..].copy_from_slice(&block[..31]);
+    // SAFETY: Each input contains exactly 32 initialized bytes. AVX2 is enabled,
+    // and the intrinsic permits unaligned loads.
+    let encoded = unsafe { _mm256_loadu_si256(block.as_ptr().cast()) };
+    // SAFETY: The complete 32-byte XOR array is initialized.
+    let xors = unsafe { _mm256_loadu_si256(xor.as_ptr().cast()) };
+    // SAFETY: The complete 32-byte feedback array is initialized.
+    let feedback = unsafe { _mm256_loadu_si256(previous.as_ptr().cast()) };
+    // SAFETY: The complete 32-byte rotation array is initialized.
+    let rotations = unsafe { _mm256_loadu_si256(rotation.as_ptr().cast()) };
+    // SAFETY: The complete 32-byte addition array is initialized.
+    let additions = unsafe { _mm256_loadu_si256(add.as_ptr().cast()) };
+    let mut value = _mm256_xor_si256(_mm256_xor_si256(encoded, xors), feedback);
+    // AVX2 has no per-byte variable rotate. Select rotations by 1, 2, and
+    // 4 bits; masks remove the neighboring-byte bits from 16-bit shifts.
+    macro_rules! rotate {
+        ($right:literal, $left:literal, $mask:literal) => {{
+            let low = _mm256_and_si256(_mm256_srli_epi16::<$right>(value), _mm256_set1_epi8($mask));
+            let high =
+                _mm256_and_si256(_mm256_slli_epi16::<$left>(value), _mm256_set1_epi8(!$mask));
+            let bit = _mm256_set1_epi8($right);
+            let select = _mm256_cmpeq_epi8(_mm256_and_si256(rotations, bit), bit);
+            value = _mm256_blendv_epi8(value, _mm256_or_si256(low, high), select);
+        }};
+    }
+    rotate!(1, 7, 127);
+    rotate!(2, 6, 63);
+    rotate!(4, 4, 15);
+    value = _mm256_sub_epi8(value, additions);
+    // SAFETY: The destination has writable storage for all 32 bytes.
+    unsafe { _mm256_storeu_si256(block.as_mut_ptr().cast(), value) };
+}

--- a/crates/common/rokbattles-container-simd/src/lib.rs
+++ b/crates/common/rokbattles-container-simd/src/lib.rs
@@ -1,0 +1,117 @@
+//! SIMD decoding for the layered mask in ROKB v1 files.
+//!
+//! AVX2 processes eight 32-byte blocks per batch; NEON processes four.
+//! The caller decodes the remaining bytes with the scalar implementation, then
+//! removes the XOR mask. Header and checksum validation belong to the container reader.
+
+#![deny(missing_docs)]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+#[cfg(target_arch = "x86_64")]
+mod avx2;
+#[cfg(target_arch = "aarch64")]
+mod neon;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+mod schedule;
+
+/// Decodes a prefix of complete layered-mask blocks and advances its PRNG state.
+///
+/// Returns `(bytes_processed, next_state)` and modifies only that prefix.
+/// Continue scalar decoding on the remainder with `next_state`. The processed
+/// byte count is always a multiple of 32.
+///
+/// `state` is the current xorshift32 state. At the start of a payload, pass its
+/// seed, replacing zero with `0x6d2b79f5`. This function does not normalize it.
+///
+/// Returns `(0, state)` when no supported backend is available or fewer than
+/// one batch remains: 256 bytes for AVX2, 128 bytes for NEON.
+/// CPU detection precedes every call into target-specific code.
+pub fn decode_blocks(payload: &mut [u8], state: u32) -> (usize, u32) {
+    if payload.len() < 128 {
+        return (0, state);
+    }
+    #[cfg(target_arch = "x86_64")]
+    if payload.len() >= 256 && std::arch::is_x86_feature_detected!("avx2") {
+        // SAFETY: AVX2 was detected. The backend bounds all loads and stores to
+        // initialized fixed-size arrays and complete 256-byte input batches.
+        return unsafe { avx2::decode_blocks(payload, state) };
+    }
+    #[cfg(target_arch = "aarch64")]
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        // SAFETY: NEON was detected. The backend bounds memory operations to
+        // initialized fixed-size arrays and complete 128-byte input batches.
+        return unsafe { neon::decode_blocks(payload, state) };
+    }
+    (0, state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn next(state: &mut u32) -> u32 {
+        *state ^= *state << 13;
+        *state ^= *state >> 17;
+        *state ^= *state << 5;
+        *state
+    }
+
+    fn scalar(payload: &mut [u8], mut state: u32) -> u32 {
+        for block in payload.as_chunks_mut::<32>().0 {
+            let keys: [u32; 32] = std::array::from_fn(|_| next(&mut state));
+            let mut swaps: Vec<_> = (1..32)
+                .rev()
+                .map(|index| (index, next(&mut state) as usize % (index + 1)))
+                .collect();
+            swaps.reverse();
+            for (index, other) in swaps {
+                block.swap(index, other);
+            }
+            let mut previous = 0;
+            for (byte, key) in block.iter_mut().zip(keys) {
+                let [add, xor, rotation, _] = key.to_le_bytes();
+                let encoded = *byte;
+                *byte = (*byte ^ xor ^ previous)
+                    .rotate_right(u32::from(rotation & 7))
+                    .wrapping_sub(add);
+                previous = encoded;
+            }
+        }
+        state
+    }
+
+    #[test]
+    fn matches_scalar_state_and_bytes_without_touching_remainder_or_guards() {
+        for length in 0..1_025 {
+            for offset in [0, 1, 7, 15, 31] {
+                for seed in [0, 1, 42, u32::MAX] {
+                    let mut bytes: Vec<u8> =
+                        (0..length + offset + 32).map(|i| (i * 197) as u8).collect();
+                    let mut expected = bytes.clone();
+                    let payload = bytes.get_mut(offset..offset + length).expect("payload");
+                    let (processed, state) = decode_blocks(payload, seed);
+                    assert!(processed <= length);
+                    assert_eq!(processed % 32, 0);
+                    let expected_state =
+                        scalar(expected.get_mut(offset..offset + processed).expect("prefix"), seed);
+                    assert_eq!(state, expected_state);
+                    assert_eq!(bytes, expected);
+                    #[cfg(target_arch = "x86_64")]
+                    if std::arch::is_x86_feature_detected!("avx2") {
+                        assert_eq!(processed, length / 256 * 256);
+                    } else {
+                        assert_eq!(processed, 0);
+                    }
+                    #[cfg(target_arch = "aarch64")]
+                    if std::arch::is_aarch64_feature_detected!("neon") {
+                        assert_eq!(processed, length / 128 * 128);
+                    } else {
+                        assert_eq!(processed, 0);
+                    }
+                    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+                    assert_eq!(processed, 0);
+                }
+            }
+        }
+    }
+}

--- a/crates/common/rokbattles-container-simd/src/neon.rs
+++ b/crates/common/rokbattles-container-simd/src/neon.rs
@@ -27,7 +27,7 @@ pub(super) unsafe fn decode_blocks(payload: &mut [u8], mut state: u32) -> (usize
             unsafe { vst1q_u32(row.as_mut_ptr(), states) };
         }
         for (lane, block) in batch.as_chunks_mut::<32>().0.iter_mut().enumerate() {
-            let keys = std::array::from_fn(|index| schedule[index][lane]);
+            let keys = std::array::from_fn(|index| schedule[index][lane].to_le());
             // Rows 32..63 hold choices for indices 31..1. Replay them in reverse.
             for index in 1..32 {
                 block.swap(index, schedule[63 - index][lane] as usize % (index + 1));
@@ -42,46 +42,27 @@ pub(super) unsafe fn decode_blocks(payload: &mut [u8], mut state: u32) -> (usize
 
 #[target_feature(enable = "neon")]
 unsafe fn transform(block: &mut [u8; 32], keys: &[u32; 32]) {
-    let mut add = [0_u8; 32];
-    let mut xor = [0_u8; 32];
-    let mut rotation = [0_u8; 32];
-    for (((add, xor), rotation), key) in add.iter_mut().zip(&mut xor).zip(&mut rotation).zip(keys) {
-        let bytes = key.to_le_bytes();
-        *add = bytes[0];
-        *xor = bytes[1];
-        *rotation = bytes[2] & 7;
-    }
-    let mut previous = [0_u8; 32];
-    // Capture feedback before either half is modified, including the byte that
-    // crosses the 16-byte vector boundary. Feedback resets only every 32 bytes.
-    previous[1..].copy_from_slice(&block[..31]);
-    for ((((block, add), xor), rotation), previous) in block
-        .as_chunks_mut::<16>()
-        .0
-        .iter_mut()
-        .zip(add.as_chunks::<16>().0)
-        .zip(xor.as_chunks::<16>().0)
-        .zip(rotation.as_chunks::<16>().0)
-        .zip(previous.as_chunks::<16>().0)
-    {
-        // SAFETY: Each input contains 16 initialized bytes, and NEON is enabled.
-        // The intrinsic permits an unaligned address.
+    let mut previous = vdupq_n_u8(0);
+    for (block, keys) in block.as_chunks_mut::<16>().0.iter_mut().zip(keys.as_chunks::<16>().0) {
+        // Each little-endian key contains addition, XOR, rotation, and an unused byte.
+        // The load separates these fields into four vectors, keeping the keys in order.
+        // SAFETY: `keys` contains the 64 initialized bytes read by `vld4q_u8`;
+        // the intrinsic permits an unaligned address. NEON is enabled.
+        let fields = unsafe { vld4q_u8(keys.as_ptr().cast()) };
+        // SAFETY: `block` contains the 16 initialized bytes read by `vld1q_u8`;
+        // the intrinsic permits an unaligned address.
         let encoded = unsafe { vld1q_u8(block.as_ptr()) };
-        // SAFETY: The XOR chunk contains 16 initialized bytes.
-        let xors = unsafe { vld1q_u8(xor.as_ptr()) };
-        // SAFETY: The feedback chunk contains 16 initialized bytes.
-        let feedback = unsafe { vld1q_u8(previous.as_ptr()) };
-        // SAFETY: The rotation chunk contains 16 initialized bytes.
-        let rotations = unsafe { vld1q_u8(rotation.as_ptr()) };
-        // SAFETY: The addition chunk contains 16 initialized bytes.
-        let additions = unsafe { vld1q_u8(add.as_ptr()) };
-        let value = veorq_u8(veorq_u8(encoded, xors), feedback);
-        let rotations = vreinterpretq_s8_u8(rotations);
+        // Each byte uses the preceding encoded byte as feedback. The first half
+        // starts with zero; the second starts with the first half's last encoded byte.
+        let feedback = vextq_u8::<15>(previous, encoded);
+        previous = encoded;
+        let value = veorq_u8(veorq_u8(encoded, fields.1), feedback);
+        let rotations = vreinterpretq_s8_u8(vandq_u8(fields.2, vdupq_n_u8(7)));
         // Signed counts select the shift direction. For a zero rotation, the
         // right part is unchanged and the left shift by eight contributes zero.
         let right = vshlq_u8(value, vnegq_s8(rotations));
         let left = vshlq_u8(value, vsubq_s8(vdupq_n_s8(8), rotations));
-        let value = vsubq_u8(vorrq_u8(right, left), additions);
+        let value = vsubq_u8(vorrq_u8(right, left), fields.0);
         // SAFETY: The destination contains writable storage for all 16 bytes.
         unsafe { vst1q_u8(block.as_mut_ptr(), value) };
     }

--- a/crates/common/rokbattles-container-simd/src/neon.rs
+++ b/crates/common/rokbattles-container-simd/src/neon.rs
@@ -1,0 +1,88 @@
+use std::arch::aarch64::*;
+
+use crate::schedule::jump;
+
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Fixed batches bound lanes to 0..4 and schedule rows to 0..63"
+)]
+#[target_feature(enable = "neon")]
+pub(super) unsafe fn decode_blocks(payload: &mut [u8], mut state: u32) -> (usize, u32) {
+    let mut processed = 0;
+    for batch in payload.as_chunks_mut::<128>().0 {
+        let mut seeds = [0_u32; 4];
+        for seed in &mut seeds {
+            *seed = state;
+            state = jump(state);
+        }
+        let mut schedule = [[0_u32; 4]; 63];
+        // SAFETY: `seeds` contains four initialized u32s; the load permits an
+        // unaligned address. NEON is required by this function.
+        let mut states = unsafe { vld1q_u32(seeds.as_ptr()) };
+        for row in &mut schedule {
+            states = veorq_u32(states, vshlq_n_u32::<13>(states));
+            states = veorq_u32(states, vshrq_n_u32::<17>(states));
+            states = veorq_u32(states, vshlq_n_u32::<5>(states));
+            // SAFETY: The row holds four initialized u32 lanes and permits an unaligned store.
+            unsafe { vst1q_u32(row.as_mut_ptr(), states) };
+        }
+        for (lane, block) in batch.as_chunks_mut::<32>().0.iter_mut().enumerate() {
+            let keys = std::array::from_fn(|index| schedule[index][lane]);
+            // Rows 32..63 hold choices for indices 31..1. Replay them in reverse.
+            for index in 1..32 {
+                block.swap(index, schedule[63 - index][lane] as usize % (index + 1));
+            }
+            // SAFETY: NEON is enabled; block and keys are complete initialized arrays.
+            unsafe { transform(block, &keys) };
+        }
+        processed += batch.len();
+    }
+    (processed, state)
+}
+
+#[target_feature(enable = "neon")]
+unsafe fn transform(block: &mut [u8; 32], keys: &[u32; 32]) {
+    let mut add = [0_u8; 32];
+    let mut xor = [0_u8; 32];
+    let mut rotation = [0_u8; 32];
+    for (((add, xor), rotation), key) in add.iter_mut().zip(&mut xor).zip(&mut rotation).zip(keys) {
+        let bytes = key.to_le_bytes();
+        *add = bytes[0];
+        *xor = bytes[1];
+        *rotation = bytes[2] & 7;
+    }
+    let mut previous = [0_u8; 32];
+    // Capture feedback before either half is modified, including the byte that
+    // crosses the 16-byte vector boundary. Feedback resets only every 32 bytes.
+    previous[1..].copy_from_slice(&block[..31]);
+    for ((((block, add), xor), rotation), previous) in block
+        .as_chunks_mut::<16>()
+        .0
+        .iter_mut()
+        .zip(add.as_chunks::<16>().0)
+        .zip(xor.as_chunks::<16>().0)
+        .zip(rotation.as_chunks::<16>().0)
+        .zip(previous.as_chunks::<16>().0)
+    {
+        // SAFETY: Each input contains 16 initialized bytes, and NEON is enabled.
+        // The intrinsic permits an unaligned address.
+        let encoded = unsafe { vld1q_u8(block.as_ptr()) };
+        // SAFETY: The XOR chunk contains 16 initialized bytes.
+        let xors = unsafe { vld1q_u8(xor.as_ptr()) };
+        // SAFETY: The feedback chunk contains 16 initialized bytes.
+        let feedback = unsafe { vld1q_u8(previous.as_ptr()) };
+        // SAFETY: The rotation chunk contains 16 initialized bytes.
+        let rotations = unsafe { vld1q_u8(rotation.as_ptr()) };
+        // SAFETY: The addition chunk contains 16 initialized bytes.
+        let additions = unsafe { vld1q_u8(add.as_ptr()) };
+        let value = veorq_u8(veorq_u8(encoded, xors), feedback);
+        let rotations = vreinterpretq_s8_u8(rotations);
+        // Signed counts select the shift direction. For a zero rotation, the
+        // right part is unchanged and the left shift by eight contributes zero.
+        let right = vshlq_u8(value, vnegq_s8(rotations));
+        let left = vshlq_u8(value, vsubq_s8(vdupq_n_s8(8), rotations));
+        let value = vsubq_u8(vorrq_u8(right, left), additions);
+        // SAFETY: The destination contains writable storage for all 16 bytes.
+        unsafe { vst1q_u8(block.as_mut_ptr(), value) };
+    }
+}

--- a/crates/common/rokbattles-container-simd/src/schedule.rs
+++ b/crates/common/rokbattles-container-simd/src/schedule.rs
@@ -1,0 +1,57 @@
+//! A full block consumes 32 byte keys and 31 Fisher-Yates choices. Jumping the
+//! linear xorshift32 recurrence by 63 steps gives independent starting states
+//! for adjacent blocks without generating their keys serially.
+
+const fn advance(mut state: u32) -> u32 {
+    let mut step = 0;
+    while step < 63 {
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        step += 1;
+    }
+    state
+}
+
+#[expect(clippy::indexing_slicing, reason = "Const loops stay within the four 256-entry tables")]
+const fn tables() -> [[u32; 256]; 4] {
+    let mut tables = [[0; 256]; 4];
+    let mut byte = 0;
+    while byte < 4 {
+        let mut value = 0;
+        while value < 256 {
+            tables[byte][value] = advance((value as u32) << (byte * 8));
+            value += 1;
+        }
+        byte += 1;
+    }
+    tables
+}
+
+const JUMP: [[u32; 256]; 4] = tables();
+
+#[expect(clippy::indexing_slicing, reason = "Byte values always index within 256-entry tables")]
+pub(super) fn jump(state: u32) -> u32 {
+    let bytes = state.to_le_bytes();
+    // Each lookup is bounded by a byte. Xorshift is linear over XOR, so the
+    // transformed byte contributions reconstruct the transformed whole state.
+    JUMP[0][usize::from(bytes[0])]
+        ^ JUMP[1][usize::from(bytes[1])]
+        ^ JUMP[2][usize::from(bytes[2])]
+        ^ JUMP[3][usize::from(bytes[3])]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jump_matches_63_serial_steps() {
+        for bit in 0..32 {
+            assert_eq!(jump(1 << bit), advance(1 << bit));
+        }
+        for state in [0, 1, 42, 0x6d2b_79f5, u32::MAX] {
+            assert_eq!(jump(state), advance(state));
+        }
+    }
+}

--- a/crates/common/rokbattles-container/Cargo.toml
+++ b/crates/common/rokbattles-container/Cargo.toml
@@ -9,12 +9,13 @@ crate-type = ["rlib", "cdylib"]
 
 [features]
 default = ["read", "write"]
-read = ["dep:crc32fast", "dep:serde_json"]
+read = ["dep:crc32fast", "dep:serde_json", "dep:rokbattles-container-simd"]
 write = ["dep:crc32fast", "dep:serde_json"]
 schemas = ["read", "dep:serde"]
 wasm-read = ["schemas", "dep:wasm-bindgen", "dep:js-sys", "dep:serde-wasm-bindgen"]
 
 [dependencies]
+rokbattles-container-simd = { path = "../rokbattles-container-simd", optional = true }
 thiserror.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde-wasm-bindgen = { workspace = true, optional = true }
@@ -25,3 +26,11 @@ js-sys = { workspace = true, optional = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "container"
+harness = false
+required-features = ["read", "write"]

--- a/crates/common/rokbattles-container/benches/container.rs
+++ b/crates/common/rokbattles-container/benches/container.rs
@@ -1,0 +1,180 @@
+use std::{hint::black_box, time::Duration};
+
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rokbattles_container::{Reader, schema, write_envelope};
+
+#[cfg_attr(
+    test,
+    expect(unused_imports, reason = "Criterion does not run the included module’s unit tests")
+)]
+#[path = "../src/mask.rs"]
+mod mask;
+
+fn input(length: usize) -> Vec<u8> {
+    (0..length).map(|index| (index.wrapping_mul(197).wrapping_add(101) & 255) as u8).collect()
+}
+
+fn benchmark_file(criterion: &mut Criterion, name: &str, file: &[u8]) {
+    let reader = Reader::default();
+    reader.decode(&mut file.to_vec()).expect("valid benchmark file");
+    let mut group = criterion.benchmark_group(name);
+    group.throughput(Throughput::Bytes(file.len() as u64));
+    // Restoring the masked input is setup work; the decode benchmark includes its copy.
+    group.bench_function("read_envelope", |bencher| {
+        bencher.iter_batched_ref(
+            || file.to_vec(),
+            |bytes| {
+                let envelope = reader.read_envelope(black_box(bytes)).expect("envelope");
+                black_box(envelope.payload);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("decode", |bencher| {
+        bencher.iter(|| {
+            let mut bytes = black_box(file).to_vec();
+            black_box(reader.decode(&mut bytes).expect("decode"));
+        });
+    });
+    group.finish();
+}
+
+fn benchmarks(criterion: &mut Criterion) {
+    for size in [0, 31, 32, 33, 1_024, 64 * 1_024, 1_024 * 1_024] {
+        let payload = input(size);
+        let file = write_envelope(schema::BYTES, &payload, 42).expect("write bytes");
+        benchmark_file(criterion, &format!("bytes/{size}"), &file);
+        let mut group = criterion.benchmark_group("write_bytes");
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &payload, |bencher, bytes| {
+            bencher.iter(|| {
+                black_box(write_envelope(schema::BYTES, black_box(bytes), 42).expect("write"))
+            });
+        });
+        group.finish();
+    }
+
+    let payload = input(64 * 1_024);
+    let mut masked = payload.clone();
+    mask::encode(&mut masked, 42);
+    let mut group = criterion.benchmark_group("stages/65536");
+    group.throughput(Throughput::Bytes(payload.len() as u64));
+    group.bench_function("unmask", |bencher| {
+        bencher.iter_batched_ref(
+            || masked.clone(),
+            |bytes| mask::decode(black_box(bytes), 42),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_function("crc32", |bencher| {
+        bencher.iter(|| black_box(crc32fast::hash(black_box(&payload))));
+    });
+    group.finish();
+
+    let text = "ROK Battles — éàø\0".repeat(2_048);
+    benchmark_file(criterion, "text", &rokbattles_container::write_text(&text, 42).expect("text"));
+    let json = serde_json::json!({"name": "ROK Battles", "coordinates": vec![[123, -456]; 2_048]});
+    benchmark_file(criterion, "json", &rokbattles_container::write_json(&json, 42).expect("json"));
+
+    #[cfg(feature = "schemas")]
+    for (name, schema_id, payload) in territory_payloads() {
+        let file = write_envelope(schema_id, &payload, 42).expect("territory file");
+        benchmark_file(criterion, name, &file);
+    }
+    if let Some(path) = std::env::var_os("CONTAINER_BENCH_DIR") {
+        let mut files = Vec::new();
+        collect_files(std::path::Path::new(&path), &mut files);
+        assert!(!files.is_empty(), "CONTAINER_BENCH_DIR must contain BIN files");
+        let reader = Reader::default();
+        for file in &files {
+            reader.decode(&mut file.clone()).expect("valid directory fixture");
+        }
+        let mut group = criterion.benchmark_group("directory");
+        group.throughput(Throughput::Bytes(files.iter().map(|file| file.len() as u64).sum()));
+        group.bench_function("decode", |bencher| {
+            bencher.iter(|| {
+                for file in black_box(&files) {
+                    black_box(reader.decode(&mut file.clone()).expect("decode"));
+                }
+            });
+        });
+        group.finish();
+    }
+    if let Some(path) = std::env::var_os("CONTAINER_BENCH_FILE") {
+        let bytes = std::fs::read(path).expect("read CONTAINER_BENCH_FILE");
+        benchmark_file(criterion, "file", &bytes);
+    }
+}
+
+fn collect_files(path: &std::path::Path, files: &mut Vec<Vec<u8>>) {
+    let mut entries: Vec<_> = std::fs::read_dir(path)
+        .expect("read benchmark directory")
+        .map(|entry| entry.expect("directory entry").path())
+        .collect();
+    entries.sort();
+    for path in entries {
+        if path.is_dir() {
+            collect_files(&path, files);
+        } else if path.extension().is_some_and(|extension| extension == "bin") {
+            files.push(std::fs::read(path).expect("read benchmark file"));
+        }
+    }
+}
+
+#[cfg(feature = "schemas")]
+fn uint(bytes: &mut Vec<u8>, mut value: u32) {
+    while value >= 128 {
+        bytes.push((value as u8 & 127) | 128);
+        value >>= 7;
+    }
+    bytes.push(value as u8);
+}
+
+#[cfg(feature = "schemas")]
+fn territory_payloads() -> [(&'static str, u16, Vec<u8>); 3] {
+    use rokbattles_container::schemas::territory::{
+        MESH_DEFINITIONS, PROVINCE_GRID, SPATIAL_CHUNK,
+    };
+
+    let mut mesh = vec![10, 1, 1, 0];
+    uint(&mut mesh, 8_192);
+    for _ in 0..8_192 {
+        mesh.extend_from_slice(&[2, 1]);
+    }
+    uint(&mut mesh, 8_190);
+    for index in 0..8_190 {
+        uint(&mut mesh, index);
+    }
+
+    let mut chunk = vec![10, 0, 0, 0];
+    uint(&mut chunk, 1_024);
+    for index in 0..1_024 {
+        uint(&mut chunk, index);
+        chunk.push(1);
+        uint(&mut chunk, index * 20);
+        uint(&mut chunk, index * 10);
+    }
+    chunk.extend_from_slice(&[0, 0]);
+
+    let mut province = vec![1, 1, 10];
+    uint(&mut province, 512);
+    uint(&mut province, 512);
+    province.extend_from_slice(&[1, 1, 1, 2]);
+    uint(&mut province, 512);
+    for row in 0_u32..512 {
+        uint(&mut province, 512);
+        province.push((row % 4) as u8);
+    }
+    [
+        ("mesh", MESH_DEFINITIONS, mesh),
+        ("chunk", SPATIAL_CHUNK, chunk),
+        ("province", PROVINCE_GRID, province),
+    ]
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(30).warm_up_time(Duration::from_millis(500)).measurement_time(Duration::from_secs(1));
+    targets = benchmarks
+}
+criterion_main!(benches);

--- a/crates/common/rokbattles-container/src/error.rs
+++ b/crates/common/rokbattles-container/src/error.rs
@@ -2,7 +2,7 @@
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
-    /// The input cannot contain a complete header.
+    /// The input is shorter than the header.
     #[error("ROKB header is truncated")]
     TruncatedHeader,
     /// The magic does not identify a ROKB file.
@@ -20,7 +20,7 @@ pub enum Error {
     /// The selected decoder does not support this schema ID.
     #[error("unknown ROKB schema {0}")]
     UnknownSchema(u16),
-    /// The caller expected a different payload type.
+    /// The header schema ID differs from the required ID.
     #[error("expected ROKB schema {expected}, got {actual}")]
     SchemaMismatch {
         /// The required schema ID.
@@ -31,13 +31,13 @@ pub enum Error {
     /// Declared length differs from the bytes following the header.
     #[error("ROKB payload length mismatch")]
     LengthMismatch,
-    /// The configured limit, wire length, or host allocation size was exceeded.
+    /// An input or schema limit was exceeded, or an allocation failed.
     #[error("ROKB payload exceeds the size limit")]
     PayloadTooLarge,
     /// The checksum did not match the unmasked payload.
     #[error("ROKB payload checksum failed")]
     ChecksumMismatch,
-    /// A text payload contains invalid UTF-8.
+    /// Payload text contains invalid UTF-8.
     #[error("invalid ROKB UTF-8 text: {0}")]
     InvalidUtf8(#[from] std::str::Utf8Error),
     /// A JSON payload cannot be read or written.

--- a/crates/common/rokbattles-container/src/lib.rs
+++ b/crates/common/rokbattles-container/src/lib.rs
@@ -1,15 +1,17 @@
-//! Reads and writes ROKB containers with schema-specific payloads.
+//! Reads and writes ROKB `.bin` files with schema-specific payloads.
 //!
-//! Files use the `.bin` extension. Each file contains a 20-byte header followed by one masked payload. The
-//! header identifies the schema, seed, payload length, and checksum. Readers
-//! validate the envelope before interpreting the payload.
+//! Each file contains a 20-byte header followed by a masked payload. The header
+//! records the schema ID, seed, payload length, and checksum. Readers validate
+//! the envelope before decoding the payload.
 //!
-//! Enable `read` for the Rust reader, `write` for the writers, or `wasm-read`
-//! for JavaScript bindings to the same reader. The default features are `read`
-//! and `write`. Built-in schemas support bytes, UTF-8 text, and JSON; callers
-//! supply the serialization and decoding logic for application schemas. Enable
-//! `schemas` for territory planner schemas 401–403; `wasm-read` includes it.
-//! Reserved schemas 1–3 do not require `schemas`.
+//! The default features, `read` and `write`, support bytes, UTF-8 text, and JSON
+//! under reserved schema IDs 1–3. The `schemas` feature adds territory planner
+//! decoders for IDs 401–403. Other layouts use caller-supplied serialization
+//! and decoding. The `wasm-read` feature includes `schemas` and exposes the
+//! reader to JavaScript.
+//!
+//! Readers select AVX2 or NEON when available and otherwise use scalar
+//! decoding. All implementations read the same wire format.
 //!
 //! Masking is reversible using the public seed. CRC32 detects accidental
 //! payload corruption; neither mechanism authenticates the file or restricts

--- a/crates/common/rokbattles-container/src/mask.rs
+++ b/crates/common/rokbattles-container/src/mask.rs
@@ -37,6 +37,14 @@ fn layered(payload: &mut [u8], seed: u32, decode: bool) {
     // Reset at the stage boundary, then carry state across blocks. Changing
     // either boundary changes the wire format, including partial final blocks.
     let mut state = if seed == 0 { 0x6d2b_79f5 } else { seed };
+    #[cfg(feature = "read")]
+    let payload = if decode {
+        let (processed, next_state) = rokbattles_container_simd::decode_blocks(payload, state);
+        state = next_state;
+        payload.split_at_mut(processed).1
+    } else {
+        payload
+    };
     for block in payload.chunks_mut(32) {
         let mut keys = [0_u32; 32];
         for key in keys.iter_mut().take(block.len()) {

--- a/crates/common/rokbattles-container/src/read.rs
+++ b/crates/common/rokbattles-container/src/read.rs
@@ -1,6 +1,6 @@
 use crate::{Error, HEADER_LEN, Header, MAGIC, VERSION, mask, schema};
 
-/// Bounds enforced before copying, unmasking, or decoding a payload.
+/// Input limits checked before copying or unmasking the payload.
 #[derive(Debug, Clone, Copy)]
 pub struct ReadLimits {
     /// Maximum payload bytes, excluding the header; defaults to 16 MiB.
@@ -75,8 +75,8 @@ impl Reader {
     ///
     /// Rejects invalid headers, unsupported versions or flags, oversized input,
     /// length mismatches, and checksum failures. Header and framing errors leave
-    /// the buffer unchanged. A checksum failure leaves the payload
-    /// modified; discard it or reload the original file before retrying.
+    /// the buffer unchanged. A checksum failure leaves the payload modified;
+    /// reload the original file before retrying.
     pub fn read_envelope<'a>(&self, bytes: &'a mut [u8]) -> Result<Envelope<'a>, Error> {
         let header = self.read_header(bytes)?;
         let payload = bytes.get_mut(HEADER_LEN..).ok_or(Error::TruncatedHeader)?;
@@ -92,10 +92,9 @@ impl Reader {
     /// # Errors
     ///
     /// Returns envelope validation errors, [`Error::UnknownSchema`] for an
-    /// unsupported schema, or an error for invalid payload fields or exceeded
-    /// schema limits. As with
-    /// [`Self::read_envelope`], errors after unmasking leave the input modified;
-    /// reload the original file before retrying.
+    /// unsupported schema, or an error for invalid fields or exceeded schema
+    /// limits. Errors after unmasking leave the input modified; reload the
+    /// original file before retrying.
     pub fn decode(&self, bytes: &mut [u8]) -> Result<Decoded, Error> {
         self.decode_expected(bytes, None)
     }
@@ -106,10 +105,10 @@ impl Reader {
     ///
     /// # Errors
     ///
-    /// Returns [`Self::decode`]'s errors or [`Error::SchemaMismatch`] if the
-    /// validated envelope has a different ID. The schema check precedes payload
-    /// interpretation, after unmasking. A schema mismatch leaves the input
-    /// unmasked; reload the original file before retrying.
+    /// Returns errors from [`Self::decode`] or [`Error::SchemaMismatch`] if the
+    /// header has a different ID. The schema check runs after unmasking and
+    /// before payload interpretation. A mismatch leaves the input unmasked;
+    /// reload the original file before retrying.
     pub fn decode_expected(
         &self,
         bytes: &mut [u8],

--- a/crates/common/rokbattles-container/src/schemas/mod.rs
+++ b/crates/common/rokbattles-container/src/schemas/mod.rs
@@ -1,7 +1,6 @@
-//! Application payload schemas available with the `schemas` feature.
+//! Application payload decoders enabled by the `schemas` feature.
 //!
-//! Schema IDs identify complete wire layouts. The territory layouts use unsigned
-//! base-128 varints, zigzag signed values, and quantized coordinates. Decoders
-//! consume the entire payload and reject unsupported tags or arithmetic overflow.
+//! Each schema ID identifies one wire layout. Decoders validate its fields and
+//! consume the complete payload.
 
 pub mod territory;

--- a/crates/common/rokbattles-container/src/schemas/territory.rs
+++ b/crates/common/rokbattles-container/src/schemas/territory.rs
@@ -1,12 +1,12 @@
-//! Territory planner payloads for mesh definitions, spatial chunks, and provinces.
+//! Territory planner mesh definitions, spatial chunks, and province grids.
 //!
-//! Decoded collections are bounded independently of the encoded file size:
-//! at most 64 MiB of vector elements and string bytes per payload. This includes
-//! expanded province cells, preventing short run-length streams from requesting
-//! unbounded allocations. Other collections share a 65,536-element limit to bound
-//! the number of JavaScript objects created during WASM serialization. These
-//! limits apply to both readers; JavaScript heap usage also depends on the engine.
-//! Integers use canonical u32 varints, with zigzag encoding for i32 coordinates.
+//! Payloads use canonical base-128 `u32` varints, zigzag-encoded `i32` values,
+//! and scaled coordinates. Decoders reject invalid tags, overflow, and trailing bytes.
+//!
+//! Each payload can allocate up to 64 MiB of vector elements and string bytes,
+//! including expanded province cells. Other collections share a 65,536-element
+//! limit to bound JavaScript object creation. These limits apply to Rust and
+//! WASM readers; JavaScript heap usage also depends on the engine.
 
 use serde::Serialize;
 
@@ -43,7 +43,8 @@ pub struct MeshDefinition {
 pub struct MeshInstance {
     /// Referenced mesh definition ID.
     pub mesh: u32,
-    /// Six affine coefficients in the payload's original order.
+    /// Coefficients `[a, b, c, d, tx, ty]` mapping local `(x, y)` to
+    /// `(a*x + b*y + tx, c*x + d*y + ty)` in world coordinates.
     pub affine: [f64; 6],
 }
 
@@ -149,9 +150,9 @@ pub struct MapStructure {
     pub label: String,
     /// Occupied collision area.
     pub collision: Collision,
-    /// Claimed territory radius.
+    /// Claimed territory radius in cells.
     pub territory_radius_in_cells: u32,
-    /// Optional teleport restriction radius; absent becomes JavaScript `null`.
+    /// Teleport restriction radius in cells; `None` becomes JavaScript `null`.
     pub teleport_radius_in_cells: Option<u32>,
     /// Whether an alliance can claim this structure.
     pub claimable: bool,
@@ -286,7 +287,7 @@ impl PayloadReader<'_> {
 
     fn count(&mut self, minimum_bytes: usize) -> Result<usize, Error> {
         let count = usize::try_from(self.uint()?).map_err(|_error| Error::PayloadTooLarge)?;
-        // Check the wire bound before allocating, even when the output budget fits.
+        // Every entry needs at least this many bytes, regardless of the allocation limit.
         if count > self.bytes.len() / minimum_bytes {
             return Err(invalid("territory count exceeds remaining payload"));
         }

--- a/crates/common/rokbattles-container/src/wasm.rs
+++ b/crates/common/rokbattles-container/src/wasm.rs
@@ -1,8 +1,7 @@
 //! JavaScript bindings for the Rust reader.
 //!
-//! Exported classes own Rust allocations. JavaScript callers release them with
-//! `free()` after use. Decoded values are JavaScript-owned
-//! copies and remain valid after releasing the result wrapper.
+//! Call `free()` on readers and result wrappers to release their Rust allocations.
+//! Decoded values belong to JavaScript and remain valid after the wrapper is freed.
 
 use wasm_bindgen::prelude::*;
 
@@ -35,11 +34,12 @@ impl DecodedValue {
 
     /// Returns the decoded JavaScript value.
     ///
-    /// Bytes become `Uint8Array`, text becomes `string`, and JSON becomes
-    /// JavaScript objects and arrays. JSON integers become `BigInt`, including
-    /// small integers; floating-point values become `Number`. Territory schema
-    /// values use JavaScript numbers and objects, with province cells exported
-    /// as `Uint8Array` and blocked province IDs as arrays.
+    /// Byte payloads become `Uint8Array`; text becomes `string`. JSON preserves
+    /// objects, arrays, and primitive values. All JSON integers become `BigInt`;
+    /// floating-point values become `Number`.
+    ///
+    /// Territory schemas use JavaScript objects and numbers. Province cells
+    /// become `Uint8Array`, and blocked province IDs become arrays.
     #[wasm_bindgen(getter, unchecked_return_type = "ContainerValue")]
     pub fn value(&self) -> JsValue {
         self.value.clone()

--- a/crates/common/rokbattles-container/src/write.rs
+++ b/crates/common/rokbattles-container/src/write.rs
@@ -2,11 +2,9 @@ use crate::{Error, HEADER_LEN, MAGIC, VERSION, mask, schema};
 
 /// Writes serialized payload bytes with a nonzero schema ID.
 ///
-/// Always applies XOR then layered masking with the supplied seed, including zero.
-/// Flags are reserved and written as zero.
-///
-/// The caller must serialize the payload according to `schema_id`; this
-/// function writes the envelope without interpreting those bytes.
+/// The caller serializes the payload according to `schema_id`. This function
+/// adds the header and applies XOR followed by layered masking. Seed zero is
+/// valid; reserved flags are always zero.
 ///
 /// # Errors
 ///
@@ -22,7 +20,7 @@ pub fn write_envelope(schema_id: u16, payload: &[u8], seed: u32) -> Result<Vec<u
     bytes.try_reserve_exact(capacity).map_err(|_allocation| Error::PayloadTooLarge)?;
     bytes.extend_from_slice(&MAGIC);
     bytes.push(VERSION);
-    bytes.push(0); // Flags are reserved for future functionality.
+    bytes.push(0); // Reserved flags.
     bytes.extend_from_slice(&schema_id.to_le_bytes());
     bytes.extend_from_slice(&seed.to_le_bytes());
     bytes.extend_from_slice(&length.to_le_bytes());


### PR DESCRIPTION
Container readers now automatically use AVX2 or NEON to decode the layered mask, with scalar decoding for unsupported CPUs and remaining bytes. The new `rokbattles-container-simd` crate isolates the architecture-specific code and is a direct path dependency of the reader. Public reader APIs, writers, and the ROKB wire format remain unchanged; WASM retains scalar decoding.

The backends generate keys for independent 32-byte blocks in parallel. AVX2 processes eight blocks per batch and NEON processes four. Each batch advances the xorshift32 state by exactly the same amount as scalar decoding, so partial tails resume with the correct state.

Adds Criterion benchmarks for envelope reads, complete decoding, writes, individual unmasking/CRC stages, and the three planner schemas. Optional file and directory inputs support real asset measurements. Also refines the crate documentation and code comments.

On a Ryzen 7 9800X3D with the workspace release settings, complete decoding of all 1,294 planner files fell from 18.2 ms to 13.1–13.2 ms across three Criterion runs: 27–28% lower latency. WASM prototypes did not show a repeatable 20% improvement, so no WASM SIMD backend is included.

On Apple M4 with Rust 1.98 and the same workspace release settings, complete decoding of 1,294 planner files downloaded from the CDN fell from 23.32–23.58 ms with scalar decoding to 14.28–14.34 ms with NEON across three Criterion runs: 39% lower latency. Direct key-byte loads and register feedback reduced latency another 4–5% versus the original NEON implementation. These are relative gains on different CPUs; historical CDN asset identity was not verified.

Validation:
- All 1,294 planner files matched the previous reader, including corruption-error comparisons for the native AVX2 integration and WASM result parity.
- SIMD parity tests cover 20,500 combinations of lengths, offsets, and seeds; container tests cover framing, malformed payloads, masking round trips, and schema decoding.
- Tests passed on the native AVX2 host and under non-AVX2 CPU emulation. NEON parity and masking round trips passed under ARM emulation.
- Native Apple M4 debug and release tests, including all 20,500 SIMD parity cases and container doctests, passed. All 1,294 CDN files decoded successfully; all-target/all-feature Clippy and formatting passed.
- Apple Silicon cross-compilation and Clippy passed. Rust 1.98 native checks, feature combinations, rustdoc, doctests, formatting, Biome, WASM generation, and the site build passed.
- Daybreak Blue found no actionable security issues in the AVX2 backend and automatic dispatch. NEON was added afterward and validated through cross-compilation, Clippy, emulated tests, and native Apple M4 tests; it has not had a separate agent security review.

Run `cargo bench -p rokbattles-container --features schemas` for the benchmark suite.

Stacked on #898; the container crate is introduced by #897.
