### PR TITLE
feat(combat-lab): support epic commanders

### DIFF
--- a/crates/apps/rokbattles-jobs/src/commander_catalog.rs
+++ b/crates/apps/rokbattles-jobs/src/commander_catalog.rs
@@ -6,33 +6,33 @@ use crate::error::JobsError;
 
 const COMMANDERS_YAML: &str = include_str!("../../../../datasets/commanders.yaml");
 
-pub(crate) fn legendary_commander_ids() -> Result<Vec<i64>, JobsError> {
+pub(crate) fn combat_lab_commander_ids() -> Result<Vec<i64>, JobsError> {
     let mut ids = BTreeSet::new();
     let mut current_id = None;
-    let mut current_is_legendary = false;
+    let mut current_is_supported = false;
 
     for line in COMMANDERS_YAML.lines() {
         if let Some(id) = parse_top_level_commander_id(line) {
-            if current_is_legendary && let Some(previous_id) = current_id {
+            if current_is_supported && let Some(previous_id) = current_id {
                 ids.insert(previous_id);
             }
 
             current_id = Some(id);
-            current_is_legendary = false;
+            current_is_supported = false;
             continue;
         }
 
-        if line.trim() == "rarity: legendary" {
-            current_is_legendary = true;
+        if matches!(line.trim(), "rarity: legendary" | "rarity: epic") {
+            current_is_supported = true;
         }
     }
 
-    if current_is_legendary && let Some(previous_id) = current_id {
+    if current_is_supported && let Some(previous_id) = current_id {
         ids.insert(previous_id);
     }
 
     if ids.is_empty() {
-        return Err(JobsError::MissingLegendaryCommanders);
+        return Err(JobsError::MissingCombatLabCommanders);
     }
 
     Ok(ids.into_iter().collect())
@@ -53,13 +53,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn legendary_commander_ids_reads_expected_dataset_values() {
-        let ids = legendary_commander_ids().expect("legendary IDs");
+    fn combat_lab_commander_ids_reads_expected_dataset_values() {
+        let ids = combat_lab_commander_ids().expect("Combat Lab IDs");
 
         assert!(ids.contains(&509));
         assert!(ids.contains(&6));
         assert!(ids.contains(&179));
         assert!(ids.contains(&187));
-        assert!(!ids.contains(&12));
+        assert!(ids.contains(&3));
+        assert!(ids.contains(&12));
+        assert!(ids.contains(&537));
+        assert!(!ids.contains(&22));
+        assert!(!ids.contains(&33));
     }
 }

--- a/crates/apps/rokbattles-jobs/src/error.rs
+++ b/crates/apps/rokbattles-jobs/src/error.rs
@@ -19,8 +19,8 @@ pub enum JobsError {
     Yaml(#[from] yaml_serde::Error),
     #[error("MONGODB_URI must include a default database")]
     MissingDatabase,
-    #[error("Commander dataset contains no legendary commanders")]
-    MissingLegendaryCommanders,
+    #[error("Commander dataset contains no legendary or epic commanders")]
+    MissingCombatLabCommanders,
     #[error("invalid Combat Lab data: {0}")]
     InvalidCombatLabData(String),
     #[error("invalid materialized DRASTC data: {0}")]

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -26,7 +26,7 @@ use self::{
     model::{MonthLoadouts, PairingKey, PairingRoot, PerformancePoint, RawTotals, range_cutoffs},
     pipeline::{loadout_pipeline, performance_pipeline},
 };
-use crate::{commander_catalog::legendary_commander_ids, error::JobsError};
+use crate::{commander_catalog::combat_lab_commander_ids, error::JobsError};
 
 const PERFORMANCE_KIND: i64 = 1;
 const LOADOUT_KIND: i64 = 2;
@@ -41,7 +41,7 @@ const DAILY_LOADOUT_DAYS: i64 = 8;
 /// Counts and timings from one compact Combat Lab refresh.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct CommanderPairingsV2PrecomputeStats {
-    pub legendary_commanders: usize,
+    pub supported_commanders: usize,
     pub pairings: usize,
     pub performance_points: usize,
     pub loadout_snapshots: usize,
@@ -61,7 +61,7 @@ pub async fn precompute_commander_pairings_v2_data(
     let now_ms = generation.timestamp_millis();
     let cutoffs = range_cutoffs(now_ms);
     let daily_loadout_cutoff = now_ms - DAILY_LOADOUT_DAYS * model::DAY_MS;
-    let legendary_ids = legendary_commander_ids()?;
+    let commander_ids = combat_lab_commander_ids()?;
     let catalogs = Catalogs::load()?;
     let output = reports_store.precomputed_commander_pairings_v2_collection();
     let mut roots = read_stored_drastc(reports_store).await?;
@@ -76,7 +76,7 @@ pub async fn precompute_commander_pairings_v2_data(
             read_performance_partition(
                 reports_store.battle_collection(),
                 output,
-                &legendary_ids,
+                &commander_ids,
                 start_ms,
                 end_ms,
                 generation,
@@ -100,7 +100,7 @@ pub async fn precompute_commander_pairings_v2_data(
     let loadout_context = LoadoutPartitionContext {
         source: reports_store.battle_collection(),
         output,
-        legendary_ids: &legendary_ids,
+        commander_ids: &commander_ids,
         daily_cutoff_ms: daily_loadout_cutoff,
         generation,
         catalogs: &catalogs,
@@ -132,7 +132,7 @@ pub async fn precompute_commander_pairings_v2_data(
     output.delete_many(doc! { "g": { "$ne": generation } }).await?;
 
     Ok(CommanderPairingsV2PrecomputeStats {
-        legendary_commanders: legendary_ids.len(),
+        supported_commanders: commander_ids.len(),
         pairings,
         performance_points,
         loadout_snapshots,
@@ -214,14 +214,14 @@ struct PerformancePartition {
 async fn read_performance_partition(
     source: &Collection<Document>,
     output: &Collection<Document>,
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
     start_ms: i64,
     end_ms: i64,
     generation: DateTime,
     cutoffs: &[i64; 4],
 ) -> Result<PerformancePartition, JobsError> {
     let mut cursor = source
-        .aggregate(performance_pipeline(legendary_ids, start_ms, end_ms))
+        .aggregate(performance_pipeline(commander_ids, start_ms, end_ms))
         .allow_disk_use(true)
         .batch_size(1_000)
         .hint(Hint::Keys(doc! {
@@ -272,7 +272,7 @@ struct LoadoutPartition {
 struct LoadoutPartitionContext<'a> {
     source: &'a Collection<Document>,
     output: &'a Collection<Document>,
-    legendary_ids: &'a [i64],
+    commander_ids: &'a [i64],
     daily_cutoff_ms: i64,
     generation: DateTime,
     catalogs: &'a Catalogs,
@@ -286,7 +286,7 @@ async fn read_loadout_partition(
     let mut cursor = context
         .source
         .aggregate(loadout_pipeline(
-            context.legendary_ids,
+            context.commander_ids,
             start_ms,
             end_ms,
             context.daily_cutoff_ms,

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
@@ -7,12 +7,12 @@ const LOADOUT_CHUNK_MS: i64 = 126 * DAY_MS;
 const WEEK_MS: i64 = 7 * DAY_MS;
 
 pub(super) fn performance_pipeline(
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
     start_ms: i64,
     end_ms: i64,
 ) -> Vec<Document> {
     let mut pipeline =
-        pairing_entries_pipeline(legendary_ids, start_ms, end_ms, EntryShape::Performance);
+        pairing_entries_pipeline(commander_ids, start_ms, end_ms, EntryShape::Performance);
     pipeline.extend([
         scenario_and_date_stage(PERFORMANCE_CHUNK_MS),
         doc! { "$unwind": "$c" },
@@ -48,13 +48,13 @@ pub(super) fn performance_pipeline(
 }
 
 pub(super) fn loadout_pipeline(
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
     start_ms: i64,
     end_ms: i64,
     daily_cutoff_ms: i64,
 ) -> Vec<Document> {
     let mut pipeline =
-        pairing_entries_pipeline(legendary_ids, start_ms, end_ms, EntryShape::Loadout);
+        pairing_entries_pipeline(commander_ids, start_ms, end_ms, EntryShape::Loadout);
     pipeline.extend([
         doc! { "$match": { "u": { "$gt": 0_i64 } } },
         loadout_scenario_and_date_stage(daily_cutoff_ms),
@@ -106,12 +106,12 @@ enum EntryShape {
 }
 
 fn pairing_entries_pipeline(
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
     start_ms: i64,
     end_ms: i64,
     shape: EntryShape,
 ) -> Vec<Document> {
-    let ids = legendary_ids.iter().copied().map(Bson::Int64).collect::<Vec<_>>();
+    let ids = commander_ids.iter().copied().map(Bson::Int64).collect::<Vec<_>>();
     let sender_condition = commander_condition(
         "$sender.commanders.primary.id",
         "$sender.commanders.secondary.id",

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
@@ -15,11 +15,11 @@ use crate::error::JobsError;
 
 pub(super) async fn read_drastc_aggregation(
     source: &Collection<Document>,
-    legendary_ids: &[i64],
+    commander_ids: &[i64],
     cutoff_mail_time: i64,
 ) -> Result<DrastcAggregation, JobsError> {
     let mut cursor = source
-        .aggregate(build_drastc_pipeline(legendary_ids, cutoff_mail_time))
+        .aggregate(build_drastc_pipeline(commander_ids, cutoff_mail_time))
         .allow_disk_use(true)
         .hint(Hint::Keys(
             doc! { "metadata.mail_time": -1, "metadata.kvk": 1, "opponents.player_id": 1 },

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
@@ -1,4 +1,4 @@
-//! Precompute DRASTC scores for legendary open-field commander pairings.
+//! Precompute DRASTC scores for supported open-field commander pairings.
 
 mod confidence;
 mod mapper;
@@ -20,7 +20,7 @@ use self::{
     output::build_drastc_document,
     scoring::{build_drastc_scores_from_aggregates, supported_drastc_pairings},
 };
-use crate::{commander_catalog::legendary_commander_ids, error::JobsError};
+use crate::{commander_catalog::combat_lab_commander_ids, error::JobsError};
 
 const BULK_WRITE_BATCH_SIZE: usize = 1_000;
 const RANKING_WINDOW_DAYS: i64 = 365;
@@ -29,7 +29,7 @@ const MILLIS_PER_DAY: i64 = 24 * 60 * 60 * 1_000;
 /// Counts from one DRASTC precompute run.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DrastcPrecomputeStats {
-    pub legendary_commanders: usize,
+    pub supported_commanders: usize,
     pub observed_pairings: usize,
     pub supported_pairings: usize,
     pub scored_pairings: usize,
@@ -44,14 +44,14 @@ pub async fn precompute_drastc_data(
 ) -> Result<DrastcPrecomputeStats, JobsError> {
     let refreshed_at = DateTime::now();
     let cutoff_mail_time = ranking_cutoff_mail_time(refreshed_at);
-    let legendary_ids = legendary_commander_ids()?;
+    let commander_ids = combat_lab_commander_ids()?;
     let aggregation = read_drastc_aggregation(
         reports_store.battle_collection(),
-        &legendary_ids,
+        &commander_ids,
         cutoff_mail_time,
     )
     .await?;
-    let supported_pairings = supported_drastc_pairings(&legendary_ids);
+    let supported_pairings = supported_drastc_pairings(&commander_ids);
     let scores = build_drastc_scores_from_aggregates(
         &aggregation.observed,
         &supported_pairings,
@@ -77,7 +77,7 @@ pub async fn precompute_drastc_data(
     let documents_stored = validate_materialized_data(output, documents_written).await?;
 
     Ok(DrastcPrecomputeStats {
-        legendary_commanders: legendary_ids.len(),
+        supported_commanders: commander_ids.len(),
         observed_pairings: aggregation.observed.len(),
         supported_pairings: supported_pairings.len(),
         scored_pairings: scores.len(),

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
@@ -7,8 +7,8 @@ use super::model::{PairingKey, Strategy};
 
 const MIN_REFERENCE_RANGE_PAIRING_BATTLES: i64 = 5_000;
 
-pub(super) fn build_drastc_pipeline(legendary_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
-    let mut pipeline = build_pairing_entries_pipeline(legendary_ids, cutoff_mail_time);
+pub(super) fn build_drastc_pipeline(commander_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
+    let mut pipeline = build_pairing_entries_pipeline(commander_ids, cutoff_mail_time);
     pipeline.extend([
         doc! { "$match": { "strategy": Strategy::OpenField.as_str() } },
         raw_totals_group_stage(doc! {
@@ -23,29 +23,29 @@ pub(super) fn build_drastc_pipeline(legendary_ids: &[i64], cutoff_mail_time: i64
     pipeline
 }
 
-fn build_pairing_entries_pipeline(legendary_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
-    let legendary_id_values = legendary_id_bson_array(legendary_ids);
+fn build_pairing_entries_pipeline(commander_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
+    let commander_id_values = commander_id_bson_array(commander_ids);
     let sender_condition = ids_match_condition(
         "$sender.commanders.primary.id",
         "$sender.commanders.secondary.id",
-        &legendary_id_values,
+        &commander_id_values,
     );
     let opponent_condition = ids_match_condition(
         "$opponents.commanders.primary.id",
         "$opponents.commanders.secondary.id",
-        &legendary_id_values,
+        &commander_id_values,
     );
     let pair_filters = vec![
         Bson::Document(doc! {
-            "sender.commanders.primary.id": { "$in": legendary_id_values.clone() },
-            "sender.commanders.secondary.id": { "$in": legendary_id_values.clone() },
+            "sender.commanders.primary.id": { "$in": commander_id_values.clone() },
+            "sender.commanders.secondary.id": { "$in": commander_id_values.clone() },
         }),
         Bson::Document(doc! {
             "opponents": {
                 "$elemMatch": {
                     "player_id": { "$gt": 0 },
-                    "commanders.primary.id": { "$in": legendary_id_values.clone() },
-                    "commanders.secondary.id": { "$in": legendary_id_values },
+                    "commanders.primary.id": { "$in": commander_id_values.clone() },
+                    "commanders.secondary.id": { "$in": commander_id_values },
                 }
             }
         }),
@@ -504,19 +504,19 @@ fn aggregate_consistency_rate_expr() -> Document {
     }
 }
 
-fn legendary_id_bson_array(legendary_ids: &[i64]) -> Vec<Bson> {
-    legendary_ids.iter().map(|id| Bson::Int64(*id)).collect()
+fn commander_id_bson_array(commander_ids: &[i64]) -> Vec<Bson> {
+    commander_ids.iter().map(|id| Bson::Int64(*id)).collect()
 }
 
 fn ids_match_condition(
     primary_expr: &'static str,
     secondary_expr: &'static str,
-    legendary_ids: &[Bson],
+    commander_ids: &[Bson],
 ) -> Document {
     doc! {
         "$and": [
-            { "$in": [primary_expr, legendary_ids.to_vec()] },
-            { "$in": [secondary_expr, legendary_ids.to_vec()] },
+            { "$in": [primary_expr, commander_ids.to_vec()] },
+            { "$in": [secondary_expr, commander_ids.to_vec()] },
             { "$ne": [primary_expr, secondary_expr] },
         ]
     }

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
@@ -30,8 +30,8 @@ pub(super) fn build_drastc_scores_from_aggregates(
     scores
 }
 
-pub(super) fn supported_drastc_pairings(legendary_ids: &[i64]) -> Vec<PairingKey> {
-    ordered_pairing_keys(legendary_ids)
+pub(super) fn supported_drastc_pairings(commander_ids: &[i64]) -> Vec<PairingKey> {
+    ordered_pairing_keys(commander_ids)
         .filter(|key| {
             u32::try_from(key.primary_commander_id)
                 .ok()
@@ -43,9 +43,9 @@ pub(super) fn supported_drastc_pairings(legendary_ids: &[i64]) -> Vec<PairingKey
         .collect()
 }
 
-fn ordered_pairing_keys(legendary_ids: &[i64]) -> impl Iterator<Item = PairingKey> + '_ {
-    legendary_ids.iter().flat_map(|primary| {
-        legendary_ids.iter().filter(move |secondary| primary != *secondary).map(move |secondary| {
+fn ordered_pairing_keys(commander_ids: &[i64]) -> impl Iterator<Item = PairingKey> + '_ {
+    commander_ids.iter().flat_map(|primary| {
+        commander_ids.iter().filter(move |secondary| primary != *secondary).map(move |secondary| {
             PairingKey { primary_commander_id: *primary, secondary_commander_id: *secondary }
         })
     })

--- a/crates/apps/rokbattles-jobs/src/scheduler.rs
+++ b/crates/apps/rokbattles-jobs/src/scheduler.rs
@@ -199,7 +199,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
             match precompute_drastc_data(&reports_store).await {
                 Ok(stats) => {
                     info!(
-                        legendary_commanders = stats.legendary_commanders,
+                        supported_commanders = stats.supported_commanders,
                         observed_pairings = stats.observed_pairings,
                         supported_pairings = stats.supported_pairings,
                         scored_pairings = stats.scored_pairings,
@@ -226,7 +226,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         |reports_store| async move {
             match precompute_commander_pairings_v2_data(&reports_store).await {
                 Ok(stats) => info!(
-                    legendary_commanders = stats.legendary_commanders,
+                    supported_commanders = stats.supported_commanders,
                     pairings = stats.pairings,
                     performance_points = stats.performance_points,
                     loadout_snapshots = stats.loadout_snapshots,

--- a/packages/site/src/app/(legacy)/combat-lab/page.tsx
+++ b/packages/site/src/app/(legacy)/combat-lab/page.tsx
@@ -1,6 +1,6 @@
 import { getLocale } from "next-intl/server";
 import { CombatLab } from "@/components/combat-lab/combat-lab";
-import { getLegendaryCommanderOptions, isLegendaryCommanderId } from "@/lib/combat-lab/commanders";
+import { getCombatLabCommanderOptions, isCombatLabCommanderId } from "@/lib/combat-lab/commanders";
 import { fetchCombatLabPreview } from "@/lib/combat-lab/preview-api";
 
 const defaultPrimaryCommanderId = 509;
@@ -12,8 +12,8 @@ export default async function CombatLabPage({
   searchParams: Promise<{ primary?: string; secondary?: string }>;
 }) {
   const params = await searchParams;
-  const requestedPrimary = legendaryCommanderId(params.primary) ?? defaultPrimaryCommanderId;
-  const requestedSecondary = legendaryCommanderId(params.secondary) ?? defaultSecondaryCommanderId;
+  const requestedPrimary = combatLabCommanderId(params.primary) ?? defaultPrimaryCommanderId;
+  const requestedSecondary = combatLabCommanderId(params.secondary) ?? defaultSecondaryCommanderId;
   const primary = requestedPrimary;
   const secondary =
     requestedSecondary === primary
@@ -24,14 +24,14 @@ export default async function CombatLabPage({
   const locale = await getLocale();
   const [data, commanderOptions] = await Promise.all([
     fetchCombatLabPreview({ primary, secondary, locale }),
-    getLegendaryCommanderOptions(locale),
+    getCombatLabCommanderOptions(locale),
   ]);
   return <CombatLab commanderOptions={commanderOptions} data={data} />;
 }
 
-function legendaryCommanderId(value: string | undefined): number | null {
+function combatLabCommanderId(value: string | undefined): number | null {
   const number = Number(value);
-  return Number.isSafeInteger(number) && number > 0 && isLegendaryCommanderId(number)
+  return Number.isSafeInteger(number) && number > 0 && isCombatLabCommanderId(number)
     ? number
     : null;
 }

--- a/packages/site/src/components/combat-lab/commander-pairing-drawer.tsx
+++ b/packages/site/src/components/combat-lab/commander-pairing-drawer.tsx
@@ -285,7 +285,7 @@ export function CommanderPairingDrawer({
               data-testid="commander-results-empty"
             >
               <p className="font-semibold text-sm text-zinc-950 dark:text-white">
-                {t("No legendary commanders match")}
+                {t("No commanders match")}
               </p>
               <p className="mt-1 text-sm/6 text-zinc-500 dark:text-zinc-400">
                 {t("Try removing a talent or changing your search.")}

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -1337,9 +1337,9 @@ msgid "commanders"
 msgstr "commanders"
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
-msgstr "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
+msgstr "No commanders match"
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
 msgctxt "1Y2wA2"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -1346,8 +1346,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -1346,8 +1346,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -1337,8 +1337,8 @@ msgid "commanders"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx
-msgctxt "AV8fRu"
-msgid "No legendary commanders match"
+msgctxt "pALI0S"
+msgid "No commanders match"
 msgstr ""
 
 #: src/components/combat-lab/commander-pairing-drawer.tsx

--- a/packages/site/src/lib/combat-lab/commanders.ts
+++ b/packages/site/src/lib/combat-lab/commanders.ts
@@ -6,11 +6,11 @@ export type CombatLabCommanderOption = {
   talents: string[];
 };
 
-export function getLegendaryCommanderOptions(locale?: string): CombatLabCommanderOption[] {
+export function getCombatLabCommanderOptions(locale?: string): CombatLabCommanderOption[] {
   const options: CombatLabCommanderOption[] = [];
 
   for (const [id, commander] of Object.entries(commanderMap)) {
-    if (commander.rarity !== "legendary") {
+    if (!isCombatLabCommanderId(Number(id))) {
       continue;
     }
 
@@ -26,6 +26,7 @@ export function getLegendaryCommanderOptions(locale?: string): CombatLabCommande
   return options.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function isLegendaryCommanderId(id: number) {
-  return commanderMap[String(id) as keyof typeof commanderMap]?.rarity === "legendary";
+export function isCombatLabCommanderId(id: number) {
+  const rarity = commanderMap[String(id) as keyof typeof commanderMap]?.rarity;
+  return rarity === "legendary" || rarity === "epic";
 }


### PR DESCRIPTION
Combat Lab excluded epic commanders from its scheduled data generation and commander picker. Include all 22 epics alongside the 112 legendary commanders in the pairing and DRASTC job catalogs, picker options, and URL validation. Update the empty-search message and job statistics naming to reflect the expanded catalog.

The API already accepts these commander IDs and needs no changes. DRASTC scoring retains the existing model's supported-pairing restrictions. Epic pairing data becomes available after the updated scheduled job runs; pairings without generated data retain the existing 404 behavior.

Validation:

- Regression test failed on epic Sun Tzu before the fix; all 72 job tests now pass, including epic inclusion and elite/advanced exclusion.
- Jobs Clippy, Rust formatting, site typechecking, Biome, and diff checks pass.
- React Doctor: 100/100, no issues.
- With the local site and API running, verified all 134 runtime picker options, selected Sun Tzu as primary and Hermann as secondary, and confirmed no Next.js compilation or runtime errors. Existing legendary pairing data loads successfully.
- Did not execute a data refresh; the current database returns 404 for the ungenerated Sun Tzu/Hermann pairing.
