### PR TITLE
feat(jobs): add pre-SoC Combat Lab refreshes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4705,6 +4705,7 @@ dependencies = [
  "futures",
  "mimalloc",
  "mongodb",
+ "regex",
  "rokbattles-api",
  "rokbattles-bson",
  "rokbattles-drastc",

--- a/crates/apps/rokbattles-jobs/Cargo.toml
+++ b/crates/apps/rokbattles-jobs/Cargo.toml
@@ -25,3 +25,6 @@ mimalloc = { workspace = true, features = ["secure"] }
 
 [lib]
 doctest = false
+
+[dev-dependencies]
+regex = "1"

--- a/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
+++ b/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
@@ -2,8 +2,8 @@
 
 use mongodb::{
     Collection, IndexModel,
-    bson::{Document, doc},
-    options::IndexOptions,
+    bson::{Document, Regex, doc},
+    options::{Hint, IndexOptions},
 };
 use rokbattles_api::db::ReportsStore;
 use rokbattles_drastc::{PRESOC_RAGE_TABLE, RageTable, SOC_RAGE_TABLE};
@@ -24,16 +24,32 @@ impl CombatLabSeason {
 
     pub(crate) fn scope_pipeline(self, mut pipeline: Vec<Document>) -> Vec<Document> {
         if self == Self::PreSoc {
-            // Match the report API's sender-based season semantics, including dot suffixes.
+            // Separate exact seasons and literal prefixes so the season index gets narrow bounds.
+            // This preserves the report API's sender-based season semantics.
             // MongoDB coalesces this with the existing leading match before reading reports.
             pipeline.insert(
                 0,
                 doc! {
-                    "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                    "$match": { "sender.server_season": { "$in": [
+                        "1", "2",
+                        Regex { pattern: r"^1\..*$".into(), options: String::new() },
+                        Regex { pattern: r"^2\..*$".into(), options: String::new() },
+                    ] } }
                 },
             );
         }
         pipeline
+    }
+
+    pub(crate) fn source_hint(self) -> Hint {
+        Hint::Keys(match self {
+            Self::Soc => {
+                doc! { "metadata.mail_time": -1, "metadata.kvk": 1, "opponents.player_id": 1 }
+            }
+            Self::PreSoc => {
+                doc! { "metadata.kvk": 1, "sender.server_season": 1, "metadata.mail_time": -1 }
+            }
+        })
     }
 
     pub(crate) fn drastc_collection(self, store: &ReportsStore) -> Collection<Document> {
@@ -98,21 +114,29 @@ mod tests {
     #[test]
     fn presoc_matches_only_seasons_one_and_two_with_optional_dot_suffixes() {
         let pipeline = CombatLabSeason::PreSoc.scope_pipeline(vec![]);
-        let pattern = pipeline[0]
+        let values = pipeline[0]
             .get_document("$match")
             .expect("match")
             .get_document("sender.server_season")
             .expect("sender season")
-            .get_str("$regex")
-            .expect("season regex");
-        let regex = regex::Regex::new(pattern).expect("valid regex");
+            .get_array("$in")
+            .expect("season alternatives");
+        let matches = |value: &str| {
+            values.iter().any(|candidate| match candidate {
+                mongodb::bson::Bson::String(exact) => exact == value,
+                mongodb::bson::Bson::RegularExpression(regex) => {
+                    regex::Regex::new(&regex.pattern).expect("valid regex").is_match(value)
+                }
+                _ => false,
+            })
+        };
         for value in ["1", "1.1", "2", "2.1", "1.2", "2.10"] {
-            assert!(regex.is_match(value), "excluded {value}");
+            assert!(matches(value), "excluded {value}");
         }
         for value in
             ["", "-1", "0", "3", "3.1", "4", "4.1", "99", "100", "100.1", "10", "21", "1x1", " 1"]
         {
-            assert!(!regex.is_match(value), "included {value}");
+            assert!(!matches(value), "included {value}");
         }
     }
 

--- a/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
+++ b/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
@@ -1,0 +1,154 @@
+//! Shared inputs and storage isolation for Combat Lab precomputation.
+
+use mongodb::{
+    Collection, IndexModel,
+    bson::{Document, doc},
+    options::IndexOptions,
+};
+use rokbattles_api::db::ReportsStore;
+use rokbattles_drastc::{PRESOC_RAGE_TABLE, RageTable, SOC_RAGE_TABLE};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CombatLabSeason {
+    Soc,
+    PreSoc,
+}
+
+impl CombatLabSeason {
+    pub(crate) fn rage_table(self) -> RageTable {
+        match self {
+            Self::Soc => SOC_RAGE_TABLE,
+            Self::PreSoc => PRESOC_RAGE_TABLE,
+        }
+    }
+
+    pub(crate) fn scope_pipeline(self, mut pipeline: Vec<Document>) -> Vec<Document> {
+        if self == Self::PreSoc {
+            // Match the report API's sender-based season semantics, including dot suffixes.
+            // MongoDB coalesces this with the existing leading match before reading reports.
+            pipeline.insert(
+                0,
+                doc! {
+                    "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                },
+            );
+        }
+        pipeline
+    }
+
+    pub(crate) fn drastc_collection(self, store: &ReportsStore) -> Collection<Document> {
+        match self {
+            Self::Soc => store.precomputed_drastc_collection().clone(),
+            Self::PreSoc => presoc_collection(store, "g_rok_prec_drastc_presoc"),
+        }
+    }
+
+    pub(crate) fn pairings_collection(self, store: &ReportsStore) -> Collection<Document> {
+        match self {
+            Self::Soc => store.precomputed_commander_pairings_v2_collection().clone(),
+            Self::PreSoc => presoc_collection(store, "g_rok_prec_cmdr_pairings_v2_presoc"),
+        }
+    }
+
+    pub(crate) async fn ensure_drastc_index(
+        self,
+        output: &Collection<Document>,
+    ) -> mongodb::error::Result<()> {
+        if self == Self::PreSoc {
+            output
+                .create_index(
+                    IndexModel::builder()
+                        .keys(doc! { "primary_commander_id": 1, "secondary_commander_id": 1 })
+                        .options(IndexOptions::builder().unique(true).build())
+                        .build(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn ensure_pairings_indexes(
+        self,
+        output: &Collection<Document>,
+    ) -> mongodb::error::Result<()> {
+        if self == Self::PreSoc {
+            output
+                .create_indexes([
+                    IndexModel::builder()
+                        .keys(doc! { "k": 1, "p": 1, "s": 1, "g": -1, "m": 1, "q": 1 })
+                        .options(IndexOptions::builder().unique(true).build())
+                        .build(),
+                    IndexModel::builder().keys(doc! { "g": 1 }).build(),
+                ])
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+fn presoc_collection(store: &ReportsStore, name: &str) -> Collection<Document> {
+    let source = store.battle_collection();
+    source.client().database(&source.namespace().db).collection(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use mongodb::{Client, options::ClientOptions};
+
+    use super::*;
+
+    #[test]
+    fn presoc_matches_only_seasons_one_and_two_with_optional_dot_suffixes() {
+        let pipeline = CombatLabSeason::PreSoc.scope_pipeline(vec![]);
+        let pattern = pipeline[0]
+            .get_document("$match")
+            .expect("match")
+            .get_document("sender.server_season")
+            .expect("sender season")
+            .get_str("$regex")
+            .expect("season regex");
+        let regex = regex::Regex::new(pattern).expect("valid regex");
+        for value in ["1", "1.1", "2", "2.1", "1.2", "2.10"] {
+            assert!(regex.is_match(value), "excluded {value}");
+        }
+        for value in
+            ["", "-1", "0", "3", "3.1", "4", "4.1", "99", "100", "100.1", "10", "21", "1x1", " 1"]
+        {
+            assert!(!regex.is_match(value), "included {value}");
+        }
+    }
+
+    #[test]
+    fn soc_preserves_the_existing_report_scope() {
+        let pipeline = vec![doc! { "$match": { "metadata.kvk": true } }];
+        assert_eq!(CombatLabSeason::Soc.scope_pipeline(pipeline.clone()), pipeline);
+    }
+
+    #[test]
+    fn rage_tables_are_selected_by_season() {
+        assert_eq!(CombatLabSeason::Soc.rage_table(), SOC_RAGE_TABLE);
+        assert_eq!(CombatLabSeason::PreSoc.rage_table(), PRESOC_RAGE_TABLE);
+    }
+
+    #[tokio::test]
+    async fn collections_are_isolated_within_the_reports_database() {
+        // Construct handles only; this test performs no database operations.
+        let client = Client::with_options(ClientOptions::default()).expect("client");
+        let store = ReportsStore::new(client.database("season_test"));
+        for (season, scores, pairings) in [
+            (CombatLabSeason::Soc, "g_rok_prec_drastc", "g_rok_prec_cmdr_pairings_v2"),
+            (
+                CombatLabSeason::PreSoc,
+                "g_rok_prec_drastc_presoc",
+                "g_rok_prec_cmdr_pairings_v2_presoc",
+            ),
+        ] {
+            let score_namespace = season.drastc_collection(&store).namespace();
+            let pairing_namespace = season.pairings_collection(&store).namespace();
+            assert_eq!(score_namespace.db, "season_test");
+            assert_eq!(score_namespace.coll, scores);
+            assert_eq!(pairing_namespace.db, "season_test");
+            assert_eq!(pairing_namespace.coll, pairings);
+        }
+    }
+}

--- a/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
+++ b/crates/apps/rokbattles-jobs/src/combat_lab_season.rs
@@ -93,8 +93,6 @@ fn presoc_collection(store: &ReportsStore, name: &str) -> Collection<Document> {
 
 #[cfg(test)]
 mod tests {
-    use mongodb::{Client, options::ClientOptions};
-
     use super::*;
 
     #[test]
@@ -128,27 +126,5 @@ mod tests {
     fn rage_tables_are_selected_by_season() {
         assert_eq!(CombatLabSeason::Soc.rage_table(), SOC_RAGE_TABLE);
         assert_eq!(CombatLabSeason::PreSoc.rage_table(), PRESOC_RAGE_TABLE);
-    }
-
-    #[tokio::test]
-    async fn collections_are_isolated_within_the_reports_database() {
-        // Construct handles only; this test performs no database operations.
-        let client = Client::with_options(ClientOptions::default()).expect("client");
-        let store = ReportsStore::new(client.database("season_test"));
-        for (season, scores, pairings) in [
-            (CombatLabSeason::Soc, "g_rok_prec_drastc", "g_rok_prec_cmdr_pairings_v2"),
-            (
-                CombatLabSeason::PreSoc,
-                "g_rok_prec_drastc_presoc",
-                "g_rok_prec_cmdr_pairings_v2_presoc",
-            ),
-        ] {
-            let score_namespace = season.drastc_collection(&store).namespace();
-            let pairing_namespace = season.pairings_collection(&store).namespace();
-            assert_eq!(score_namespace.db, "season_test");
-            assert_eq!(score_namespace.coll, scores);
-            assert_eq!(pairing_namespace.db, "season_test");
-            assert_eq!(pairing_namespace.coll, pairings);
-        }
     }
 }

--- a/crates/apps/rokbattles-jobs/src/commander_catalog.rs
+++ b/crates/apps/rokbattles-jobs/src/commander_catalog.rs
@@ -1,51 +1,39 @@
-//! Commander catalog helpers shared by precompute jobs.
+//! Commander rarity and KvK eligibility from the versioned commander dataset.
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
-use crate::error::JobsError;
+use serde::Deserialize;
+
+use crate::{combat_lab_season::CombatLabSeason, error::JobsError};
 
 const COMMANDERS_YAML: &str = include_str!("../../../../datasets/commanders.yaml");
 
-pub(crate) fn combat_lab_commander_ids() -> Result<Vec<i64>, JobsError> {
-    let mut ids = BTreeSet::new();
-    let mut current_id = None;
-    let mut current_is_supported = false;
-
-    for line in COMMANDERS_YAML.lines() {
-        if let Some(id) = parse_top_level_commander_id(line) {
-            if current_is_supported && let Some(previous_id) = current_id {
-                ids.insert(previous_id);
-            }
-
-            current_id = Some(id);
-            current_is_supported = false;
-            continue;
-        }
-
-        if matches!(line.trim(), "rarity: legendary" | "rarity: epic") {
-            current_is_supported = true;
-        }
-    }
-
-    if current_is_supported && let Some(previous_id) = current_id {
-        ids.insert(previous_id);
-    }
-
+pub(crate) fn combat_lab_commander_ids(season: CombatLabSeason) -> Result<Vec<i64>, JobsError> {
+    let dataset: CommanderDataset = yaml_serde::from_str(COMMANDERS_YAML)?;
+    let ids: Vec<_> = dataset
+        .commanders
+        .into_iter()
+        .filter_map(|(id, commander)| {
+            let rarity_supported = matches!(commander.rarity.as_str(), "legendary" | "epic");
+            let season_supported = season == CombatLabSeason::Soc || commander.kvk_limit < 3;
+            (rarity_supported && season_supported).then_some(id)
+        })
+        .collect();
     if ids.is_empty() {
         return Err(JobsError::MissingCombatLabCommanders);
     }
-
-    Ok(ids.into_iter().collect())
+    Ok(ids)
 }
 
-fn parse_top_level_commander_id(line: &str) -> Option<i64> {
-    let rest = line.strip_prefix("  ")?;
-    if rest.starts_with(' ') {
-        return None;
-    }
+#[derive(Deserialize)]
+struct CommanderDataset {
+    commanders: BTreeMap<i64, CommanderDefinition>,
+}
 
-    let id = rest.strip_suffix(':')?;
-    id.parse::<i64>().ok()
+#[derive(Deserialize)]
+struct CommanderDefinition {
+    rarity: String,
+    kvk_limit: u8,
 }
 
 #[cfg(test)]
@@ -54,7 +42,7 @@ mod tests {
 
     #[test]
     fn combat_lab_commander_ids_reads_expected_dataset_values() {
-        let ids = combat_lab_commander_ids().expect("Combat Lab IDs");
+        let ids = combat_lab_commander_ids(CombatLabSeason::Soc).expect("Combat Lab IDs");
 
         assert!(ids.contains(&509));
         assert!(ids.contains(&6));
@@ -65,5 +53,23 @@ mod tests {
         assert!(ids.contains(&537));
         assert!(!ids.contains(&22));
         assert!(!ids.contains(&33));
+    }
+
+    #[test]
+    fn presoc_includes_epic_and_legendary_commanders_below_kvk_limit_three() {
+        let ids = combat_lab_commander_ids(CombatLabSeason::PreSoc).expect("pre-SoC IDs");
+        for id in [3, 6, 64, 536, 537, 618, 627] {
+            assert!(ids.contains(&id), "eligible commander {id} was excluded");
+        }
+        for id in [22, 33, 103, 179, 509, 575, 999_999] {
+            assert!(!ids.contains(&id), "ineligible commander {id} was included");
+        }
+    }
+
+    #[test]
+    fn commander_dataset_requires_kvk_limits() {
+        let result =
+            yaml_serde::from_str::<CommanderDataset>("commanders:\n  3:\n    rarity: epic\n");
+        assert!(result.is_err());
     }
 }

--- a/crates/apps/rokbattles-jobs/src/lib.rs
+++ b/crates/apps/rokbattles-jobs/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Shared code for the jobs.
 
+pub(crate) mod combat_lab_season;
 pub(crate) mod commander_catalog;
 pub mod config;
 pub mod error;

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -15,7 +15,6 @@ use futures::{StreamExt, stream};
 use mongodb::{
     Collection,
     bson::{Bson, DateTime, Document, doc},
-    options::Hint,
 };
 use rokbattles_api::db::ReportsStore;
 use rokbattles_bson::{bson_to_f64, bson_to_i64};
@@ -95,6 +94,7 @@ async fn precompute_for_season(
                 reports_store.battle_collection(),
                 &output,
                 performance_pipeline(&commander_ids, start_ms, end_ms, season),
+                season,
                 generation,
                 &cutoffs,
             )
@@ -231,6 +231,7 @@ async fn read_performance_partition(
     source: &Collection<Document>,
     output: &Collection<Document>,
     pipeline: Vec<Document>,
+    season: CombatLabSeason,
     generation: DateTime,
     cutoffs: &[i64; 4],
 ) -> Result<PerformancePartition, JobsError> {
@@ -238,11 +239,7 @@ async fn read_performance_partition(
         .aggregate(pipeline)
         .allow_disk_use(true)
         .batch_size(1_000)
-        .hint(Hint::Keys(doc! {
-            "metadata.mail_time": -1,
-            "metadata.kvk": 1,
-            "opponents.player_id": 1,
-        }))
+        .hint(season.source_hint())
         .await?;
     let mut writer = BulkWriter::new(output);
     let mut roots = BTreeMap::<PairingKey, PairingRoot>::new();
@@ -309,11 +306,7 @@ async fn read_loadout_partition(
         ))
         .allow_disk_use(true)
         .batch_size(1_000)
-        .hint(Hint::Keys(doc! {
-            "metadata.mail_time": -1,
-            "metadata.kvk": 1,
-            "opponents.player_id": 1,
-        }))
+        .hint(context.season.source_hint())
         .await?;
     let mut writer = BulkWriter::new(context.output);
     let mut governor_last_seen = HashMap::<(PairingKey, i64, i64), i64>::new();

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -26,7 +26,10 @@ use self::{
     model::{MonthLoadouts, PairingKey, PairingRoot, PerformancePoint, RawTotals, range_cutoffs},
     pipeline::{loadout_pipeline, performance_pipeline},
 };
-use crate::{commander_catalog::combat_lab_commander_ids, error::JobsError};
+use crate::{
+    combat_lab_season::CombatLabSeason, commander_catalog::combat_lab_commander_ids,
+    error::JobsError,
+};
 
 const PERFORMANCE_KIND: i64 = 1;
 const LOADOUT_KIND: i64 = 2;
@@ -56,15 +59,30 @@ pub struct CommanderPairingsV2PrecomputeStats {
 pub async fn precompute_commander_pairings_v2_data(
     reports_store: &ReportsStore,
 ) -> Result<CommanderPairingsV2PrecomputeStats, JobsError> {
+    precompute_for_season(reports_store, CombatLabSeason::Soc).await
+}
+
+/// Refresh Season 1/2 Combat Lab data using only pre-SoC scores and reports.
+pub async fn precompute_commander_pairings_v2_presoc_data(
+    reports_store: &ReportsStore,
+) -> Result<CommanderPairingsV2PrecomputeStats, JobsError> {
+    precompute_for_season(reports_store, CombatLabSeason::PreSoc).await
+}
+
+async fn precompute_for_season(
+    reports_store: &ReportsStore,
+    season: CombatLabSeason,
+) -> Result<CommanderPairingsV2PrecomputeStats, JobsError> {
     let started = Instant::now();
     let generation = DateTime::now();
     let now_ms = generation.timestamp_millis();
     let cutoffs = range_cutoffs(now_ms);
     let daily_loadout_cutoff = now_ms - DAILY_LOADOUT_DAYS * model::DAY_MS;
-    let commander_ids = combat_lab_commander_ids()?;
+    let commander_ids = combat_lab_commander_ids(season)?;
     let catalogs = Catalogs::load()?;
-    let output = reports_store.precomputed_commander_pairings_v2_collection();
-    let mut roots = read_stored_drastc(reports_store).await?;
+    let output = season.pairings_collection(reports_store);
+    season.ensure_pairings_indexes(&output).await?;
+    let mut roots = read_stored_drastc(&season.drastc_collection(reports_store)).await?;
     let performance_partitions = time_partitions(cutoffs[0], now_ms, PERFORMANCE_CHUNK_MS);
     let mut documents_written = 0_usize;
     let mut max_document_bytes = 0_usize;
@@ -75,10 +93,8 @@ pub async fn precompute_commander_pairings_v2_data(
         .map(|(start_ms, end_ms)| {
             read_performance_partition(
                 reports_store.battle_collection(),
-                output,
-                &commander_ids,
-                start_ms,
-                end_ms,
+                &output,
+                performance_pipeline(&commander_ids, start_ms, end_ms, season),
                 generation,
                 &cutoffs,
             )
@@ -99,8 +115,9 @@ pub async fn precompute_commander_pairings_v2_data(
     let loadout_partitions = time_partitions(cutoffs[0], now_ms, LOADOUT_CHUNK_MS);
     let loadout_context = LoadoutPartitionContext {
         source: reports_store.battle_collection(),
-        output,
+        output: &output,
         commander_ids: &commander_ids,
+        season,
         daily_cutoff_ms: daily_loadout_cutoff,
         generation,
         catalogs: &catalogs,
@@ -119,7 +136,7 @@ pub async fn precompute_commander_pairings_v2_data(
     let loadout_seconds = loadout_started.elapsed().as_secs();
 
     let pairings = roots.len();
-    let mut writer = BulkWriter::new(output);
+    let mut writer = BulkWriter::new(&output);
     for (key, root) in roots {
         writer.push(root_document(key, root, generation)?).await?;
     }
@@ -145,10 +162,9 @@ pub async fn precompute_commander_pairings_v2_data(
 }
 
 async fn read_stored_drastc(
-    reports_store: &ReportsStore,
+    source: &Collection<Document>,
 ) -> Result<BTreeMap<PairingKey, PairingRoot>, JobsError> {
-    let mut cursor = reports_store
-        .precomputed_drastc_collection()
+    let mut cursor = source
         .find(doc! {})
         .projection(doc! {
             "_id": 0,
@@ -214,14 +230,12 @@ struct PerformancePartition {
 async fn read_performance_partition(
     source: &Collection<Document>,
     output: &Collection<Document>,
-    commander_ids: &[i64],
-    start_ms: i64,
-    end_ms: i64,
+    pipeline: Vec<Document>,
     generation: DateTime,
     cutoffs: &[i64; 4],
 ) -> Result<PerformancePartition, JobsError> {
     let mut cursor = source
-        .aggregate(performance_pipeline(commander_ids, start_ms, end_ms))
+        .aggregate(pipeline)
         .allow_disk_use(true)
         .batch_size(1_000)
         .hint(Hint::Keys(doc! {
@@ -273,6 +287,7 @@ struct LoadoutPartitionContext<'a> {
     source: &'a Collection<Document>,
     output: &'a Collection<Document>,
     commander_ids: &'a [i64],
+    season: CombatLabSeason,
     daily_cutoff_ms: i64,
     generation: DateTime,
     catalogs: &'a Catalogs,
@@ -290,6 +305,7 @@ async fn read_loadout_partition(
             start_ms,
             end_ms,
             context.daily_cutoff_ms,
+            context.season,
         ))
         .allow_disk_use(true)
         .batch_size(1_000)

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
@@ -547,7 +547,11 @@ mod tests {
             assert_eq!(
                 pipeline[0],
                 doc! {
-                    "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                    "$match": { "sender.server_season": { "$in": [
+                    "1", "2",
+                    mongodb::bson::Regex { pattern: r"^1\..*$".into(), options: String::new() },
+                    mongodb::bson::Regex { pattern: r"^2\..*$".into(), options: String::new() },
+                ] } }
                 }
             );
             assert_eq!(

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
@@ -1,6 +1,8 @@
 use mongodb::bson::{Bson, Document, doc};
 use rokbattles_api::db::exclude_test_client_filter;
 
+use crate::combat_lab_season::CombatLabSeason;
+
 const DAY_MS: i64 = 24 * 60 * 60 * 1_000;
 const PERFORMANCE_CHUNK_MS: i64 = 32 * DAY_MS;
 const LOADOUT_CHUNK_MS: i64 = 126 * DAY_MS;
@@ -10,6 +12,7 @@ pub(super) fn performance_pipeline(
     commander_ids: &[i64],
     start_ms: i64,
     end_ms: i64,
+    season: CombatLabSeason,
 ) -> Vec<Document> {
     let mut pipeline =
         pairing_entries_pipeline(commander_ids, start_ms, end_ms, EntryShape::Performance);
@@ -44,7 +47,7 @@ pub(super) fn performance_pipeline(
         },
         doc! { "$project": { "_id": 0, "p": "$_id.p", "s": "$_id.s", "m": "$_id.m", "v": 1 } },
     ]);
-    pipeline
+    season.scope_pipeline(pipeline)
 }
 
 pub(super) fn loadout_pipeline(
@@ -52,6 +55,7 @@ pub(super) fn loadout_pipeline(
     start_ms: i64,
     end_ms: i64,
     daily_cutoff_ms: i64,
+    season: CombatLabSeason,
 ) -> Vec<Document> {
     let mut pipeline =
         pairing_entries_pipeline(commander_ids, start_ms, end_ms, EntryShape::Loadout);
@@ -96,7 +100,7 @@ pub(super) fn loadout_pipeline(
             }
         },
     ]);
-    pipeline
+    season.scope_pipeline(pipeline)
 }
 
 #[derive(Clone, Copy)]
@@ -499,7 +503,7 @@ mod tests {
 
     #[test]
     fn performance_pipeline_groups_once_by_day_instead_of_expanding_time_ranges() {
-        let pipeline = performance_pipeline(&[1, 2], 0, 100);
+        let pipeline = performance_pipeline(&[1, 2], 0, 100, CombatLabSeason::Soc);
         let rendered = format!("{pipeline:?}");
 
         let matcher = pipeline[0].get_document("$match").expect("leading match");
@@ -522,7 +526,7 @@ mod tests {
 
     #[test]
     fn loadout_pipeline_compacts_skill_objects_after_selecting_latest_snapshots() {
-        let pipeline = loadout_pipeline(&[1, 2], 0, 100, 50);
+        let pipeline = loadout_pipeline(&[1, 2], 0, 100, 50, CombatLabSeason::Soc);
         let rendered = format!("{pipeline:?}");
         let top = rendered.find("$top").expect("latest snapshot selection");
         let skill_compaction = rendered.find("$slice").expect("skill compaction");
@@ -532,5 +536,24 @@ mod tests {
         assert!(rendered.contains("[Int64(4), Int64(5)]"));
         assert!(rendered.contains("$$allSkills.level"));
         assert!(rendered.contains("$$this.level"));
+    }
+
+    #[test]
+    fn presoc_performance_and_loadouts_filter_season_before_expanding_opponents() {
+        for pipeline in [
+            performance_pipeline(&[3, 6], 0, 100, CombatLabSeason::PreSoc),
+            loadout_pipeline(&[3, 6], 0, 100, 50, CombatLabSeason::PreSoc),
+        ] {
+            assert_eq!(
+                pipeline[0],
+                doc! {
+                    "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                }
+            );
+            assert_eq!(
+                pipeline[1].get_document("$match").expect("report match").get_bool("metadata.kvk"),
+                Ok(true)
+            );
+        }
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/confidence.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/confidence.rs
@@ -4,7 +4,6 @@ use futures::StreamExt;
 use mongodb::{
     Collection,
     bson::{Document, doc},
-    options::Hint,
 };
 use rokbattles_bson::{bson_to_f64, bson_to_i64};
 use rokbattles_drastc::DrastcConfidence;
@@ -22,15 +21,8 @@ pub(super) async fn read_pairing_confidences(
     season: CombatLabSeason,
 ) -> Result<BTreeMap<PairingKey, DrastcConfidence>, JobsError> {
     let pipeline = build_confidence_pipeline(supported_pairings, cutoff_mail_time, season);
-    let mut cursor = source
-        .aggregate(pipeline)
-        .allow_disk_use(true)
-        .hint(Hint::Keys(doc! {
-            "metadata.mail_time": -1,
-            "metadata.kvk": 1,
-            "opponents.player_id": 1,
-        }))
-        .await?;
+    let mut cursor =
+        source.aggregate(pipeline).allow_disk_use(true).hint(season.source_hint()).await?;
     let mut confidences = BTreeMap::new();
 
     while let Some(next) = cursor.next().await {
@@ -173,7 +165,11 @@ mod tests {
         assert_eq!(
             pipeline[0],
             doc! {
-                "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                "$match": { "sender.server_season": { "$in": [
+                    "1", "2",
+                    mongodb::bson::Regex { pattern: r"^1\..*$".into(), options: String::new() },
+                    mongodb::bson::Regex { pattern: r"^2\..*$".into(), options: String::new() },
+                ] } }
             }
         );
         assert_eq!(

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/confidence.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/confidence.rs
@@ -13,14 +13,15 @@ use super::{
     model::{PairingKey, Strategy},
     pipeline::build_supported_pairing_entries_pipeline,
 };
-use crate::error::JobsError;
+use crate::{combat_lab_season::CombatLabSeason, error::JobsError};
 
 pub(super) async fn read_pairing_confidences(
     source: &Collection<Document>,
     supported_pairings: &[PairingKey],
     cutoff_mail_time: i64,
+    season: CombatLabSeason,
 ) -> Result<BTreeMap<PairingKey, DrastcConfidence>, JobsError> {
-    let pipeline = build_confidence_pipeline(supported_pairings, cutoff_mail_time);
+    let pipeline = build_confidence_pipeline(supported_pairings, cutoff_mail_time, season);
     let mut cursor = source
         .aggregate(pipeline)
         .allow_disk_use(true)
@@ -44,6 +45,7 @@ pub(super) async fn read_pairing_confidences(
 pub(super) fn build_confidence_pipeline(
     supported_pairings: &[PairingKey],
     cutoff_mail_time: i64,
+    season: CombatLabSeason,
 ) -> Vec<Document> {
     let mut pipeline =
         build_supported_pairing_entries_pipeline(supported_pairings, cutoff_mail_time);
@@ -91,7 +93,7 @@ pub(super) fn build_confidence_pipeline(
             }
         },
     ]);
-    pipeline
+    season.scope_pipeline(pipeline)
 }
 
 fn map_confidence_document(document: &Document) -> Option<(PairingKey, DrastcConfidence)> {
@@ -126,7 +128,8 @@ mod tests {
     fn confidence_pipeline_groups_open_field_battles_by_governor_then_pairing() {
         let pairing = PairingKey { primary_commander_id: 595, secondary_commander_id: 596 };
         let cutoff_mail_time = 1_755_000_000_000_000_i64;
-        let pipeline = build_confidence_pipeline(&[pairing], cutoff_mail_time);
+        let pipeline =
+            build_confidence_pipeline(&[pairing], cutoff_mail_time, CombatLabSeason::Soc);
         let group_count = pipeline.iter().filter(|stage| stage.contains_key("$group")).count();
         let pairing_match = pipeline
             .iter()
@@ -161,5 +164,21 @@ mod tests {
         assert_eq!(key, PairingKey { primary_commander_id: 595, secondary_commander_id: 596 });
         assert_eq!(confidence.unique_governors, 816);
         assert!((confidence.effective_governors - 28.41).abs() < 0.005);
+    }
+
+    #[test]
+    fn presoc_confidence_uses_the_same_report_season_scope_as_scores() {
+        let pairing = PairingKey { primary_commander_id: 3, secondary_commander_id: 6 };
+        let pipeline = build_confidence_pipeline(&[pairing], 100, CombatLabSeason::PreSoc);
+        assert_eq!(
+            pipeline[0],
+            doc! {
+                "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+            }
+        );
+        assert_eq!(
+            pipeline[1].get_document("$match").expect("report match").get_bool("metadata.kvk"),
+            Ok(true)
+        );
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
@@ -1,8 +1,7 @@
 use futures::StreamExt;
 use mongodb::{
     Collection,
-    bson::{Bson, Document, doc},
-    options::Hint,
+    bson::{Bson, Document},
 };
 use rokbattles_bson::{bson_to_f64, bson_to_i64};
 use rokbattles_drastc::{DrastcReferenceRanges, ReferenceRange};
@@ -22,9 +21,7 @@ pub(super) async fn read_drastc_aggregation(
     let mut cursor = source
         .aggregate(build_drastc_pipeline(commander_ids, cutoff_mail_time, season))
         .allow_disk_use(true)
-        .hint(Hint::Keys(
-            doc! { "metadata.mail_time": -1, "metadata.kvk": 1, "opponents.player_id": 1 },
-        ))
+        .hint(season.source_hint())
         .await?;
     let mut aggregation = DrastcAggregation::default();
     while let Some(next) = cursor.next().await {

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mapper.rs
@@ -11,15 +11,16 @@ use super::{
     model::{DrastcAggregation, PairingKey, PairingRawTotals},
     pipeline::build_drastc_pipeline,
 };
-use crate::error::JobsError;
+use crate::{combat_lab_season::CombatLabSeason, error::JobsError};
 
 pub(super) async fn read_drastc_aggregation(
     source: &Collection<Document>,
     commander_ids: &[i64],
     cutoff_mail_time: i64,
+    season: CombatLabSeason,
 ) -> Result<DrastcAggregation, JobsError> {
     let mut cursor = source
-        .aggregate(build_drastc_pipeline(commander_ids, cutoff_mail_time))
+        .aggregate(build_drastc_pipeline(commander_ids, cutoff_mail_time, season))
         .allow_disk_use(true)
         .hint(Hint::Keys(
             doc! { "metadata.mail_time": -1, "metadata.kvk": 1, "opponents.player_id": 1 },

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
@@ -20,7 +20,10 @@ use self::{
     output::build_drastc_document,
     scoring::{build_drastc_scores_from_aggregates, supported_drastc_pairings},
 };
-use crate::{commander_catalog::combat_lab_commander_ids, error::JobsError};
+use crate::{
+    combat_lab_season::CombatLabSeason, commander_catalog::combat_lab_commander_ids,
+    error::JobsError,
+};
 
 const BULK_WRITE_BATCH_SIZE: usize = 1_000;
 const RANKING_WINDOW_DAYS: i64 = 365;
@@ -42,25 +45,44 @@ pub struct DrastcPrecomputeStats {
 pub async fn precompute_drastc_data(
     reports_store: &ReportsStore,
 ) -> Result<DrastcPrecomputeStats, JobsError> {
+    precompute_for_season(reports_store, CombatLabSeason::Soc).await
+}
+
+/// Refresh Season 1/2 scores using the pre-SoC rage table and isolated storage.
+pub async fn precompute_drastc_presoc_data(
+    reports_store: &ReportsStore,
+) -> Result<DrastcPrecomputeStats, JobsError> {
+    precompute_for_season(reports_store, CombatLabSeason::PreSoc).await
+}
+
+async fn precompute_for_season(
+    reports_store: &ReportsStore,
+    season: CombatLabSeason,
+) -> Result<DrastcPrecomputeStats, JobsError> {
+    let output = season.drastc_collection(reports_store);
+    season.ensure_drastc_index(&output).await?;
     let refreshed_at = DateTime::now();
     let cutoff_mail_time = ranking_cutoff_mail_time(refreshed_at);
-    let commander_ids = combat_lab_commander_ids()?;
+    let commander_ids = combat_lab_commander_ids(season)?;
     let aggregation = read_drastc_aggregation(
         reports_store.battle_collection(),
         &commander_ids,
         cutoff_mail_time,
+        season,
     )
     .await?;
-    let supported_pairings = supported_drastc_pairings(&commander_ids);
+    let supported_pairings = supported_drastc_pairings(&commander_ids, season.rage_table());
     let scores = build_drastc_scores_from_aggregates(
         &aggregation.observed,
         &supported_pairings,
         aggregation.reference_ranges,
+        season.rage_table(),
     );
     let confidences = read_pairing_confidences(
         reports_store.battle_collection(),
         &supported_pairings,
         cutoff_mail_time,
+        season,
     )
     .await?;
     let documents = scores
@@ -71,10 +93,9 @@ pub async fn precompute_drastc_data(
             })
         })
         .collect();
-    let output = reports_store.precomputed_drastc_collection();
-    let documents_written = write_documents(output, documents).await?;
+    let documents_written = write_documents(&output, documents).await?;
     output.delete_many(doc! { "refreshed_at": { "$ne": refreshed_at } }).await?;
-    let documents_stored = validate_materialized_data(output, documents_written).await?;
+    let documents_stored = validate_materialized_data(&output, documents_written).await?;
 
     Ok(DrastcPrecomputeStats {
         supported_commanders: commander_ids.len(),

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
@@ -948,7 +948,11 @@ mod tests {
         assert_eq!(
             pipeline[0],
             doc! {
-                "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+                "$match": { "sender.server_season": { "$in": [
+                    "1", "2",
+                    mongodb::bson::Regex { pattern: r"^1\..*$".into(), options: String::new() },
+                    mongodb::bson::Regex { pattern: r"^2\..*$".into(), options: String::new() },
+                ] } }
             }
         );
         assert_eq!(

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
@@ -4,10 +4,15 @@ use mongodb::bson::{Bson, Document, doc};
 use rokbattles_api::db::exclude_test_client_filter;
 
 use super::model::{PairingKey, Strategy};
+use crate::combat_lab_season::CombatLabSeason;
 
 const MIN_REFERENCE_RANGE_PAIRING_BATTLES: i64 = 5_000;
 
-pub(super) fn build_drastc_pipeline(commander_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
+pub(super) fn build_drastc_pipeline(
+    commander_ids: &[i64],
+    cutoff_mail_time: i64,
+    season: CombatLabSeason,
+) -> Vec<Document> {
     let mut pipeline = build_pairing_entries_pipeline(commander_ids, cutoff_mail_time);
     pipeline.extend([
         doc! { "$match": { "strategy": Strategy::OpenField.as_str() } },
@@ -20,7 +25,7 @@ pub(super) fn build_drastc_pipeline(commander_ids: &[i64], cutoff_mail_time: i64
         reference_window_stage(),
         drastc_output_project_stage(),
     ]);
-    pipeline
+    season.scope_pipeline(pipeline)
 }
 
 fn build_pairing_entries_pipeline(commander_ids: &[i64], cutoff_mail_time: i64) -> Vec<Document> {
@@ -688,7 +693,7 @@ mod tests {
     #[test]
     fn build_drastc_pipeline_starts_with_indexable_kvk_filter() {
         let cutoff_mail_time = 1_755_000_000_000_000_i64;
-        let pipeline = build_drastc_pipeline(&[509, 6], cutoff_mail_time);
+        let pipeline = build_drastc_pipeline(&[509, 6], cutoff_mail_time, CombatLabSeason::Soc);
         let matcher = pipeline
             .first()
             .and_then(|stage| stage.get_document("$match").ok())
@@ -714,7 +719,8 @@ mod tests {
 
     #[test]
     fn build_drastc_pipeline_streams_pairing_documents_without_facets() {
-        let pipeline = build_drastc_pipeline(&[509, 6], 1_755_000_000_000_000_i64);
+        let pipeline =
+            build_drastc_pipeline(&[509, 6], 1_755_000_000_000_000_i64, CombatLabSeason::Soc);
         let group_count = pipeline.iter().filter(|stage| stage.contains_key("$group")).count();
 
         assert_eq!(group_count, 1);
@@ -934,5 +940,21 @@ mod tests {
                 }
             }
         );
+    }
+
+    #[test]
+    fn presoc_aggregation_filters_sender_season_before_extracting_pairings() {
+        let pipeline = build_drastc_pipeline(&[3, 6], 100, CombatLabSeason::PreSoc);
+        assert_eq!(
+            pipeline[0],
+            doc! {
+                "$match": { "sender.server_season": { "$regex": r"^[12](?:\..*)?$" } }
+            }
+        );
+        assert_eq!(
+            pipeline[1].get_document("$match").expect("report match").get_bool("metadata.kvk"),
+            Ok(true)
+        );
+        assert!(format!("{pipeline:?}").contains("$setWindowFields"));
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use rokbattles_drastc::{DrastcModel, DrastcReferenceRanges, DrastcScore, SOC_RAGE_TABLE};
+use rokbattles_drastc::{DrastcModel, DrastcReferenceRanges, DrastcScore, RageTable};
 
 use super::model::{PairingKey, PairingRawTotals};
 
@@ -8,6 +8,7 @@ pub(super) fn build_drastc_scores_from_aggregates(
     observed: &BTreeMap<PairingKey, PairingRawTotals>,
     supported_pairings: &[PairingKey],
     reference_ranges: DrastcReferenceRanges,
+    rage_table: RageTable,
 ) -> BTreeMap<PairingKey, DrastcScore> {
     let mut scores = BTreeMap::new();
 
@@ -17,7 +18,7 @@ pub(super) fn build_drastc_scores_from_aggregates(
         };
 
         let mut model = DrastcModel::new();
-        model.set_rage_table(SOC_RAGE_TABLE);
+        model.set_rage_table(rage_table);
         model.set_reference_ranges(reference_ranges);
         model.set_theoretical(key.primary_commander_id as u32, key.secondary_commander_id as u32);
         model.push(raw.to_drastc_record());
@@ -30,14 +31,17 @@ pub(super) fn build_drastc_scores_from_aggregates(
     scores
 }
 
-pub(super) fn supported_drastc_pairings(commander_ids: &[i64]) -> Vec<PairingKey> {
+pub(super) fn supported_drastc_pairings(
+    commander_ids: &[i64],
+    rage_table: RageTable,
+) -> Vec<PairingKey> {
     ordered_pairing_keys(commander_ids)
         .filter(|key| {
             u32::try_from(key.primary_commander_id)
                 .ok()
                 .zip(u32::try_from(key.secondary_commander_id).ok())
                 .is_some_and(|(primary, secondary)| {
-                    DrastcModel::is_supported(SOC_RAGE_TABLE, primary, secondary)
+                    DrastcModel::is_supported(rage_table, primary, secondary)
                 })
         })
         .collect()
@@ -53,13 +57,15 @@ fn ordered_pairing_keys(commander_ids: &[i64]) -> impl Iterator<Item = PairingKe
 
 #[cfg(test)]
 mod tests {
-    use rokbattles_drastc::{DrastcReferenceRanges, ReferenceRange};
+    use rokbattles_drastc::{
+        DrastcReferenceRanges, PRESOC_RAGE_TABLE, ReferenceRange, SOC_RAGE_TABLE,
+    };
 
     use super::*;
 
     #[test]
     fn supported_drastc_pairings_returns_only_model_supported_pairings() {
-        let keys = supported_drastc_pairings(&[575, 579, 540]);
+        let keys = supported_drastc_pairings(&[575, 579, 540], SOC_RAGE_TABLE);
 
         assert!(
             keys.contains(&PairingKey { primary_commander_id: 579, secondary_commander_id: 575 })
@@ -98,11 +104,46 @@ mod tests {
             consistency: ReferenceRange::new(10, 0.0, 1.0),
         };
 
-        let scores = build_drastc_scores_from_aggregates(&observed, &[key], ranges);
+        let scores = build_drastc_scores_from_aggregates(&observed, &[key], ranges, SOC_RAGE_TABLE);
 
         let score = scores.get(&key).expect("drastc score");
         assert_eq!(score.samples, 2);
         assert_eq!(score.breakdown.rage.value, 8.0);
         assert_eq!(score.breakdown.assist.value, 14.24);
+    }
+
+    #[test]
+    fn presoc_table_pairings_are_eligible_and_use_presoc_rage_values() {
+        use crate::{
+            combat_lab_season::CombatLabSeason, commander_catalog::combat_lab_commander_ids,
+        };
+        let ids = combat_lab_commander_ids(CombatLabSeason::PreSoc).expect("pre-SoC commanders");
+        let keys = supported_drastc_pairings(&ids, PRESOC_RAGE_TABLE);
+        assert_eq!(keys.len(), PRESOC_RAGE_TABLE.len());
+        let key = PairingKey { primary_commander_id: 3, secondary_commander_id: 6 };
+        assert!(keys.contains(&key));
+        assert!(!supported_drastc_pairings(&ids, SOC_RAGE_TABLE).contains(&key));
+        let observed = BTreeMap::from([(
+            key,
+            PairingRawTotals {
+                total_battles: 10,
+                kill_points_gained: 100,
+                kill_points_lost: 50,
+                normalized_duration_seconds_total: 100.0,
+                ..Default::default()
+            },
+        )]);
+        let scores = build_drastc_scores_from_aggregates(
+            &observed,
+            &keys,
+            DrastcReferenceRanges {
+                damage: ReferenceRange::new(10, 0.0, 4.0),
+                sustainability: ReferenceRange::new(10, -2.0, 2.0),
+                trade: ReferenceRange::new(10, 0.0, 2.0),
+                consistency: ReferenceRange::new(10, 0.0, 1.0),
+            },
+            PRESOC_RAGE_TABLE,
+        );
+        assert_eq!(scores.get(&key).expect("Sun Tzu/YSG score").breakdown.rage.value, 7.5);
     }
 }

--- a/crates/apps/rokbattles-jobs/src/scheduler.rs
+++ b/crates/apps/rokbattles-jobs/src/scheduler.rs
@@ -8,11 +8,14 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::{error, info, warn};
 
 use crate::{
-    error::JobsError, precompute_barbarian::precompute_barbarian_data,
+    error::JobsError,
+    precompute_barbarian::precompute_barbarian_data,
     precompute_barbarianfort::precompute_barbarian_fort_data,
     precompute_baulur::precompute_baulur_data,
-    precompute_cmdr_pairings_v2::precompute_commander_pairings_v2_data,
-    precompute_drastc::precompute_drastc_data,
+    precompute_cmdr_pairings_v2::{
+        precompute_commander_pairings_v2_data, precompute_commander_pairings_v2_presoc_data,
+    },
+    precompute_drastc::{precompute_drastc_data, precompute_drastc_presoc_data},
     precompute_kahar_treasure::precompute_kahar_treasure_data,
     precompute_karuak_ceremony::precompute_karuak_ceremony_data,
     refresh_binds::refresh_claimed_governor_bindings,
@@ -31,28 +34,20 @@ pub const PRECOMPUTE_KAHAR_TREASURE_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
 pub const PRECOMPUTE_KARUAK_CEREMONY_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
-pub const PRECOMPUTE_DRASTC_CRON: &str = "0 0 */8 * * *";
+pub const PRECOMPUTE_SOC_CRON: &str = "0 0 */8 * * *";
 /// Every 8 hours
-pub const PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON: &str = "0 0 */8 * * *";
+pub const PRECOMPUTE_PRESOC_CRON: &str = "0 0 */8 * * *";
 
 /// Create the scheduler with the governor bind refresh job registered.
 pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler, JobsError> {
     let scheduler = JobScheduler::new().await?;
     let reports_store = Arc::new(reports_store);
-    let refresh_lock = Arc::new(Mutex::new(()));
-    let barbarian_lock = Arc::new(Mutex::new(()));
-    let barbarian_fort_lock = Arc::new(Mutex::new(()));
-    let baulur_lock = Arc::new(Mutex::new(()));
-    let kahar_treasure_lock = Arc::new(Mutex::new(()));
-    let karuak_ceremony_lock = Arc::new(Mutex::new(()));
-    let drastc_lock = Arc::new(Mutex::new(()));
-    let commander_pairings_v2_lock = Arc::new(Mutex::new(()));
 
     add_locked_job(
         &scheduler,
         REFRESH_BINDS_CRON,
         Arc::clone(&reports_store),
-        refresh_lock,
+        Arc::new(Mutex::new(())),
         "governor bind refresh is already running; skipping this tick",
         |reports_store| async move {
             match refresh_claimed_governor_bindings(&reports_store).await {
@@ -77,7 +72,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         &scheduler,
         PRECOMPUTE_KARUAK_CEREMONY_CRON,
         Arc::clone(&reports_store),
-        karuak_ceremony_lock,
+        Arc::new(Mutex::new(())),
         "Karuak Ceremony precompute is already running; skipping this tick",
         |reports_store| async move {
             match precompute_karuak_ceremony_data(&reports_store).await {
@@ -97,7 +92,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         &scheduler,
         PRECOMPUTE_BARBARIAN_CRON,
         Arc::clone(&reports_store),
-        barbarian_lock,
+        Arc::new(Mutex::new(())),
         "barbarian precompute is already running; skipping this tick",
         |reports_store| async move {
             match precompute_barbarian_data(&reports_store).await {
@@ -121,7 +116,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         &scheduler,
         PRECOMPUTE_BARBARIAN_FORT_CRON,
         Arc::clone(&reports_store),
-        barbarian_fort_lock,
+        Arc::new(Mutex::new(())),
         "barbarian fort precompute is already running; skipping this tick",
         |reports_store| async move {
             match precompute_barbarian_fort_data(&reports_store).await {
@@ -145,7 +140,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         &scheduler,
         PRECOMPUTE_BAULUR_CRON,
         Arc::clone(&reports_store),
-        baulur_lock,
+        Arc::new(Mutex::new(())),
         "Baulur precompute is already running; skipping this tick",
         |reports_store| async move {
             match precompute_baulur_data(&reports_store).await {
@@ -169,7 +164,7 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
         &scheduler,
         PRECOMPUTE_KAHAR_TREASURE_CRON,
         Arc::clone(&reports_store),
-        kahar_treasure_lock,
+        Arc::new(Mutex::new(())),
         "Kahar treasure precompute is already running; skipping this tick",
         |reports_store| async move {
             match precompute_kahar_treasure_data(&reports_store).await {
@@ -189,28 +184,25 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
     )
     .await?;
 
+    // Keep the dependent jobs in one locked cycle so pairing roots use this cycle's scores.
     add_locked_job(
         &scheduler,
-        PRECOMPUTE_DRASTC_CRON,
+        PRECOMPUTE_SOC_CRON,
         Arc::clone(&reports_store),
-        drastc_lock,
-        "DRASTC precompute is already running; skipping this tick",
+        Arc::new(Mutex::new(())),
+        "SoC DRASTC and commander pairings are already running; skipping this tick",
         |reports_store| async move {
             match precompute_drastc_data(&reports_store).await {
-                Ok(stats) => {
-                    info!(
-                        supported_commanders = stats.supported_commanders,
-                        observed_pairings = stats.observed_pairings,
-                        supported_pairings = stats.supported_pairings,
-                        scored_pairings = stats.scored_pairings,
-                        confidence_scored_pairings = stats.confidence_scored_pairings,
-                        documents_written = stats.documents_written,
-                        documents_stored = stats.documents_stored,
-                        "precomputed DRASTC data"
-                    );
-                }
+                Ok(stats) => info!(?stats, "precomputed SoC DRASTC data"),
                 Err(error) => {
-                    error!(%error, "failed to precompute DRASTC data");
+                    error!(%error, "failed to precompute SoC DRASTC; skipping dependent pairings");
+                    return;
+                }
+            }
+            match precompute_commander_pairings_v2_data(&reports_store).await {
+                Ok(stats) => info!(?stats, "precomputed SoC compact commander pairings data"),
+                Err(error) => {
+                    error!(%error, "failed to precompute SoC compact commander pairings data")
                 }
             }
         },
@@ -219,27 +211,21 @@ pub async fn build_scheduler(reports_store: ReportsStore) -> Result<JobScheduler
 
     add_locked_job(
         &scheduler,
-        PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON,
+        PRECOMPUTE_PRESOC_CRON,
         reports_store,
-        commander_pairings_v2_lock,
-        "compact commander pairings precompute is already running; skipping this tick",
+        Arc::new(Mutex::new(())),
+        "pre-SoC DRASTC and commander pairings are already running; skipping this tick",
         |reports_store| async move {
-            match precompute_commander_pairings_v2_data(&reports_store).await {
-                Ok(stats) => info!(
-                    supported_commanders = stats.supported_commanders,
-                    pairings = stats.pairings,
-                    performance_points = stats.performance_points,
-                    loadout_snapshots = stats.loadout_snapshots,
-                    documents_written = stats.documents_written,
-                    max_document_bytes = stats.max_document_bytes,
-                    performance_seconds = stats.performance_seconds,
-                    loadout_seconds = stats.loadout_seconds,
-                    total_seconds = stats.total_seconds,
-                    "precomputed compact commander pairings data"
-                ),
+            match precompute_drastc_presoc_data(&reports_store).await {
+                Ok(stats) => info!(?stats, "precomputed pre-SoC DRASTC data"),
                 Err(error) => {
-                    error!(%error, "failed to precompute compact commander pairings data")
+                    error!(%error, "failed to precompute pre-SoC DRASTC; skipping dependent pairings");
+                    return;
                 }
+            }
+            match precompute_commander_pairings_v2_presoc_data(&reports_store).await {
+                Ok(stats) => info!(?stats, "precomputed pre-SoC compact commander pairings data"),
+                Err(error) => error!(%error, "failed to precompute pre-SoC compact commander pairings data"),
             }
         },
     )
@@ -284,8 +270,8 @@ where
 mod tests {
     use super::{
         PRECOMPUTE_BARBARIAN_CRON, PRECOMPUTE_BARBARIAN_FORT_CRON, PRECOMPUTE_BAULUR_CRON,
-        PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON, PRECOMPUTE_DRASTC_CRON,
-        PRECOMPUTE_KAHAR_TREASURE_CRON, PRECOMPUTE_KARUAK_CEREMONY_CRON, REFRESH_BINDS_CRON,
+        PRECOMPUTE_KAHAR_TREASURE_CRON, PRECOMPUTE_KARUAK_CEREMONY_CRON, PRECOMPUTE_SOC_CRON,
+        REFRESH_BINDS_CRON,
     };
 
     #[test]
@@ -314,17 +300,17 @@ mod tests {
     }
 
     #[test]
-    fn precompute_drastc_cron_runs_every_eight_hours_utc() {
-        assert_eq!(PRECOMPUTE_DRASTC_CRON, "0 0 */8 * * *");
-    }
-
-    #[test]
-    fn compact_commander_pairings_cron_is_synchronized_with_drastc() {
-        assert_eq!(PRECOMPUTE_COMMANDER_PAIRINGS_V2_CRON, PRECOMPUTE_DRASTC_CRON);
+    fn soc_refresh_cycle_runs_every_eight_hours_utc() {
+        assert_eq!(PRECOMPUTE_SOC_CRON, "0 0 */8 * * *");
     }
 
     #[test]
     fn precompute_karuak_ceremony_cron_runs_every_eight_hours_utc() {
         assert_eq!(PRECOMPUTE_KARUAK_CEREMONY_CRON, "0 0 */8 * * *");
+    }
+
+    #[test]
+    fn presoc_refresh_cycle_runs_every_eight_hours_utc() {
+        assert_eq!(super::PRECOMPUTE_PRESOC_CRON, "0 0 */8 * * *");
     }
 }


### PR DESCRIPTION
Add pre-SoC DRASTC and Combat Lab pairing refreshes for Season 1/2 reports. Both select epic and legendary commanders with `kvk_limit < 3` and filter `sender.server_season` to `1`, `2`, and their dot-suffixed variants, matching the report API's season semantics.

- Score with `PRESOC_RAGE_TABLE` and write to `g_rok_prec_drastc_presoc`.
- Generate compact pairing data in `g_rok_prec_cmdr_pairings_v2_presoc`, reading scores only from the pre-SoC collection.
- Apply the same season scope to score aggregation, confidence, performance, and loadouts; create indexes for the new output collections.
- Use exact season values and literal dot prefixes with the existing season index for pre-SoC queries. Keep the existing time index hint for SoC.
- Run each SoC/pre-SoC cycle every eight hours under its own lock: DRASTC first, then pairings. Skip dependent pairings if DRASTC fails, and skip overlapping ticks.

Stacked on #903. No site or API endpoint changes. No additional report-source index is required, and temporary execution tooling is excluded.

Validation: all 81 job tests, Jobs Clippy, Rust formatting, and diff checks pass. A one-day execution-statistics comparison returned identical results while the optimized pre-SoC query examined 98.6% fewer index keys and 94.3% fewer documents. Full 365-day refresh cycles completed successfully for both eras; verified fresh generations, commander eligibility, epic pairings, and API responses. SoC published 57 scores and 7,512 pairings; pre-SoC published 18 scores and 1,425 pairings.
