### PR TITLE
feat(combat-lab): add pre-SoC exploration and rankings

### DIFF
--- a/crates/apps/rokbattles-api/src/db/reports_store.rs
+++ b/crates/apps/rokbattles-api/src/db/reports_store.rs
@@ -34,7 +34,9 @@ pub struct ReportsStore {
     g_rok_prec_kahartreasure: Collection<Document>,
     g_rok_prec_karuakceremony: Collection<Document>,
     g_rok_prec_drastc: Collection<Document>,
+    g_rok_prec_drastc_presoc: Collection<Document>,
     g_rok_prec_cmdr_pairings_v2: Collection<Document>,
+    g_rok_prec_cmdr_pairings_v2_presoc: Collection<Document>,
 }
 
 impl ReportsStore {
@@ -59,7 +61,9 @@ impl ReportsStore {
             g_rok_prec_kahartreasure: db.collection("g_rok_prec_kahartreasure"),
             g_rok_prec_karuakceremony: db.collection("g_rok_prec_karuakceremony"),
             g_rok_prec_drastc: db.collection("g_rok_prec_drastc"),
+            g_rok_prec_drastc_presoc: db.collection("g_rok_prec_drastc_presoc"),
             g_rok_prec_cmdr_pairings_v2: db.collection("g_rok_prec_cmdr_pairings_v2"),
+            g_rok_prec_cmdr_pairings_v2_presoc: db.collection("g_rok_prec_cmdr_pairings_v2_presoc"),
         }
     }
 
@@ -571,6 +575,16 @@ impl ReportsStore {
     /// Access materialized DRASTC scores for Combat Lab.
     pub fn precomputed_drastc_collection(&self) -> &Collection<Document> {
         &self.g_rok_prec_drastc
+    }
+
+    /// Access materialized pre-SoC DRASTC scores for Combat Lab.
+    pub fn precomputed_drastc_presoc_collection(&self) -> &Collection<Document> {
+        &self.g_rok_prec_drastc_presoc
+    }
+
+    /// Access compact, chunked pre-SoC Combat Lab commander pairing aggregates.
+    pub fn precomputed_commander_pairings_v2_presoc_collection(&self) -> &Collection<Document> {
+        &self.g_rok_prec_cmdr_pairings_v2_presoc
     }
 
     /// Access compact, chunked Combat Lab commander pairing aggregates.

--- a/crates/apps/rokbattles-api/src/routes/combat_lab.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab.rs
@@ -11,6 +11,7 @@ use axum::{
 };
 use futures::TryStreamExt;
 use mongodb::{
+    Collection,
     bson::{Bson, DateTime, Document, doc},
     options::{FindOneOptions, FindOptions},
 };
@@ -77,13 +78,32 @@ pub async fn get_pairing(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let primary = parse_required_i64(&params, "primary")?;
-    let secondary = parse_required_i64(&params, "secondary")?;
+    pairing_response(state.reports_store.precomputed_commander_pairings_v2_collection(), &params)
+        .await
+}
+
+/// Return one completed pre-SoC Combat Lab generation.
+pub async fn get_pairing_presoc(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, ApiError> {
+    pairing_response(
+        state.reports_store.precomputed_commander_pairings_v2_presoc_collection(),
+        &params,
+    )
+    .await
+}
+
+async fn pairing_response(
+    collection: &Collection<Document>,
+    params: &HashMap<String, String>,
+) -> Result<impl IntoResponse + use<>, ApiError> {
+    let primary = parse_required_i64(params, "primary")?;
+    let secondary = parse_required_i64(params, "secondary")?;
     if primary == secondary {
         return Err(ApiError::bad_request("Commanders must be different"));
     }
 
-    let collection = state.reports_store.precomputed_commander_pairings_v2_collection();
     let root_options =
         FindOneOptions::builder().projection(doc! { "_id": 0 }).sort(doc! { "g": -1 }).build();
     let Some(root) = collection
@@ -147,11 +167,23 @@ pub async fn get_rankings(
     State(state): State<Arc<AppState>>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let request = parse_rankings_request(&params)?;
-    let collection = state
-        .reports_store
-        .precomputed_drastc_collection()
-        .clone_with_type::<RawCombatLabRankingDocument>();
+    rankings_response(state.reports_store.precomputed_drastc_collection(), &params).await
+}
+
+/// Return pre-SoC DRASTC rankings.
+pub async fn get_rankings_presoc(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, ApiError> {
+    rankings_response(state.reports_store.precomputed_drastc_presoc_collection(), &params).await
+}
+
+async fn rankings_response(
+    collection: &Collection<Document>,
+    params: &HashMap<String, String>,
+) -> Result<impl IntoResponse + use<>, ApiError> {
+    let request = parse_rankings_request(params)?;
+    let collection = collection.clone_with_type::<RawCombatLabRankingDocument>();
     let cursor = collection
         .find(doc! {})
         .with_options(rankings_find_options(request))

--- a/crates/apps/rokbattles-api/src/routes/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/mod.rs
@@ -25,6 +25,8 @@ fn v2_router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/global/combat-lab", get(combat_lab::get_pairing))
         .route("/global/combat-lab/rankings", get(combat_lab::get_rankings))
+        .route("/global/combat-lab/presoc", get(combat_lab::get_pairing_presoc))
+        .route("/global/combat-lab/rankings/presoc", get(combat_lab::get_rankings_presoc))
 }
 
 fn v1_router() -> Router<Arc<AppState>> {

--- a/packages/site/src/app/(legacy)/combat-lab/presoc/page.tsx
+++ b/packages/site/src/app/(legacy)/combat-lab/presoc/page.tsx
@@ -3,5 +3,5 @@ import { CombatLabPage } from "@/components/combat-lab/combat-lab-page";
 export default function Page(props: {
   searchParams: Promise<{ primary?: string; secondary?: string }>;
 }) {
-  return <CombatLabPage {...props} season="soc" />;
+  return <CombatLabPage {...props} season="presoc" />;
 }

--- a/packages/site/src/app/(legacy)/combat-lab/presoc/rankings/page.tsx
+++ b/packages/site/src/app/(legacy)/combat-lab/presoc/rankings/page.tsx
@@ -1,0 +1,5 @@
+import { CombatLabRankingsContent } from "@/components/combat-lab/combat-lab-rankings-content";
+
+export default function Page() {
+  return <CombatLabRankingsContent />;
+}

--- a/packages/site/src/components/combat-lab/combat-lab-header.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-header.tsx
@@ -2,8 +2,11 @@
 
 import { cn } from "cnfast";
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import { useExtracted } from "next-intl";
+import { Listbox, ListboxOption } from "@/components/ui/listbox";
 import { Text } from "@/components/ui/text";
+import { type CombatLabSeason, combatLabPath, combatLabSeason } from "@/lib/combat-lab/season";
 
 type CombatLabHeaderProps = {
   active: "explore" | "rankings";
@@ -11,12 +14,19 @@ type CombatLabHeaderProps = {
 };
 
 const sections = [
-  { key: "explore", href: "/combat-lab" },
-  { key: "rankings", href: "/combat-lab/rankings" },
+  { key: "explore", suffix: "" },
+  { key: "rankings", suffix: "/rankings" },
 ] as const;
 
 export function CombatLabHeader({ active, children }: CombatLabHeaderProps) {
   const t = useExtracted();
+  const season = combatLabSeason(usePathname());
+  const router = useRouter();
+  const labels = { soc: t("Season of Conquest"), presoc: t("Pre-Season of Conquest") };
+  const changeSeason = (next: CombatLabSeason) => {
+    const path = `${combatLabPath(next)}${active === "rankings" ? "/rankings" : ""}`;
+    router.push(path);
+  };
 
   return (
     <header className="relative -mx-6 -mt-6 overflow-hidden border-zinc-950/10 border-b bg-zinc-950 text-white lg:-mx-10 lg:-mt-10 lg:rounded-t-lg dark:border-white/10">
@@ -32,8 +42,19 @@ export function CombatLabHeader({ active, children }: CombatLabHeaderProps) {
         </div>
         <nav
           aria-label={t("Combat Lab sections")}
-          className="mt-5 flex flex-wrap gap-2 border-white/10 border-b pb-3"
+          className="mt-5 flex flex-wrap items-center gap-2 border-white/10 border-b pb-3"
         >
+          <div className="dark w-full sm:w-64">
+            <Listbox<CombatLabSeason>
+              aria-label={t("Combat Lab season")}
+              value={season}
+              onChange={changeSeason}
+              renderValue={(value) => (value === "presoc" ? labels.presoc : labels.soc)}
+            >
+              <ListboxOption value="soc">{labels.soc}</ListboxOption>
+              <ListboxOption value="presoc">{labels.presoc}</ListboxOption>
+            </Listbox>
+          </div>
           {sections.map((section) => {
             const current = active === section.key;
             const label = section.key === "explore" ? t("Explore") : t("Rankings");
@@ -46,7 +67,7 @@ export function CombatLabHeader({ active, children }: CombatLabHeaderProps) {
                     ? "bg-white text-zinc-950 shadow-sm"
                     : "text-zinc-300 hover:bg-white/10 hover:text-white"
                 )}
-                href={section.href}
+                href={`${combatLabPath(season)}${section.suffix}`}
                 key={section.key}
               >
                 {label}

--- a/packages/site/src/components/combat-lab/combat-lab-page.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-page.tsx
@@ -1,0 +1,41 @@
+import { getLocale } from "next-intl/server";
+import { CombatLab } from "@/components/combat-lab/combat-lab";
+import { getCombatLabCommanderOptions, isCombatLabCommanderId } from "@/lib/combat-lab/commanders";
+import { fetchCombatLabPreview } from "@/lib/combat-lab/preview-api";
+import type { CombatLabSeason } from "@/lib/combat-lab/season";
+
+export async function CombatLabPage({
+  searchParams,
+  season,
+}: {
+  season: CombatLabSeason;
+  searchParams: Promise<{ primary?: string; secondary?: string }>;
+}) {
+  const defaultPrimaryCommanderId = season === "presoc" ? 64 : 509;
+  const defaultSecondaryCommanderId = 6;
+  const params = await searchParams;
+  const requestedPrimary =
+    combatLabCommanderId(params.primary, season) ?? defaultPrimaryCommanderId;
+  const requestedSecondary =
+    combatLabCommanderId(params.secondary, season) ?? defaultSecondaryCommanderId;
+  const primary = requestedPrimary;
+  const secondary =
+    requestedSecondary === primary
+      ? primary === defaultSecondaryCommanderId
+        ? defaultPrimaryCommanderId
+        : defaultSecondaryCommanderId
+      : requestedSecondary;
+  const locale = await getLocale();
+  const [data, commanderOptions] = await Promise.all([
+    fetchCombatLabPreview({ primary, secondary, locale, season }),
+    getCombatLabCommanderOptions(locale, season),
+  ]);
+  return <CombatLab commanderOptions={commanderOptions} data={data} />;
+}
+
+function combatLabCommanderId(value: string | undefined, season: CombatLabSeason): number | null {
+  const number = Number(value);
+  return Number.isSafeInteger(number) && number > 0 && isCombatLabCommanderId(number, season)
+    ? number
+    : null;
+}

--- a/packages/site/src/components/combat-lab/combat-lab-rankings-content.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-rankings-content.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "next/navigation";
 import { parseAsStringLiteral, useQueryStates } from "nuqs";
 import { Suspense } from "react";
 import { CombatLabRankingsLoading } from "@/components/combat-lab/combat-lab-rankings-loading";
@@ -14,8 +15,10 @@ import {
   combatLabRankingDirections,
   combatLabRankingSorts,
 } from "@/lib/combat-lab/rankings-api";
+import { combatLabSeason } from "@/lib/combat-lab/season";
 
 export function CombatLabRankingsContent() {
+  const season = combatLabSeason(usePathname());
   const clientReady = useClientReady();
   const [sorting, setSorting] = useQueryStates(
     {
@@ -44,7 +47,7 @@ export function CombatLabRankingsContent() {
 
   return (
     <Suspense
-      key={`${sorting.sort}:${sorting.direction}`}
+      key={`${season}:${sorting.sort}:${sorting.direction}`}
       fallback={
         <CombatLabRankingsFrame>
           <CombatLabRankingsLoading />
@@ -52,6 +55,7 @@ export function CombatLabRankingsContent() {
       }
     >
       <CombatLabRankingsResults
+        season={season}
         sort={sorting.sort}
         direction={sorting.direction}
         onSort={handleSort}

--- a/packages/site/src/components/combat-lab/combat-lab-rankings-results.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-rankings-results.tsx
@@ -12,21 +12,24 @@ import {
   type CombatLabRankingSort,
   loadCombatLabRankingsResult,
 } from "@/lib/combat-lab/rankings-api";
+import type { CombatLabSeason } from "@/lib/combat-lab/season";
 
 type CombatLabRankingsResultsProps = {
+  season: CombatLabSeason;
   sort: CombatLabRankingSort;
   direction: CombatLabRankingDirection;
   onSort: (sort: CombatLabRankingSort) => void;
 };
 
 export function CombatLabRankingsResults({
+  season,
   sort,
   direction,
   onSort,
 }: CombatLabRankingsResultsProps) {
   const t = useExtracted();
   const locale = useLocale();
-  const result = use(loadCombatLabRankingsResult({ sort, direction }));
+  const result = use(loadCombatLabRankingsResult({ season, sort, direction }));
 
   if (result.status === "error") {
     return (
@@ -50,6 +53,7 @@ export function CombatLabRankingsResults({
       }
     >
       <CombatLabRankingsTable
+        season={season}
         items={result.items}
         sort={sort}
         direction={direction}

--- a/packages/site/src/components/combat-lab/combat-lab-rankings-table.tsx
+++ b/packages/site/src/components/combat-lab/combat-lab-rankings-table.tsx
@@ -19,6 +19,7 @@ import type {
   CombatLabRankingDirection,
   CombatLabRankingSort,
 } from "@/lib/combat-lab/rankings-api";
+import { type CombatLabSeason, combatLabPath } from "@/lib/combat-lab/season";
 import { getCommanderName } from "@/lib/commander";
 
 const overallColumn = { key: "overall", label: "DRASTC" } as const;
@@ -36,6 +37,7 @@ const breakdownColumns: Array<{
 ];
 
 type CombatLabRankingsTableProps = {
+  season: CombatLabSeason;
   items: CombatLabRanking[];
   sort: CombatLabRankingSort;
   direction: CombatLabRankingDirection;
@@ -43,6 +45,7 @@ type CombatLabRankingsTableProps = {
 };
 
 export function CombatLabRankingsTable({
+  season,
   items,
   sort,
   direction,
@@ -88,7 +91,7 @@ export function CombatLabRankingsTable({
         {items.map((item, index) => {
           const primaryName = getCommanderName(item.primaryCommanderId, locale) ?? "Unknown";
           const secondaryName = getCommanderName(item.secondaryCommanderId, locale) ?? "Unknown";
-          const href = `/combat-lab?primary=${item.primaryCommanderId}&secondary=${item.secondaryCommanderId}`;
+          const href = `${combatLabPath(season)}?primary=${item.primaryCommanderId}&secondary=${item.secondaryCommanderId}`;
 
           return (
             <TableRow

--- a/packages/site/src/components/platform-layout.tsx
+++ b/packages/site/src/components/platform-layout.tsx
@@ -44,7 +44,12 @@ type PlatformLayoutProps = {
   initialUser?: CurrentUser | null;
 };
 
-const fullWidthRoutes = new Set(["/combat-lab", "/combat-lab/rankings"]);
+const fullWidthRoutes = new Set([
+  "/combat-lab",
+  "/combat-lab/rankings",
+  "/combat-lab/presoc",
+  "/combat-lab/presoc/rankings",
+]);
 
 export function PlatformLayout({ children, initialUser }: PlatformLayoutProps) {
   const t = useExtracted();

--- a/packages/site/src/i18n/messages/ar.po
+++ b/packages/site/src/i18n/messages/ar.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/de.po
+++ b/packages/site/src/i18n/messages/de.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/en.po
+++ b/packages/site/src/i18n/messages/en.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr "No data available"
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr "Season of Conquest"
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr "Pre-Season of Conquest"
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1037,6 +1048,11 @@ msgstr "Explore commander pairing performance with DRASTC scoring when available
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
 msgstr "Combat Lab sections"
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
+msgstr "Combat Lab season"
 
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "7JlauX"
@@ -2349,11 +2365,6 @@ msgstr "Season 2"
 msgctxt "Ygh1LR"
 msgid "Season 3"
 msgstr "Season 3"
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
-msgstr "Season of Conquest"
 
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "gvEP4o"

--- a/packages/site/src/i18n/messages/es.po
+++ b/packages/site/src/i18n/messages/es.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/fr.po
+++ b/packages/site/src/i18n/messages/fr.po
@@ -1032,6 +1032,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1045,6 +1056,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2357,11 +2373,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/id.po
+++ b/packages/site/src/i18n/messages/id.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/it.po
+++ b/packages/site/src/i18n/messages/it.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/ja.po
+++ b/packages/site/src/i18n/messages/ja.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/ko.po
+++ b/packages/site/src/i18n/messages/ko.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/ms.po
+++ b/packages/site/src/i18n/messages/ms.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/pl.po
+++ b/packages/site/src/i18n/messages/pl.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/pt.po
+++ b/packages/site/src/i18n/messages/pt.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/ru.po
+++ b/packages/site/src/i18n/messages/ru.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/th.po
+++ b/packages/site/src/i18n/messages/th.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/tr.po
+++ b/packages/site/src/i18n/messages/tr.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/vi.po
+++ b/packages/site/src/i18n/messages/vi.po
@@ -1032,6 +1032,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr "Mùa Chinh phạt"
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1045,6 +1056,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2358,11 +2374,6 @@ msgstr "Mùa 2"
 msgctxt "Ygh1LR"
 msgid "Season 3"
 msgstr "Mùa 3"
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
-msgstr "Mùa Chinh phạt"
 
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "gvEP4o"

--- a/packages/site/src/i18n/messages/zh_CN.po
+++ b/packages/site/src/i18n/messages/zh_CN.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/i18n/messages/zh_TW.po
+++ b/packages/site/src/i18n/messages/zh_TW.po
@@ -1023,6 +1023,17 @@ msgid "No data available"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
+#: src/components/reports/reports-filter-dialog.tsx
+msgctxt "wudsnZ"
+msgid "Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "hi-PJC"
+msgid "Pre-Season of Conquest"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
 #: src/components/platform-layout.tsx
 msgctxt "H2meTq"
 msgid "Combat Lab"
@@ -1036,6 +1047,11 @@ msgstr ""
 #: src/components/combat-lab/combat-lab-header.tsx
 msgctxt "WvzQkE"
 msgid "Combat Lab sections"
+msgstr ""
+
+#: src/components/combat-lab/combat-lab-header.tsx
+msgctxt "DmQBb7"
+msgid "Combat Lab season"
 msgstr ""
 
 #: src/components/combat-lab/combat-lab-header.tsx
@@ -2348,11 +2364,6 @@ msgstr ""
 #: src/components/reports/reports-filter-dialog.tsx
 msgctxt "Ygh1LR"
 msgid "Season 3"
-msgstr ""
-
-#: src/components/reports/reports-filter-dialog.tsx
-msgctxt "wudsnZ"
-msgid "Season of Conquest"
 msgstr ""
 
 #: src/components/reports/reports-filter-dialog.tsx

--- a/packages/site/src/lib/combat-lab/commanders.ts
+++ b/packages/site/src/lib/combat-lab/commanders.ts
@@ -1,3 +1,4 @@
+import type { CombatLabSeason } from "@/lib/combat-lab/season";
 import { commanderMap, getCommanderName } from "@/lib/commander";
 
 export type CombatLabCommanderOption = {
@@ -6,11 +7,14 @@ export type CombatLabCommanderOption = {
   talents: string[];
 };
 
-export function getCombatLabCommanderOptions(locale?: string): CombatLabCommanderOption[] {
+export function getCombatLabCommanderOptions(
+  locale?: string,
+  season: CombatLabSeason = "soc"
+): CombatLabCommanderOption[] {
   const options: CombatLabCommanderOption[] = [];
 
   for (const [id, commander] of Object.entries(commanderMap)) {
-    if (!isCombatLabCommanderId(Number(id))) {
+    if (!isCombatLabCommanderId(Number(id), season)) {
       continue;
     }
 
@@ -26,7 +30,10 @@ export function getCombatLabCommanderOptions(locale?: string): CombatLabCommande
   return options.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-export function isCombatLabCommanderId(id: number) {
-  const rarity = commanderMap[String(id) as keyof typeof commanderMap]?.rarity;
-  return rarity === "legendary" || rarity === "epic";
+export function isCombatLabCommanderId(id: number, season: CombatLabSeason = "soc") {
+  const commander = commanderMap[String(id) as keyof typeof commanderMap];
+  return (
+    (commander?.rarity === "legendary" || commander?.rarity === "epic") &&
+    (season === "soc" || commander.kvk_limit < 3)
+  );
 }

--- a/packages/site/src/lib/combat-lab/preview-api.ts
+++ b/packages/site/src/lib/combat-lab/preview-api.ts
@@ -9,6 +9,7 @@ import {
   combatLabPreviewRangeKeys,
   combatLabPreviewScenarioKeys,
 } from "@/lib/combat-lab/preview-types";
+import type { CombatLabSeason } from "@/lib/combat-lab/season";
 import { calculateTradePercentage } from "@/lib/combat-lab/trade-percentage";
 import { getCommanderName } from "@/lib/commander";
 
@@ -45,15 +46,19 @@ export async function fetchCombatLabPreview(options: {
   primary: number;
   secondary: number;
   locale?: string;
+  season: CombatLabSeason;
 }): Promise<CombatLabPreviewData> {
   const params = new URLSearchParams({
     primary: options.primary.toString(),
     secondary: options.secondary.toString(),
   });
   const apiUrl = process.env.API_URL || "http://localhost:8001";
-  const response = await fetch(`${apiUrl.replace(/\/$/, "")}/v2/global/combat-lab?${params}`, {
-    cache: "no-store",
-  });
+  const response = await fetch(
+    `${apiUrl.replace(/\/$/, "")}/v2/global/combat-lab${options.season === "presoc" ? "/presoc" : ""}?${params}`,
+    {
+      cache: "no-store",
+    }
+  );
   if (response.status === 404) notFound();
   if (!response.ok) {
     throw new Error(`Could not load Combat Lab data (${response.status})`);

--- a/packages/site/src/lib/combat-lab/rankings-api.ts
+++ b/packages/site/src/lib/combat-lab/rankings-api.ts
@@ -1,3 +1,5 @@
+import type { CombatLabSeason } from "@/lib/combat-lab/season";
+
 export const combatLabRankingSorts = [
   "overall",
   "damage",
@@ -39,6 +41,7 @@ export type CombatLabRankingsResult =
 const rankingsResultCache = new Map<string, Promise<CombatLabRankingsResult>>();
 
 async function fetchCombatLabRankings(options: {
+  season: CombatLabSeason;
   sort: CombatLabRankingSort;
   direction: CombatLabRankingDirection;
 }): Promise<CombatLabRankingsResponse> {
@@ -46,9 +49,12 @@ async function fetchCombatLabRankings(options: {
     sort: options.sort,
     direction: options.direction,
   });
-  const response = await fetch(`/proxy/v2/global/combat-lab/rankings?${params}`, {
-    cache: "no-store",
-  });
+  const response = await fetch(
+    `/proxy/v2/global/combat-lab/rankings${options.season === "presoc" ? "/presoc" : ""}?${params}`,
+    {
+      cache: "no-store",
+    }
+  );
 
   if (!response.ok) {
     throw new Error(`Failed to load Combat Lab rankings: ${response.status}`);
@@ -58,10 +64,11 @@ async function fetchCombatLabRankings(options: {
 }
 
 export function loadCombatLabRankingsResult(options: {
+  season: CombatLabSeason;
   sort: CombatLabRankingSort;
   direction: CombatLabRankingDirection;
 }): Promise<CombatLabRankingsResult> {
-  const cacheKey = `${options.sort}:${options.direction}`;
+  const cacheKey = `${options.season}:${options.sort}:${options.direction}`;
   const cached = rankingsResultCache.get(cacheKey);
 
   if (cached) {

--- a/packages/site/src/lib/combat-lab/season.ts
+++ b/packages/site/src/lib/combat-lab/season.ts
@@ -1,0 +1,11 @@
+export type CombatLabSeason = "soc" | "presoc";
+
+export function combatLabSeason(pathname: string): CombatLabSeason {
+  return pathname === "/combat-lab/presoc" || pathname.startsWith("/combat-lab/presoc/")
+    ? "presoc"
+    : "soc";
+}
+
+export function combatLabPath(season: CombatLabSeason) {
+  return season === "presoc" ? "/combat-lab/presoc" : "/combat-lab";
+}


### PR DESCRIPTION
Add pre-SoC exploration and rankings to Combat Lab. A season selector before Explore/Rankings switches between Season of Conquest (default) and Pre-Season of Conquest, with the URL determining the selected season.

- Keep `/combat-lab` and `/combat-lab/rankings` for SoC; add `/combat-lab/presoc` and `/combat-lab/presoc/rankings` with the same full-width layout.
- Default pre-SoC to Saladin / Yi Seong-Gye (`64 / 6`) and limit its commander picker to epic/legendary commanders with `kvk_limit < 3`.
- Preserve the active Explore/Rankings section when switching seasons and clear query parameters. Pairing links stay within the selected season, and rankings caches are separated by season.
- Add `GET /v2/global/combat-lab/presoc` and `GET /v2/global/combat-lab/rankings/presoc`, using the pre-SoC pairing and DRASTC collections. Both share the normal endpoints' validation, response formats, sorting, and one-hour cache headers. The scheduled jobs already create the required collection indexes.

Stacked on #905 as the fourth PR in the stack.

Validation: all 200 API tests, API Clippy, Rust formatting, site typecheck, Biome, and diff checks pass. Running API checks covered 18 pre-SoC rankings, epic pairings, all 14 sorting combinations, error responses, cache headers, and source isolation. Browser checks covered all four pages, season switching, query clearing, pairing navigation, commander eligibility, browser history, and mobile/full-width layouts. Next.js reported no compilation or runtime errors; React Doctor reported no new issues. Normal API responses remain unchanged.
