### PR TITLE
perf(mail-codec): simplify dense numeric table decoding

### DIFF
--- a/crates/common/rokbattles-mail-codec/src/value.rs
+++ b/crates/common/rokbattles-mail-codec/src/value.rs
@@ -4,8 +4,6 @@
 //! Classification therefore depends on the whole sequence: item count first,
 //! then the types of the values in potential key positions.
 
-use std::collections::BTreeMap;
-
 use serde_json::{Map, Value, map::Entry};
 
 use crate::DecodeError;
@@ -95,7 +93,7 @@ fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, 
 
     if is_sequential {
         // Numeric ordering maps the file's one-based keys to zero-based array positions.
-        let mut values = BTreeMap::new();
+        let mut values = vec![Value::Null; pair_count];
         for (key, value) in owned_pairs(items) {
             #[expect(
                 clippy::unreachable,
@@ -104,9 +102,15 @@ fn numeric_keyed_table(items: Vec<Value>, table_offset: usize) -> Result<Value, 
             let Some(key) = key.as_u64().and_then(|key| usize::try_from(key).ok()) else {
                 unreachable!("sequential numeric keys were validated before conversion");
             };
-            values.insert(key, value);
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "sequential numeric keys were validated to be within 1..=pair_count."
+            )]
+            {
+                values[key - 1] = value;
+            }
         }
-        return Ok(Value::Array(values.into_values().collect()));
+        return Ok(Value::Array(values));
     }
 
     let mut map = Map::with_capacity(pair_count);
@@ -165,12 +169,55 @@ mod tests {
     }
 
     #[test]
+    fn sequential_numeric_keys_preserve_null_and_nested_values() {
+        let values = json!([3, {"nested": [true, "value"]}, 1, null, 2, [false, 42]]);
+        let classified =
+            classify_table(values.as_array().expect("array").clone(), 0).expect("classify table");
+
+        assert_eq!(classified.value, json!([null, [false, 42], {"nested": [true, "value"]}]));
+    }
+
+    #[test]
+    fn large_reversed_numeric_table_uses_numeric_order() {
+        let values = (1..=10_000).rev().flat_map(|key| [json!(key), json!(key * 3)]).collect();
+        let classified = classify_table(values, 0).expect("classify table");
+        let expected = Value::Array((1..=10_000).map(|key| json!(key * 3)).collect());
+
+        assert_eq!(classified.value, expected);
+    }
+
+    #[test]
+    fn non_sequential_numeric_keys_remain_objects() {
+        for (values, expected) in [
+            (json!([3, "third", 1, "first"]), json!({"1": "first", "3": "third"})),
+            (json!([0, "zero", 1, "first"]), json!({"0": "zero", "1": "first"})),
+            (json!([-1, "negative"]), json!({"-1": "negative"})),
+            (json!([1.5, "fractional"]), json!({"1.5": "fractional"})),
+            (json!([u64::MAX, "large"]), json!({"18446744073709551615": "large"})),
+        ] {
+            let classified = classify_table(values.as_array().expect("array").clone(), 0)
+                .expect("classify table");
+
+            assert_eq!(classified.value, expected);
+        }
+    }
+
+    #[test]
     fn duplicate_numeric_keys_are_rejected() {
         let values = json!([2, "first", 2, "second"]);
         let error = classify_table(values.as_array().expect("array").clone(), 7)
             .expect_err("duplicate should fail");
 
         assert_eq!(error, DecodeError::DuplicateTableKey { offset: 7, key: "2".to_string() });
+    }
+
+    #[test]
+    fn duplicate_numeric_key_with_null_value_is_rejected() {
+        let values = json!([1, null, 2, "second", 1, "duplicate"]);
+        let error = classify_table(values.as_array().expect("array").clone(), 7)
+            .expect_err("duplicate should fail");
+
+        assert_eq!(error, DecodeError::DuplicateTableKey { offset: 7, key: "1".to_string() });
     }
 
     #[test]


### PR DESCRIPTION
Dense numeric tables already prove their keys are a unique permutation of `1..=N`, but array construction still inserted every value into a `BTreeMap` and then traversed the tree. Fill a preallocated vector at `key - 1` instead, making array assembly linear and eliminating tree-node allocations.

The existing key validation and numeric-object fallback preserve duplicate-key errors, offsets, and numeric ordering. Complete key coverage guarantees every vector slot is filled, including slots whose decoded value is null. The change and regression tests are confined to `crates/common/rokbattles-mail-codec/src/value.rs`.

## Correctness and checks

- All **128 binary mail samples** produced byte-identical serialized decoded output before and after the change.
- **4,681 classification cases** produced identical values or errors, covering numeric-key sequences of up to four pairs, duplicates, zero/negative/fractional/large keys, and null/nested values.
- Added regression tests for null and nested values, a reversed 10,000-entry table, non-dense numeric keys, and a duplicate whose first value is null. These tests passed against both implementations.
- `cargo test -p rokbattles-mail-codec --all-features --locked`: **40 tests and 5 doc tests passed**.
- `cargo clippy -p rokbattles-mail-codec --all-targets --all-features --locked -- -D warnings`: passed.
- `cargo fmt -p rokbattles-mail-codec -- --check` and `git diff --check`: passed.

## Allocation measurements

Allocation calls per operation, comparing the original implementation at `c871e387` with this change:

| Entries | Key order | Classification before | Classification after | `decode_value` before | `decode_value` after |
| ---: | --- | ---: | ---: | ---: | ---: |
| 1,000 | Ascending / descending | 169 | 2 | 179 | 12 |
| 1,000 | Shuffled | 139 | 2 | 149 | 12 |
| 10,000 | Ascending / descending | 1,668 | 2 | 1,682 | 16 |
| 10,000 | Shuffled | 1,336 | 2 | 1,350 | 16 |

Measured with a temporary single-threaded harness wrapping the Rust `System` allocator and counting `alloc`, `alloc_zeroed`, and `realloc` calls only during classification or public `decode_value` execution. Inputs use dense numeric keys and distinct numeric values; fixture construction, cloning inputs, output comparison, and serialization happen outside the measured interval. Each result was checked against the expected numerically ordered array.

Three measurements per size/order/API combination gave identical counts, and all **36 before/after comparisons** reduced allocations. Builds used the repository's release profile (`opt-level=z`, thin LTO, one codegen unit, `panic=abort`) on Linux x86_64 with `rustc 1.100.0-nightly (f7d782a3b 2026-08-19)`. The measurement harness was kept outside the repository.
