### PR TITLE
perf(jobs): track Combat Lab chunk sizes incrementally

### DIFF
--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -399,17 +399,21 @@ async fn write_chunk_records(
 ) -> Result<(), JobsError> {
     let mut part = first_part;
     let mut current = Vec::new();
+    // The metadata fields (including part) have fixed-width BSON values. The empty
+    // document also accounts for the array's length prefix and terminating byte.
+    let empty_size =
+        encoded_size(&chunk_document(kind, pairing, month, generation, part, Vec::new()))?;
+    let mut current_size = empty_size;
 
     for record in records {
-        current.push(record);
-        let candidate = chunk_document(kind, pairing, month, generation, part, current.clone());
-        if encoded_size(&candidate)? > SAFE_BSON_BYTES {
-            let record = current.pop().expect("record was just pushed");
-            if current.is_empty() {
-                return Err(JobsError::InvalidCombatLabData(
-                    "one packed Combat Lab record exceeds the safe BSON limit".to_owned(),
-                ));
-            }
+        let record_size = encoded_record_size(&record)?;
+        // Index zero needs one byte even when the record starts a new chunk.
+        if empty_size + record_size + 1 > SAFE_BSON_BYTES {
+            return Err(JobsError::InvalidCombatLabData(
+                "one packed Combat Lab record exceeds the safe BSON limit".to_owned(),
+            ));
+        }
+        if current_size + record_size + array_index_digits(current.len()) > SAFE_BSON_BYTES {
             writer
                 .push(chunk_document(
                     kind,
@@ -421,14 +425,33 @@ async fn write_chunk_records(
                 ))
                 .await?;
             part += 1;
-            current.push(record);
+            current_size = empty_size;
         }
+        current_size += record_size + array_index_digits(current.len());
+        current.push(record);
     }
 
     if !current.is_empty() {
         writer.push(chunk_document(kind, pairing, month, generation, part, current)).await?;
     }
     Ok(())
+}
+
+fn encoded_record_size(record: &Bson) -> Result<usize, JobsError> {
+    #[derive(serde::Serialize)]
+    struct Element<'a> {
+        #[serde(rename = "")]
+        value: &'a Bson,
+    }
+
+    // Encode only this borrowed value. Remove the wrapper's four-byte length and
+    // terminator, retaining the element's type tag and key terminator. Array index
+    // digits are added separately, since the index resets when a chunk fills up.
+    Ok(mongodb::bson::to_vec(&Element { value: record })?.len() - 5)
+}
+
+fn array_index_digits(index: usize) -> usize {
+    index.checked_ilog10().unwrap_or(0) as usize + 1
 }
 
 fn chunk_document(


### PR DESCRIPTION
`write_chunk_records` cloned and BSON-encoded the entire growing chunk after every record, causing quadratic work within each chunk. Track encoded size incrementally so construction scales with the total record bytes, while preserving record order, the document schema, part numbering, and the 12 MiB limit.

Encode the empty chunk once to measure fixed metadata and array framing. Encode each borrowed record once for sizing, retaining its BSON type tag and key terminator, then add the decimal array-index length. Reset the index and accumulated size when a chunk fills up. Reject a record that cannot fit in an empty chunk, and retain `BulkWriter`'s single size validation of each completed chunk.

## Benchmarks

Two local release runs used synthetic performance tuples (11 BSON int64 values) and loadout tuples (the same outer tuple plus a nested array of 32 doubles). Each size had one warmup followed by seven measured samples. Measurements exercised `write_chunk_records` and `BulkWriter` model staging without database writes; fixture creation/cloning and dropping completed models were outside the measured interval.

Median elapsed time:

| Record shape | Records | Run 1 | Run 2 | Chunks |
| --- | ---: | ---: | ---: | ---: |
| Performance | 1,000 | 1.188 ms | 1.164 ms | 1 |
| Performance | 10,000 | 12.690 ms | 12.430 ms | 1 |
| Performance | 50,000 | 71.232 ms | 67.721 ms | 1 |
| Loadout | 1,000 | 2.661 ms | 2.671 ms | 1 |
| Loadout | 10,000 | 53.841 ms | 51.972 ms | 1 |
| Loadout | 50,000 | 217.339 ms | 217.149 ms | 3 |

The maximum/minimum median time per record was 1.20x / 1.16x for performance tuples and 2.02x / 1.95x for loadout tuples across the two runs. This supports approximately linear scaling, with roughly 2x variation for loadout records. The largest benchmark chunk was 12,582,572 bytes, below the 12,582,912-byte limit. These measurements cover construction and staging; end-to-end job CPU and allocation savings were not measured against the previous implementation.

Benchmarks used Rust 1.100.0-nightly and the workspace release profile (`opt-level = "z"`, thin LTO, one codegen unit). The temporary harness was run with:

```sh
cargo test -p rokbattles-jobs --release --locked --lib benchmark_chunk_construction -- --ignored --nocapture
```

The temporary `chunk_tests.rs` harness was removed before this PR, so the benchmark command requires restoring that harness.

## Validation

- `cargo test -p rokbattles-jobs --all-targets --all-features --locked --quiet` — 81 tests passed on the final change.
- `cargo clippy -p rokbattles-jobs --all-targets --all-features --locked -- -D warnings -D clippy::perf` — passed.
- `rustfmt --check --edition 2024 --config skip_children=true crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs` — passed.
- `git diff --check` — passed.

Before removal, the temporary harness also passed seven targeted tests covering BSON array-index digit transitions through index 10,000, mixed/nested BSON values, empty input, exact 12 MiB chunks, one-byte overflow, order/schema/part preservation for both chunk kinds, index resets across successive chunks, oversized records at the start or after valid input, and BSON serialization errors. Those checks are development evidence and are not included as regression tests in this PR.
