### PR TITLE
chore(deps): update workflow actions and Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           submodules: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -98,6 +98,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,7 @@ jobs:
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Report coverage
-        uses: getsentry/codecov-action@eb2b4a6c4be3ecb42867043570579fa3b6879f6e # 0.3.8
+        uses: getsentry/codecov-action@5f3f449cf9e909fd63513a48f27c57f090a5f321 # 0.4.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./lcov.info

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@01820bb4fd4d0a4aebcd8df2b2a143a098649cb2 # v2.2.8
+      - uses: millionco/react-doctor@013f7373f91a3b9e68bd1dc7d4d354f4b041b117 # v2.2.9
         with:
           directory: packages/desktop-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           run_install: false
 

--- a/infra/api.Dockerfile
+++ b/infra/api.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app

--- a/infra/dns-resolver.Dockerfile
+++ b/infra/dns-resolver.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app

--- a/infra/ingress.Dockerfile
+++ b/infra/ingress.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app

--- a/infra/jobs.Dockerfile
+++ b/infra/jobs.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app

--- a/infra/platform.Dockerfile
+++ b/infra/platform.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS container-wasm
 RUN apk add --no-cache build-base openssl-dev pkgconfig
 RUN --mount=type=bind,source=.,target=/src \
@@ -8,7 +8,7 @@ RUN --mount=type=bind,source=.,target=/src \
     CARGO_TARGET_DIR=/target CONTAINER_WASM_OUT_DIR=/out \
     sh /src/packages/site/scripts/build-container.sh
 
-FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
+FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS base
 WORKDIR /app
 
 FROM base AS builder
@@ -17,7 +17,7 @@ ENV API_URL=${API_URL}
 RUN apk add --no-cache git libc6-compat
 COPY --link pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY --link packages/site/package.json ./packages/site/package.json
-RUN corepack enable pnpm
+RUN npm install --global corepack@0.36.0 && corepack enable pnpm
 RUN --mount=type=cache,id=rokbattles-pnpm-store,target=/pnpm/store \
     pnpm config set store-dir /pnpm/store && \
     pnpm install --frozen-lockfile

--- a/infra/processor.Dockerfile
+++ b/infra/processor.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.25.0@sha256:0adf442eae370b6087e08edc7c50b552d80ddf261576f4ebd6421006b2461f12
+# syntax=docker/dockerfile:1.27.0@sha256:bde3983e9c939224420ddaf6b784cc30e09b035a4dea01f581230c50809f372e
 FROM rust:1.98.0-alpine@sha256:a10e64dd139b7387337c7fbe8aca31b959b57b2fd4c8ae20a02cf1d6ea424dce AS builder
 ENV CARGO_INCREMENTAL=0
 WORKDIR /app


### PR DESCRIPTION
Update the SHA-pinned pnpm, CodeQL, Codecov, and React Doctor workflow actions. Upgrade the Dockerfile frontend to 1.27.0 across all six Dockerfiles and the platform image to Node 26 Alpine, using verified registry digests.

Install Corepack 0.36.0 explicitly so the existing pnpm build step works with Node 26, which no longer bundles Corepack.

Validation:
- Matched all updated GitHub Action SHAs to their release tags.
- Verified Docker image pins against registry manifests.
- Passed an isolated Node 26.8.1 / Corepack 0.36.0 / pnpm 11.25.0 bootstrap check.
- Passed `git diff --check`.

Docker builds were not run because Docker is unavailable in this environment.
