### PR TITLE
fix(lints): unify Cargo manifests and resolve workspace warnings

### DIFF
--- a/crates/apps/rokbattles-api/Cargo.toml
+++ b/crates/apps/rokbattles-api/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 axum = { workspace = true, features = ["http1", "json", "query", "tokio", "tracing"] }
 base64 = { workspace = true }
@@ -26,5 +29,5 @@ yaml_serde = { workspace = true }
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 mimalloc = { workspace = true, features = ["secure"] }
 
-[lib]
-doctest = false
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-api/src/main.rs
+++ b/crates/apps/rokbattles-api/src/main.rs
@@ -20,7 +20,8 @@ use tracing::info;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dotenv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env");
-    dotenvy::from_path(&dotenv_path).ok();
+    // Environment variables can be supplied without a local .env file.
+    let _dotenv_result = dotenvy::from_path(&dotenv_path);
 
     let config = Config::from_env()?;
     tracing_subscriber::fmt()

--- a/crates/apps/rokbattles-api/src/routes/combat_lab.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab.rs
@@ -537,7 +537,7 @@ mod tests {
         let score = map_drastc(&value).expect("DRASTC");
 
         assert_eq!(score.samples, 10);
-        assert_eq!(score.breakdown.consistency.score, 4.0);
+        assert!((score.breakdown.consistency.score - 4.0).abs() < 1e-9);
         assert_eq!(score.confidence.unique_governors, 20);
     }
 

--- a/crates/apps/rokbattles-api/src/routes/combat_lab.rs
+++ b/crates/apps/rokbattles-api/src/routes/combat_lab.rs
@@ -29,7 +29,8 @@ fn parse_required_i64(params: &HashMap<String, String>, key: &str) -> Result<i64
     else {
         return Err(ApiError::bad_request(format!("Missing {key}")));
     };
-    let value = raw.parse::<i64>().map_err(|_| ApiError::bad_request(format!("Invalid {key}")))?;
+    let value =
+        raw.parse::<i64>().map_err(|_error| ApiError::bad_request(format!("Invalid {key}")))?;
     if value <= 0 {
         return Err(ApiError::bad_request(format!("Invalid {key}")));
     }

--- a/crates/apps/rokbattles-api/src/routes/governor/ark/mapper.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/ark/mapper.rs
@@ -198,16 +198,9 @@ fn map_pairings(individual_results: Option<&Document>) -> Vec<ArkMatchDetailPair
 }
 
 fn nested_value<'a>(document: &'a Document, path: &[&str]) -> Option<&'a Bson> {
-    if path.is_empty() {
-        return None;
-    }
-
-    if path.len() == 1 {
-        return document.get(path[0]);
-    }
-
-    let parent = nested_document(document, &path[..path.len() - 1])?;
-    parent.get(path[path.len() - 1])
+    let (key, parents) = path.split_last()?;
+    let parent = nested_document(document, parents)?;
+    parent.get(*key)
 }
 
 fn parse_timestamp_millis(value: &Bson) -> Option<i64> {
@@ -233,6 +226,7 @@ fn parse_i64(value: Option<&Bson>) -> Option<i64> {
     }
 }
 
+#[expect(clippy::float_cmp, reason = "Numeric boolean encodings must be exactly 0 or 1")]
 fn parse_bool(value: Option<&Bson>) -> Option<bool> {
     match value? {
         Bson::Boolean(value) => Some(*value),

--- a/crates/apps/rokbattles-api/src/routes/governor/ark/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/ark/query.rs
@@ -72,6 +72,6 @@ mod tests {
     #[test]
     fn parse_match_id_trims_and_rejects_empty_values() {
         assert_eq!(parse_match_id("  mail-123  ").expect("match id"), "mail-123");
-        assert!(parse_match_id("   ").is_err());
+        parse_match_id("   ").expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-api/src/routes/governor/common.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/common.rs
@@ -62,9 +62,9 @@ mod tests {
 
     #[test]
     fn parse_governor_id_param_rejects_non_positive_or_invalid_values() {
-        assert!(parse_governor_id_param("0").is_err());
-        assert!(parse_governor_id_param("-1").is_err());
-        assert!(parse_governor_id_param("abc").is_err());
+        parse_governor_id_param("0").expect_err("input should be rejected");
+        parse_governor_id_param("-1").expect_err("input should be rejected");
+        parse_governor_id_param("abc").expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-api/src/routes/governor/loot/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/loot/query.rs
@@ -137,8 +137,9 @@ fn parse_levels(params: &HashMap<String, String>, key: &str) -> Result<Vec<i32>,
 
     let mut levels = Vec::new();
     for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
-        let level =
-            value.parse::<i32>().map_err(|_| ApiError::bad_request(format!("Invalid {key}")))?;
+        let level = value
+            .parse::<i32>()
+            .map_err(|_error| ApiError::bad_request(format!("Invalid {key}")))?;
         if !levels.contains(&level) {
             levels.push(level);
         }
@@ -203,7 +204,7 @@ mod tests {
         params.insert("type".to_string(), "marauders".to_string());
         params.insert("level".to_string(), "2".to_string());
 
-        assert!(parse_barbarian_loot_request(&params).is_err());
+        parse_barbarian_loot_request(&params).expect_err("input should be rejected");
     }
 
     #[test]
@@ -211,7 +212,7 @@ mod tests {
         let mut params = date_params();
         params.insert("level".to_string(), "1,2".to_string());
 
-        assert!(parse_fort_loot_request(&params).is_err());
+        parse_fort_loot_request(&params).expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-api/src/routes/governor/pairings/aggregate.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/pairings/aggregate.rs
@@ -487,14 +487,9 @@ fn parse_buff_pairs(raw: &str) -> Vec<(i64, f64)> {
         .map(str::trim)
         .filter(|token| !token.is_empty())
         .filter_map(|token| {
-            let parts =
-                token.split(|ch| ['_', ':'].contains(&ch)).map(str::trim).collect::<Vec<_>>();
-            if parts.len() < 2 {
-                return None;
-            }
-
-            let buff_id = parts[0].parse::<i64>().ok()?;
-            let buff_value = parts[1].parse::<f64>().ok()?;
+            let mut parts = token.split(|ch| ['_', ':'].contains(&ch)).map(str::trim);
+            let buff_id = parts.next()?.parse::<i64>().ok()?;
+            let buff_value = parts.next()?.parse::<f64>().ok()?;
             (buff_id > 0 && buff_value.is_finite()).then_some((buff_id, buff_value))
         })
         .collect::<Vec<_>>()

--- a/crates/apps/rokbattles-api/src/routes/governor/pairings/aggregate.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/pairings/aggregate.rs
@@ -653,9 +653,9 @@ mod tests {
         assert_eq!(first.totals.enemy_atk_power_loss, -500);
         assert_eq!(first.totals.enemy_skill_power_loss, -700);
         assert_eq!(first.totals.dps, 48);
-        assert_eq!(first.totals.trade_percent, 125.0);
-        assert_eq!(first.totals.weighted_trade_percent, 80.0);
-        assert_eq!(first.totals.hps, 5.0);
+        assert!((first.totals.trade_percent - 125.0).abs() < 1e-9);
+        assert!((first.totals.weighted_trade_percent - 80.0).abs() < 1e-9);
+        assert!((first.totals.hps - 5.0).abs() < 1e-9);
 
         let serialized = to_document(&first.totals).expect("serialized pairing totals");
         assert_eq!(serialized.get_i64("powerLoss"), Ok(-600));

--- a/crates/apps/rokbattles-api/src/routes/governor/pairings/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/governor/pairings/query.rs
@@ -335,7 +335,7 @@ mod tests {
             ("secondary".to_string(), "456".to_string()),
             ("granularity".to_string(), "normalized".to_string()),
         ]));
-        assert!(request.is_err());
+        request.expect_err("input should be rejected");
     }
 
     #[test]
@@ -345,7 +345,7 @@ mod tests {
             ("secondary".to_string(), "456".to_string()),
             ("granularity".to_string(), "simplified".to_string()),
         ]));
-        assert!(request.is_err());
+        request.expect_err("input should be rejected");
     }
 
     #[test]
@@ -401,7 +401,7 @@ mod tests {
             "excludeActivities".to_string(),
             "unknown".to_string(),
         )]));
-        assert!(request.is_err());
+        request.expect_err("input should be rejected");
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod tests {
             "excludeBattles".to_string(),
             "duel".to_string(),
         )]));
-        assert!(request.is_err());
+        request.expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-api/src/routes/loot_explorer/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/loot_explorer/mod.rs
@@ -210,7 +210,7 @@ fn parse_optional_i32(
         return Ok(None);
     };
 
-    raw.parse::<i32>().map(Some).map_err(|_| ApiError::bad_request(format!("Invalid {key}")))
+    raw.parse::<i32>().map(Some).map_err(|_error| ApiError::bad_request(format!("Invalid {key}")))
 }
 
 fn parse_optional_i32_list(
@@ -224,8 +224,9 @@ fn parse_optional_i32_list(
 
     let mut parsed = Vec::new();
     for value in raw.split(',').map(str::trim).filter(|value| !value.is_empty()) {
-        let parsed_value =
-            value.parse::<i32>().map_err(|_| ApiError::bad_request(format!("Invalid {key}")))?;
+        let parsed_value = value
+            .parse::<i32>()
+            .map_err(|_error| ApiError::bad_request(format!("Invalid {key}")))?;
         if !parsed.contains(&parsed_value) {
             parsed.push(parsed_value);
         }
@@ -544,7 +545,7 @@ mod tests {
     fn parse_kind_request_rejects_invalid_kind() {
         let params = HashMap::from([("kind".to_string(), "abc".to_string())]);
 
-        assert!(parse_kind_request(&params).is_err());
+        parse_kind_request(&params).expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-api/src/routes/reports/battle/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/reports/battle/mod.rs
@@ -381,6 +381,6 @@ mod tests {
     #[test]
     fn trims_and_rejects_empty_report_id() {
         assert_eq!(parse_report_id("  mail-123  ").expect("id should parse"), "mail-123");
-        assert!(parse_report_id("   ").is_err());
+        parse_report_id("   ").expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-api/src/routes/reports/battle/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/reports/battle/query.rs
@@ -236,7 +236,7 @@ mod tests {
     fn rejects_non_numeric_cursor() {
         let result =
             parse_reports_request(&HashMap::from([("after".to_string(), "abc".to_string())]));
-        assert!(result.is_err());
+        result.expect_err("input should be rejected");
     }
 
     #[test]
@@ -245,7 +245,7 @@ mod tests {
             ("rs".to_string(), "both".to_string()),
             ("gs".to_string(), "sender".to_string()),
         ]));
-        assert!(result.is_err());
+        result.expect_err("input should be rejected");
     }
 
     #[test]
@@ -269,6 +269,6 @@ mod tests {
     fn rejects_subtype_without_matching_type() {
         let result =
             parse_reports_request(&HashMap::from([("subtype".to_string(), "1".to_string())]));
-        assert!(result.is_err());
+        result.expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-api/src/routes/reports/common/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/reports/common/query.rs
@@ -8,7 +8,7 @@ pub(crate) fn parse_optional_i64(
         return Ok(None);
     };
 
-    value.parse::<i64>().map(Some).map_err(|_| ApiError::bad_request(error_message))
+    value.parse::<i64>().map(Some).map_err(|_error| ApiError::bad_request(error_message))
 }
 
 #[cfg(test)]
@@ -23,6 +23,6 @@ mod tests {
 
     #[test]
     fn rejects_invalid_numbers() {
-        assert!(parse_optional_i64(Some("abc"), "bad value").is_err());
+        parse_optional_i64(Some("abc"), "bad value").expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-api/src/routes/reports/duelbattle2/mod.rs
+++ b/crates/apps/rokbattles-api/src/routes/reports/duelbattle2/mod.rs
@@ -114,7 +114,7 @@ pub async fn get_by_id(
 }
 
 fn parse_duelbattle2_id(raw_id: &str) -> Result<i64, ApiError> {
-    raw_id.trim().parse::<i64>().map_err(|_| ApiError::bad_request("Invalid duel id"))
+    raw_id.trim().parse::<i64>().map_err(|_error| ApiError::bad_request("Invalid duel id"))
 }
 
 #[cfg(test)]
@@ -136,6 +136,6 @@ mod tests {
     #[test]
     fn rejects_non_numeric_duel_id() {
         let parsed = parse_duelbattle2_id("abc");
-        assert!(parsed.is_err());
+        parsed.expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-api/src/routes/reports/duelbattle2/query.rs
+++ b/crates/apps/rokbattles-api/src/routes/reports/duelbattle2/query.rs
@@ -36,7 +36,7 @@ mod tests {
     fn rejects_non_numeric_after_cursor() {
         let result =
             parse_duelbattle2_request(&HashMap::from([("after".to_string(), "bad".to_string())]));
-        assert!(result.is_err());
+        result.expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-desktop/Cargo.toml
+++ b/crates/apps/rokbattles-desktop/Cargo.toml
@@ -16,9 +16,6 @@ name = "rokbattles_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 doctest = false
 
-[build-dependencies]
-tauri-build = { workspace = true }
-
 [dependencies]
 tauri = { workspace = true, features = ["tray-icon"] }
 tauri-plugin-opener = { workspace = true }
@@ -37,5 +34,11 @@ notify = { workspace = true }
 tauri-plugin-autostart = { workspace = true }
 tauri-plugin-single-instance = { workspace = true }
 
+[build-dependencies]
+tauri-build = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-desktop/src/lib.rs
+++ b/crates/apps/rokbattles-desktop/src/lib.rs
@@ -301,37 +301,45 @@ fn minimize_to_tray(app: AppHandle) {
     tray::hide_main_window(&app);
 }
 
-#[tauri::command]
-async fn reprocess_all(
-    app: AppHandle,
-    watcher: tauri::State<'_, WatcherManager>,
-) -> Result<(), String> {
-    watcher.stop(&app).await;
-    delete_processed(&app).map_err(|e| e.to_string())?;
-    delete_upload_queue(&app).map_err(|e| e.to_string())?;
-    watcher.start(&app).await;
-    tray::refresh_tray_menu(&app, watcher.is_paused());
-    Ok(())
-}
+#[expect(
+    clippy::unreachable,
+    reason = "Tauri generates an unreachable return-type check for async commands with borrowed state"
+)]
+mod watcher_commands {
+    use super::*;
 
-#[tauri::command]
-async fn pause_watcher(
-    app: AppHandle,
-    watcher: tauri::State<'_, WatcherManager>,
-) -> Result<(), String> {
-    watcher.stop(&app).await;
-    tray::refresh_tray_menu(&app, watcher.is_paused());
-    Ok(())
-}
+    #[tauri::command]
+    pub(super) async fn reprocess_all(
+        app: AppHandle,
+        watcher: tauri::State<'_, WatcherManager>,
+    ) -> Result<(), String> {
+        watcher.stop(&app).await;
+        delete_processed(&app).map_err(|e| e.to_string())?;
+        delete_upload_queue(&app).map_err(|e| e.to_string())?;
+        watcher.start(&app).await;
+        tray::refresh_tray_menu(&app, watcher.is_paused());
+        Ok(())
+    }
 
-#[tauri::command]
-async fn resume_watcher(
-    app: AppHandle,
-    watcher: tauri::State<'_, WatcherManager>,
-) -> Result<(), String> {
-    watcher.start(&app).await;
-    tray::refresh_tray_menu(&app, watcher.is_paused());
-    Ok(())
+    #[tauri::command]
+    pub(super) async fn pause_watcher(
+        app: AppHandle,
+        watcher: tauri::State<'_, WatcherManager>,
+    ) -> Result<(), String> {
+        watcher.stop(&app).await;
+        tray::refresh_tray_menu(&app, watcher.is_paused());
+        Ok(())
+    }
+
+    #[tauri::command]
+    pub(super) async fn resume_watcher(
+        app: AppHandle,
+        watcher: tauri::State<'_, WatcherManager>,
+    ) -> Result<(), String> {
+        watcher.start(&app).await;
+        tray::refresh_tray_menu(&app, watcher.is_paused());
+        Ok(())
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -425,9 +433,9 @@ pub fn run() {
             get_app_settings,
             request_app_quit,
             minimize_to_tray,
-            reprocess_all,
-            pause_watcher,
-            resume_watcher
+            watcher_commands::reprocess_all,
+            watcher_commands::pause_watcher,
+            watcher_commands::resume_watcher
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/crates/apps/rokbattles-desktop/src/lib.rs
+++ b/crates/apps/rokbattles-desktop/src/lib.rs
@@ -301,18 +301,12 @@ fn minimize_to_tray(app: AppHandle) {
     tray::hide_main_window(&app);
 }
 
-#[expect(
-    clippy::unreachable,
-    reason = "Tauri generates an unreachable return-type check for async commands with borrowed state"
-)]
 mod watcher_commands {
     use super::*;
 
     #[tauri::command]
-    pub(super) async fn reprocess_all(
-        app: AppHandle,
-        watcher: tauri::State<'_, WatcherManager>,
-    ) -> Result<(), String> {
+    pub(super) async fn reprocess_all(app: AppHandle) -> Result<(), String> {
+        let watcher = app.state::<WatcherManager>();
         watcher.stop(&app).await;
         delete_processed(&app).map_err(|e| e.to_string())?;
         delete_upload_queue(&app).map_err(|e| e.to_string())?;
@@ -322,20 +316,16 @@ mod watcher_commands {
     }
 
     #[tauri::command]
-    pub(super) async fn pause_watcher(
-        app: AppHandle,
-        watcher: tauri::State<'_, WatcherManager>,
-    ) -> Result<(), String> {
+    pub(super) async fn pause_watcher(app: AppHandle) -> Result<(), String> {
+        let watcher = app.state::<WatcherManager>();
         watcher.stop(&app).await;
         tray::refresh_tray_menu(&app, watcher.is_paused());
         Ok(())
     }
 
     #[tauri::command]
-    pub(super) async fn resume_watcher(
-        app: AppHandle,
-        watcher: tauri::State<'_, WatcherManager>,
-    ) -> Result<(), String> {
+    pub(super) async fn resume_watcher(app: AppHandle) -> Result<(), String> {
+        let watcher = app.state::<WatcherManager>();
         watcher.start(&app).await;
         tray::refresh_tray_menu(&app, watcher.is_paused());
         Ok(())

--- a/crates/apps/rokbattles-desktop/src/mailcache_discovery.rs
+++ b/crates/apps/rokbattles-desktop/src/mailcache_discovery.rs
@@ -1,15 +1,13 @@
-#![cfg_attr(not(any(test, target_os = "windows", target_os = "macos")), allow(dead_code))]
-
-use std::{
-    collections::BTreeSet,
-    fs,
-    path::{Path, PathBuf},
-};
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+use std::collections::BTreeSet;
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
+use std::path::PathBuf;
 #[cfg(any(test, target_os = "windows"))]
 use std::{
     collections::VecDeque,
     time::{Duration, Instant},
 };
+use std::{fs, path::Path};
 
 #[cfg(any(test, target_os = "windows"))]
 const WINDOWS_MAILCACHE_SUFFIX_LOWER: &str = "\\rise of kingdoms game\\save\\mailcache";
@@ -29,6 +27,7 @@ const MAX_WINDOWS_FALLBACK_DURATION: Duration = Duration::from_secs(2);
 
 #[cfg(any(test, target_os = "macos"))]
 const MAX_MACOS_CONTAINERS: usize = 2048;
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 const MAX_MAILCACHE_FILES_TO_CHECK: usize = 4096;
 
 #[cfg(any(test, target_os = "windows"))]
@@ -75,7 +74,7 @@ pub(crate) fn path_identity_key(path: &Path) -> String {
     }
 }
 
-#[allow(dead_code)]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn normalize_and_dedupe(paths: Vec<PathBuf>) -> Vec<String> {
     let mut set = BTreeSet::new();
     for path in paths {
@@ -291,6 +290,7 @@ fn path_matches_macos_container_pattern(path: &Path) -> bool {
     normalized.ends_with("/Data/Documents/mailcache") && normalized.contains("/Library/Containers/")
 }
 
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 fn is_valid_mailcache_dir(path: &Path) -> bool {
     if !path.is_dir() {
         return false;
@@ -298,6 +298,7 @@ fn is_valid_mailcache_dir(path: &Path) -> bool {
     dir_has_persistent_mail_files(path)
 }
 
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 fn dir_has_persistent_mail_files(path: &Path) -> bool {
     let Ok(read_dir) = fs::read_dir(path) else {
         return false;
@@ -319,6 +320,7 @@ fn dir_has_persistent_mail_files(path: &Path) -> bool {
     false
 }
 
+#[cfg(any(test, target_os = "windows", target_os = "macos"))]
 fn is_persistent_mail_filename(name: &str) -> bool {
     let Some(rest) = name.strip_prefix("Persistent.Mail.") else {
         return false;

--- a/crates/apps/rokbattles-desktop/src/tray.rs
+++ b/crates/apps/rokbattles-desktop/src/tray.rs
@@ -46,17 +46,25 @@ pub(crate) fn refresh_tray_menu(app: &AppHandle, paused: bool) {
 
 pub(crate) fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-        let _ = window.show();
-        let _ = window.unminimize();
-        let _ = window.set_focus();
+        if let Err(error) = window.show() {
+            eprintln!("[rokbattles] failed to show main window: {error}");
+        }
+        if let Err(error) = window.unminimize() {
+            eprintln!("[rokbattles] failed to restore main window: {error}");
+        }
+        if let Err(error) = window.set_focus() {
+            eprintln!("[rokbattles] failed to focus main window: {error}");
+        }
     }
 }
 
 pub(crate) fn hide_main_window(app: &AppHandle) {
     #[cfg(any(target_os = "windows", target_os = "macos"))]
     {
-        if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-            let _ = window.hide();
+        if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL)
+            && let Err(error) = window.hide()
+        {
+            eprintln!("[rokbattles] failed to hide main window: {error}");
         }
     }
 

--- a/crates/apps/rokbattles-desktop/src/watcher/mod.rs
+++ b/crates/apps/rokbattles-desktop/src/watcher/mod.rs
@@ -60,7 +60,9 @@ fn http_client() -> &'static reqwest::Client {
 }
 
 fn emit_log(app: &AppHandle, message: impl Into<String>) {
-    let _ = app.emit("rokbattles", LogPayload { message: message.into() });
+    if let Err(error) = app.emit("rokbattles", LogPayload { message: message.into() }) {
+        eprintln!("[rokbattles] failed to emit watcher log: {error}");
+    }
 }
 
 fn now_epoch_ms() -> u128 {
@@ -83,7 +85,8 @@ pub struct WatcherTask {
 
 impl WatcherTask {
     pub async fn shutdown(self, app: &AppHandle) {
-        let _ = self.shutdown.send(true);
+        // No receiver means the watcher has already stopped; still join its task below.
+        let _shutdown_result = self.shutdown.send(true);
         let mut handle = self.handle;
         tokio::select! {
             _ = &mut handle => {}
@@ -127,7 +130,8 @@ pub fn spawn_watcher(app: &AppHandle) -> WatcherTask {
             move |res: Result<notify::Event, notify::Error>| {
                 if let Ok(event) = res {
                     for path in event.paths {
-                        let _ = fs_tx.try_send(path);
+                        // Periodic directory scans recover events dropped when the queue is full.
+                        let _send_result = fs_tx.try_send(path);
                     }
                 }
             }

--- a/crates/apps/rokbattles-desktop/src/watcher/scan.rs
+++ b/crates/apps/rokbattles-desktop/src/watcher/scan.rs
@@ -59,7 +59,7 @@ impl DirScan {
     }
 
     fn peek_next_id(&self) -> Option<u128> {
-        if self.cursor == 0 { None } else { Some(self.ids[self.cursor - 1]) }
+        self.ids.get(self.cursor.checked_sub(1)?).copied()
     }
 
     fn pop_next_id(&mut self) -> Option<u128> {
@@ -67,7 +67,7 @@ impl DirScan {
             return None;
         }
         self.cursor -= 1;
-        Some(self.ids[self.cursor])
+        self.ids.get(self.cursor).copied()
     }
 
     fn path_for_id(&self, id: u128) -> PathBuf {
@@ -278,14 +278,12 @@ pub(crate) async fn refresh_scans_if_needed(app: &AppHandle, state: &mut Watcher
 
 pub(crate) fn next_file(app: &AppHandle, state: &mut WatcherState) -> Option<QueuedUpload> {
     for _ in 0..state.config.scan_budget_per_tick {
-        let (scan_idx, _best_id) = state
+        let (scan, _best_id) = state
             .scans
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, scan)| scan.peek_next_id().map(|id| (idx, id)))
+            .iter_mut()
+            .filter_map(|scan| scan.peek_next_id().map(|id| (scan, id)))
             .max_by_key(|(_, id)| *id)?;
 
-        let scan = &mut state.scans[scan_idx];
         let id = scan.pop_next_id()?;
         let path = scan.path_for_id(id);
         let key = path.to_string_lossy().to_string();

--- a/crates/apps/rokbattles-desktop/src/watcher/store.rs
+++ b/crates/apps/rokbattles-desktop/src/watcher/store.rs
@@ -139,7 +139,8 @@ fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
     if let Err(e) = fs::rename(&tmp_path, path) {
         // Best-effort fallback for Windows rename semantics.
         if e.kind() == io::ErrorKind::AlreadyExists {
-            let _ = fs::remove_file(path);
+            // A concurrent removal is harmless; the following rename reports replacement failures.
+            let _remove_result = fs::remove_file(path);
             fs::rename(&tmp_path, path).with_context(|| format!("Failed replacing {:?}", path))?;
         } else {
             return Err(e).with_context(|| format!("Failed renaming {:?} -> {:?}", tmp_path, path));

--- a/crates/apps/rokbattles-dns-resolver/Cargo.toml
+++ b/crates/apps/rokbattles-dns-resolver/Cargo.toml
@@ -21,3 +21,6 @@ mimalloc = { workspace = true, features = ["secure"] }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
+
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-dns-resolver/src/config.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/config.rs
@@ -59,14 +59,15 @@ fn parse_gateway_ipv4s(value: &str) -> Result<Vec<Ipv4Addr>, ConfigError> {
     let field_count = value.bytes().filter(|byte| *byte == b',').count().saturating_add(1);
     let mut addresses = Vec::new();
     let mut seen = HashSet::new();
-    addresses.try_reserve(field_count).map_err(|_| ConfigError::Allocation)?;
-    seen.try_reserve(field_count).map_err(|_| ConfigError::Allocation)?;
+    addresses.try_reserve(field_count).map_err(|_error| ConfigError::Allocation)?;
+    seen.try_reserve(field_count).map_err(|_error| ConfigError::Allocation)?;
     for field in value.split(',').map(str::trim) {
         if field.is_empty() {
             return Err(ConfigError::EmptyAddress);
         }
-        let address =
-            field.parse().map_err(|_| ConfigError::InvalidAddress { value: field.to_string() })?;
+        let address = field
+            .parse()
+            .map_err(|_error| ConfigError::InvalidAddress { value: field.to_string() })?;
         if !is_public_unicast(address) {
             return Err(ConfigError::NonPublic { address });
         }

--- a/crates/apps/rokbattles-dns-resolver/src/forwarder.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/forwarder.rs
@@ -83,9 +83,9 @@ impl DoHForwarder {
     /// Returns [`ForwardError::Client`] if the HTTP client cannot be constructed.
     pub fn new() -> Result<Self, ForwardError> {
         let primary = Url::parse(CLOUDFLARE_DOH_PRIMARY_URL)
-            .map_err(|_| ForwardError::EndpointConfiguration)?;
+            .map_err(|_error| ForwardError::EndpointConfiguration)?;
         let fallback = Url::parse(CLOUDFLARE_DOH_FALLBACK_URL)
-            .map_err(|_| ForwardError::EndpointConfiguration)?;
+            .map_err(|_error| ForwardError::EndpointConfiguration)?;
         Self::with_options(
             [primary, fallback],
             UPSTREAM_TIMEOUT,
@@ -146,7 +146,7 @@ impl DoHForwarder {
     /// large, or the upstream response does not match the request.
     pub async fn forward(&self, wire_request: &[u8]) -> Result<Vec<u8>, ForwardError> {
         let request =
-            Message::from_vec(wire_request).map_err(|_| ForwardError::InvalidDnsRequest)?;
+            Message::from_vec(wire_request).map_err(|_error| ForwardError::InvalidDnsRequest)?;
         let _permit = self.acquire_capacity()?;
         let result = tokio::time::timeout(
             self.total_timeout,
@@ -165,7 +165,7 @@ impl DoHForwarder {
         {
             info!("upstream DNS forwarding capacity recovered");
         }
-        Arc::clone(&self.capacity).try_acquire_owned().map_err(|_| {
+        Arc::clone(&self.capacity).try_acquire_owned().map_err(|_error| {
             if !self.overload_active.swap(true, Ordering::Relaxed) {
                 warn!("upstream DNS forwarding is at capacity; shedding query");
             }
@@ -193,7 +193,8 @@ impl DoHForwarder {
         request: &Message,
         wire_request: &[u8],
     ) -> Result<Vec<u8>, ForwardError> {
-        match self.forward_to(request, wire_request, &self.upstream_urls[0]).await {
+        let [primary_url, fallback_url] = self.upstream_urls.as_ref();
+        match self.forward_to(request, wire_request, primary_url).await {
             Ok(response) => {
                 if !self.primary_healthy.swap(true, Ordering::Relaxed) {
                     info!("primary upstream DoH endpoint recovered");
@@ -204,7 +205,7 @@ impl DoHForwarder {
                 if self.primary_healthy.swap(false, Ordering::Relaxed) {
                     warn!(error = %primary, "primary upstream DoH query failed; trying fallback");
                 }
-                match self.forward_to(request, wire_request, &self.upstream_urls[1]).await {
+                match self.forward_to(request, wire_request, fallback_url).await {
                     Ok(response) => Ok(response),
                     Err(fallback) => Err(ForwardError::AttemptsFailed {
                         primary: Box::new(primary),
@@ -269,7 +270,7 @@ fn has_dns_media_type(headers: &header::HeaderMap) -> bool {
 
 fn validate_response(request: &Message, wire_response: &[u8]) -> Result<(), ForwardError> {
     let response =
-        Message::from_vec(wire_response).map_err(|_| ForwardError::InvalidDnsResponse)?;
+        Message::from_vec(wire_response).map_err(|_error| ForwardError::InvalidDnsResponse)?;
     if response.metadata.message_type != MessageType::Response
         || response.metadata.id != request.metadata.id
         || response.queries != request.queries

--- a/crates/apps/rokbattles-dns-resolver/src/http.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/http.rs
@@ -146,7 +146,7 @@ fn decode_dns_parameter(encoded: &str) -> Result<Vec<u8>, HttpError> {
         return Err(HttpError::MessageTooLarge);
     }
     let wire_request =
-        URL_SAFE_NO_PAD.decode(encoded).map_err(|_| HttpError::InvalidDnsParameter)?;
+        URL_SAFE_NO_PAD.decode(encoded).map_err(|_error| HttpError::InvalidDnsParameter)?;
     if wire_request.len() > MAX_DNS_MESSAGE_BYTES {
         return Err(HttpError::MessageTooLarge);
     }

--- a/crates/apps/rokbattles-dns-resolver/src/main.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/main.rs
@@ -17,7 +17,8 @@ const BIND_ADDRESS: &str = "0.0.0.0:8053";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dotenv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env");
-    dotenvy::from_path(&dotenv_path).ok();
+    // Environment variables can be supplied without a local .env file.
+    let _dotenv_result = dotenvy::from_path(&dotenv_path);
 
     let config = Config::from_env()?;
     tracing_subscriber::fmt()

--- a/crates/apps/rokbattles-dns-resolver/src/resolver.rs
+++ b/crates/apps/rokbattles-dns-resolver/src/resolver.rs
@@ -81,7 +81,7 @@ impl Resolver {
     /// duplicate, cannot be reserved, or includes a non-public-unicast address.
     pub fn new(addresses: Vec<Ipv4Addr>) -> Result<Self, ResolverConfigError> {
         let mut seen = HashSet::new();
-        seen.try_reserve(addresses.len()).map_err(|_| ResolverConfigError::Allocation)?;
+        seen.try_reserve(addresses.len()).map_err(|_error| ResolverConfigError::Allocation)?;
         for &address in &addresses {
             if !is_public_unicast(address) {
                 return Err(ResolverConfigError::NonPublic { address });
@@ -140,7 +140,11 @@ impl Resolver {
     fn resolve_message(&self, request: &Message, request_wire_bytes: usize) -> Resolution {
         let mut response = response_for(request);
 
-        if request.metadata.message_type != MessageType::Query || request.queries.len() != 1 {
+        let [query] = request.queries.as_slice() else {
+            response.metadata.response_code = ResponseCode::FormErr;
+            return Resolution::Local(response);
+        };
+        if request.metadata.message_type != MessageType::Query {
             response.metadata.response_code = ResponseCode::FormErr;
             return Resolution::Local(response);
         }
@@ -150,7 +154,6 @@ impl Resolver {
             return Resolution::Local(response);
         }
 
-        let query = &request.queries[0];
         if query.query_class() != DNSClass::IN || !self.is_target(query.name()) {
             return Resolution::NonTarget(response);
         }
@@ -161,8 +164,7 @@ impl Resolver {
                 / COMPRESSED_A_ANSWER_BYTES;
             let answer_count = fleet_size.min(answer_capacity);
             let start = self.next_start.fetch_add(1, Ordering::Relaxed) % fleet_size;
-            for offset in 0..answer_count {
-                let address = self.gateway_ipv4s[(start + offset) % fleet_size];
+            for &address in self.gateway_ipv4s.iter().cycle().skip(start).take(answer_count) {
                 response.add_answer(Record::from_rdata(
                     query.name().clone(),
                     DNS_TTL_SECONDS,
@@ -341,7 +343,7 @@ mod tests {
 
     #[test]
     fn oversized_fleet_should_rotate_through_protocol_sized_response_windows() {
-        let gateways = (0..4_200)
+        let gateways = (0_u32..4_200)
             .map(|index| Ipv4Addr::new(11, ((index >> 8) & 0xff) as u8, (index & 0xff) as u8, 1))
             .collect();
         let resolver = Resolver::new(gateways).expect("all public gateways should be accepted");

--- a/crates/apps/rokbattles-ingress/Cargo.toml
+++ b/crates/apps/rokbattles-ingress/Cargo.toml
@@ -25,3 +25,6 @@ sentry = { workspace = true, features = ["backtrace", "contexts", "debug-images"
 
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 mimalloc = { workspace = true, features = ["secure"] }
+
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-ingress/src/clamav.rs
+++ b/crates/apps/rokbattles-ingress/src/clamav.rs
@@ -55,7 +55,7 @@ pub async fn scan_zstream(
         Ok::<Vec<u8>, std::io::Error>(response)
     })
     .await
-    .map_err(|_| ScanError::Timeout)??;
+    .map_err(|_error| ScanError::Timeout)??;
 
     parse_response(&response)
 }

--- a/crates/apps/rokbattles-ingress/src/config.rs
+++ b/crates/apps/rokbattles-ingress/src/config.rs
@@ -89,14 +89,14 @@ fn parse_u64(key: &'static str, value: Option<String>, default: u64) -> Result<u
     let Some(value) = value else {
         return Ok(default);
     };
-    value.parse::<u64>().map_err(|_| ConfigError::Invalid { key, value })
+    value.parse::<u64>().map_err(|_error| ConfigError::Invalid { key, value })
 }
 
 fn parse_i32(key: &'static str, value: Option<String>, default: i32) -> Result<i32, ConfigError> {
     let Some(value) = value else {
         return Ok(default);
     };
-    value.parse::<i32>().map_err(|_| ConfigError::Invalid { key, value })
+    value.parse::<i32>().map_err(|_error| ConfigError::Invalid { key, value })
 }
 
 fn parse_usize(
@@ -107,7 +107,7 @@ fn parse_usize(
     let Some(value) = value else {
         return Ok(default);
     };
-    value.parse::<usize>().map_err(|_| ConfigError::Invalid { key, value })
+    value.parse::<usize>().map_err(|_error| ConfigError::Invalid { key, value })
 }
 
 #[cfg(test)]

--- a/crates/apps/rokbattles-ingress/src/handlers.rs
+++ b/crates/apps/rokbattles-ingress/src/handlers.rs
@@ -150,7 +150,7 @@ pub async fn upload_relay(
                         .await
                         .map_err(|error| ApiError::bad_request(error.to_string()))?
                         .parse::<i32>()
-                        .map_err(|_| ApiError::bad_request("server_id must be an i32"))?,
+                        .map_err(|_error| ApiError::bad_request("server_id must be an i32"))?,
                 );
             }
             Some("player_id") => {
@@ -160,7 +160,7 @@ pub async fn upload_relay(
                         .await
                         .map_err(|error| ApiError::bad_request(error.to_string()))?
                         .parse::<i64>()
-                        .map_err(|_| ApiError::bad_request("player_id must be an i64"))?,
+                        .map_err(|_error| ApiError::bad_request("player_id must be an i64"))?,
                 );
             }
             Some("mail") => {
@@ -331,16 +331,12 @@ async fn store_compressed_raw_mail(
     };
     let action = decide_compressed_raw_action(existing.as_ref(), &checksum, metadata_differs);
 
-    if matches!(action, UploadAction::Skip) {
-        return Ok(action);
-    }
-
-    let mail = raw_mail::extract_raw_mail_metadata(decoded)?;
     let status = match action {
         UploadAction::Insert => insert_status_for_mail_type(mail_type),
         UploadAction::Update => update_status_for_mail_type(mail_type),
-        UploadAction::Skip => unreachable!("skip returned above"),
+        UploadAction::Skip => return Ok(action),
     };
+    let mail = raw_mail::extract_raw_mail_metadata(decoded)?;
     let doc = raw_mail::build_raw_mail_doc(RawMailDocumentInput {
         original_bytes: buffer,
         user_agent,
@@ -523,8 +519,7 @@ fn ua_ok(user_agent: &str) -> bool {
 }
 
 fn is_probably_json(bytes: &[u8]) -> bool {
-    let sample_len = bytes.len().min(256);
-    let sample = &bytes[..sample_len];
+    let sample = bytes.get(..256).unwrap_or(bytes);
     let Ok(text) = std::str::from_utf8(sample) else {
         return false;
     };
@@ -560,7 +555,7 @@ mod tests {
     #[test]
     fn rejects_mail_type_from_singleton_array() {
         let decoded = json!([{ "type": "Battle" }]);
-        assert!(extract_mail_type(&decoded).is_err());
+        extract_mail_type(&decoded).expect_err("input should be rejected");
     }
 
     #[test]
@@ -841,7 +836,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(header::AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
 
-        assert!(authorize_relay(&headers, "secret").is_ok());
+        authorize_relay(&headers, "secret").expect("operation should succeed");
         assert!(matches!(authorize_relay(&headers, "different"), Err(ApiError::Unauthorized)));
     }
 
@@ -873,8 +868,8 @@ mod tests {
 
     #[test]
     fn rejects_invalid_filename() {
-        assert!(parse_mail_id_from_filename("battle.mail.1").is_err());
-        assert!(parse_mail_id_from_filename("Persistent.Mail.").is_err());
+        parse_mail_id_from_filename("battle.mail.1").expect_err("input should be rejected");
+        parse_mail_id_from_filename("Persistent.Mail.").expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-ingress/src/main.rs
+++ b/crates/apps/rokbattles-ingress/src/main.rs
@@ -29,7 +29,8 @@ use crate::{config::Config, state::AppState, storage::Storage};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let dotenv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env");
-    dotenvy::from_path(&dotenv_path).ok();
+    // Environment variables can be supplied without a local .env file.
+    let _dotenv_result = dotenvy::from_path(&dotenv_path);
 
     let config = Config::from_env()?;
     let mail_reconstructor = Arc::new(MailReconstructor::load("artifacts/artifacts.json")?);

--- a/crates/apps/rokbattles-ingress/src/raw_mail.rs
+++ b/crates/apps/rokbattles-ingress/src/raw_mail.rs
@@ -21,7 +21,7 @@ pub struct RawMailMetadata {
 /// Build the document inserted into `g_rok_mails`.
 pub fn build_raw_mail_doc(input: RawMailDocumentInput<'_>) -> Result<Document, ApiError> {
     let size = i64::try_from(input.original_bytes.len())
-        .map_err(|_| ApiError::internal("mail binary is too large to store size"))?;
+        .map_err(|_error| ApiError::internal("mail binary is too large to store size"))?;
     let compressed = compress_raw_mail(input.original_bytes, input.zstd_level)?;
 
     let document = doc! {
@@ -198,7 +198,7 @@ mod tests {
     fn bounded_decompression_rejects_oversized_stored_mail() {
         let compressed = compress_raw_mail(b"mail", 3).expect("compress");
 
-        assert!(decompress_raw_mail(&compressed, 4, 3).is_err());
+        decompress_raw_mail(&compressed, 4, 3).expect_err("input should be rejected");
     }
 
     #[test]
@@ -231,7 +231,7 @@ mod tests {
             "receiver": "player_22"
         }]);
 
-        assert!(extract_raw_mail_metadata(&decoded).is_err());
+        extract_raw_mail_metadata(&decoded).expect_err("input should be rejected");
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/Cargo.toml
+++ b/crates/apps/rokbattles-jobs/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 dotenvy = { workspace = true }
 rokbattles-drastc = { path = "../../common/rokbattles-drastc" }
@@ -23,8 +26,8 @@ yaml_serde = { workspace = true }
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 mimalloc = { workspace = true, features = ["secure"] }
 
-[lib]
-doctest = false
-
 [dev-dependencies]
 regex = "1"
+
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-jobs/src/main.rs
+++ b/crates/apps/rokbattles-jobs/src/main.rs
@@ -16,7 +16,8 @@ use tracing::{debug, info};
 #[tokio::main]
 async fn main() -> Result<(), JobsError> {
     let dotenv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env");
-    dotenvy::from_path(&dotenv_path).ok();
+    // Environment variables can be supplied without a local .env file.
+    let _dotenv_result = dotenvy::from_path(&dotenv_path);
 
     let config = Config::from_env()?;
     tracing_subscriber::fmt()

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/loadout.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/loadout.rs
@@ -31,30 +31,42 @@ pub(super) struct ProjectedLoadout {
 
 pub(super) fn map_projected_loadout(value: &Bson) -> Result<ProjectedLoadout, String> {
     let values = value.as_array().ok_or("loadout record is not an array")?;
-    if values.len() != 10 {
+    let [
+        day,
+        scenario,
+        governor,
+        formation,
+        equipment,
+        armaments,
+        primary_skills,
+        primary_expertise,
+        secondary_skills,
+        secondary_expertise,
+    ] = values.as_slice()
+    else {
         return Err(format!("loadout record has {} fields instead of 10", values.len()));
-    }
-    let integer = |index: usize, name: &str| {
-        bson_to_i64(&values[index]).ok_or_else(|| format!("loadout {name} is not an integer"))
     };
-    let e = match &values[4] {
+    let integer = |value: &Bson, name: &str| {
+        bson_to_i64(value).ok_or_else(|| format!("loadout {name} is not an integer"))
+    };
+    let e = match equipment {
         Bson::String(value) => Some(value.clone()),
         Bson::Null => None,
         _ => return Err("loadout equipment is not a string or null".to_owned()),
     };
-    let a = mongodb::bson::from_bson(values[5].clone())
+    let a = mongodb::bson::from_bson(armaments.clone())
         .map_err(|error| format!("invalid loadout armaments: {error}"))?;
     Ok(ProjectedLoadout {
-        d: integer(0, "day")?,
-        c: integer(1, "scenario")?,
-        u: integer(2, "governor")?,
-        f: integer(3, "formation")?,
+        d: integer(day, "day")?,
+        c: integer(scenario, "scenario")?,
+        u: integer(governor, "governor")?,
+        f: integer(formation, "formation")?,
         e,
         a,
-        ps: optional_field(&values[6], "primary skills")?,
-        pe: optional_field(&values[7], "primary expertise")?,
-        ss: optional_field(&values[8], "secondary skills")?,
-        se: optional_field(&values[9], "secondary expertise")?,
+        ps: optional_field(primary_skills, "primary skills")?,
+        pe: optional_field(primary_expertise, "primary expertise")?,
+        ss: optional_field(secondary_skills, "secondary skills")?,
+        se: optional_field(secondary_expertise, "secondary expertise")?,
     })
 }
 
@@ -175,15 +187,14 @@ fn accumulate_equipment(bucket: &mut LoadoutBucket, value: Option<&str>, catalog
         .into_iter()
         .filter(|token| (1..=8).contains(&token.slot))
         .collect::<Vec<_>>();
-    let mut accessories = tokens
+    let accessories = tokens
         .iter()
         .filter(|token| matches!(token.slot, 7 | 8))
         .map(|token| token.item_id)
         .collect::<Vec<_>>();
-    if accessories.len() == 2 {
-        accessories.sort_unstable();
+    if let &[first, second] = accessories.as_slice() {
         bucket.accessory_sample += 1;
-        *bucket.accessory_pairs.entry((accessories[0], accessories[1])).or_default() += 1;
+        *bucket.accessory_pairs.entry((first.min(second), first.max(second))).or_default() += 1;
     }
 
     for token in tokens {

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/mod.rs
@@ -253,7 +253,7 @@ async fn read_performance_partition(
         let month = document_i64(&document, "m").ok_or_else(|| {
             JobsError::InvalidCombatLabData("performance chunk is missing its month".to_owned())
         })?;
-        let records = document.get_array("v").cloned().map_err(|_| {
+        let records = document.get_array("v").cloned().map_err(|_error| {
             JobsError::InvalidCombatLabData("performance chunk has no records".to_owned())
         })?;
         for record in &records {
@@ -326,7 +326,7 @@ async fn read_loadout_partition(
         let scenario = document_i64(&document, "c").ok_or_else(|| {
             JobsError::InvalidCombatLabData("loadout chunk is missing its scenario".to_owned())
         })?;
-        let records = document.get_array("v").map_err(|_| {
+        let records = document.get_array("v").map_err(|_error| {
             JobsError::InvalidCombatLabData("loadout chunk has no records".to_owned())
         })?;
         let mut month = MonthLoadouts { pairing, month: month_start, ..MonthLoadouts::default() };
@@ -685,7 +685,7 @@ mod tests {
             records,
         );
 
-        assert!(ensure_safe_size(&document).is_ok());
+        ensure_safe_size(&document).expect("operation should succeed");
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_cmdr_pairings_v2/pipeline.rs
@@ -238,7 +238,10 @@ fn conditional_entry(condition: Document, entry: Document) -> Document {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Each argument names a field in a battle perspective projection"
+)]
 fn perspective_entry(
     primary: &'static str,
     secondary: &'static str,

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/mod.rs
@@ -146,7 +146,7 @@ async fn validate_materialized_data(
 ) -> Result<u64, JobsError> {
     let count = validate_stored_documents(output).await?;
     let expected_count = u64::try_from(expected_count)
-        .map_err(|_| JobsError::InvalidDrastcData("document count overflowed u64".into()))?;
+        .map_err(|_error| JobsError::InvalidDrastcData("document count overflowed u64".into()))?;
     if count != expected_count {
         return Err(JobsError::InvalidDrastcData(format!(
             "wrote {expected_count} documents but collection contains {count}"

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/output.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/output.rs
@@ -86,7 +86,7 @@ mod tests {
         );
 
         assert_eq!(document.len(), 4);
-        assert!(document.get_document("drastc").is_ok());
+        document.get_document("drastc").expect("operation should succeed");
         assert!(!document.contains_key("strategies"));
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/pipeline.rs
@@ -714,7 +714,7 @@ mod tests {
             Ok(cutoff_mail_time)
         );
         assert!(!matcher.contains_key("opponents"));
-        assert!(matcher.get_array("$or").is_ok());
+        matcher.get_array("$or").expect("operation should succeed");
     }
 
     #[test]
@@ -771,15 +771,13 @@ mod tests {
             "_reference_consistency_percentiles",
             "_reference_trade_percentiles",
         ] {
-            assert!(output.get_document(field).is_ok());
+            output.get_document(field).expect("operation should succeed");
         }
         let project = drastc_output_project_stage();
-        assert!(
-            project
-                .get_document("$project")
-                .and_then(|project| project.get_document("observed"))
-                .is_ok()
-        );
+        project
+            .get_document("$project")
+            .and_then(|project| project.get_document("observed"))
+            .expect("operation should succeed");
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
@@ -16,11 +16,16 @@ pub(super) fn build_drastc_scores_from_aggregates(
         let Some(raw) = observed.get(key) else {
             continue;
         };
+        let (Ok(primary), Ok(secondary)) =
+            (u32::try_from(key.primary_commander_id), u32::try_from(key.secondary_commander_id))
+        else {
+            continue;
+        };
 
         let mut model = DrastcModel::new();
         model.set_rage_table(rage_table);
         model.set_reference_ranges(reference_ranges);
-        model.set_theoretical(key.primary_commander_id as u32, key.secondary_commander_id as u32);
+        model.set_theoretical(primary, secondary);
         model.push(raw.to_drastc_record());
 
         if let Some(score) = model.evaluate() {
@@ -73,6 +78,29 @@ mod tests {
         assert!(
             !keys.contains(&PairingKey { primary_commander_id: 575, secondary_commander_id: 540 })
         );
+    }
+
+    #[test]
+    fn scores_should_skip_commander_ids_that_would_wrap_to_supported_ids() {
+        let wrap = i64::from(u32::MAX) + 1;
+        let keys = [
+            PairingKey { primary_commander_id: 579 - wrap, secondary_commander_id: 575 },
+            PairingKey { primary_commander_id: 579, secondary_commander_id: 575 + wrap },
+        ];
+        let observed = keys
+            .iter()
+            .map(|key| (*key, PairingRawTotals { total_battles: 2, ..Default::default() }))
+            .collect();
+        let ranges = DrastcReferenceRanges {
+            damage: ReferenceRange::new(10, 0.0, 4.0),
+            sustainability: ReferenceRange::new(10, -2.0, 2.0),
+            trade: ReferenceRange::new(10, 0.0, 2.0),
+            consistency: ReferenceRange::new(10, 0.0, 1.0),
+        };
+
+        let scores = build_drastc_scores_from_aggregates(&observed, &keys, ranges, SOC_RAGE_TABLE);
+
+        assert!(scores.is_empty());
     }
 
     #[test]

--- a/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_drastc/scoring.rs
@@ -136,8 +136,8 @@ mod tests {
 
         let score = scores.get(&key).expect("drastc score");
         assert_eq!(score.samples, 2);
-        assert_eq!(score.breakdown.rage.value, 8.0);
-        assert_eq!(score.breakdown.assist.value, 14.24);
+        assert!((score.breakdown.rage.value - 8.0).abs() < 1e-9);
+        assert!((score.breakdown.assist.value - 14.24).abs() < 1e-9);
     }
 
     #[test]
@@ -172,6 +172,8 @@ mod tests {
             },
             PRESOC_RAGE_TABLE,
         );
-        assert_eq!(scores.get(&key).expect("Sun Tzu/YSG score").breakdown.rage.value, 7.5);
+        assert!(
+            (scores.get(&key).expect("Sun Tzu/YSG score").breakdown.rage.value - 7.5).abs() < 1e-9
+        );
     }
 }

--- a/crates/apps/rokbattles-jobs/src/precompute_karuak_ceremony.rs
+++ b/crates/apps/rokbattles-jobs/src/precompute_karuak_ceremony.rs
@@ -187,7 +187,7 @@ mod tests {
         let document = build_document(30_001, &aggregate, DateTime::from_millis(123));
         assert_eq!(document.get_i64("kind"), Ok(30_001));
         assert_eq!(document.get_document("totals").unwrap().get_i64("results"), Ok(2));
-        assert!(document.get_array("loot").is_ok());
+        document.get_array("loot").expect("operation should succeed");
         assert!(!document.contains_key("pools"));
     }
 }

--- a/crates/apps/rokbattles-processor/Cargo.toml
+++ b/crates/apps/rokbattles-processor/Cargo.toml
@@ -22,3 +22,6 @@ sentry = { workspace = true, features = ["backtrace", "contexts", "debug-images"
 
 [target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
 mimalloc = { workspace = true, features = ["secure"] }
+
+[lints]
+workspace = true

--- a/crates/apps/rokbattles-processor/src/config.rs
+++ b/crates/apps/rokbattles-processor/src/config.rs
@@ -71,7 +71,7 @@ fn parse_i64(key: &'static str, value: Option<String>, default: i64) -> Result<i
     let Some(value) = value else {
         return Ok(default);
     };
-    let parsed = value.parse::<i64>().map_err(|_| ConfigError::Invalid { key, value })?;
+    let parsed = value.parse::<i64>().map_err(|_error| ConfigError::Invalid { key, value })?;
     if parsed <= 0 {
         return Err(ConfigError::Invalid { key, value: parsed.to_string() });
     }
@@ -86,7 +86,7 @@ fn parse_usize(
     let Some(value) = value else {
         return Ok(default);
     };
-    let parsed = value.parse::<usize>().map_err(|_| ConfigError::Invalid { key, value })?;
+    let parsed = value.parse::<usize>().map_err(|_error| ConfigError::Invalid { key, value })?;
     if parsed == 0 {
         return Err(ConfigError::Invalid { key, value: parsed.to_string() });
     }
@@ -101,7 +101,7 @@ fn parse_duration_secs(
     let Some(value) = value else {
         return Ok(Duration::from_secs(default_secs));
     };
-    let parsed = value.parse::<u64>().map_err(|_| ConfigError::Invalid { key, value })?;
+    let parsed = value.parse::<u64>().map_err(|_error| ConfigError::Invalid { key, value })?;
     if parsed == 0 {
         return Err(ConfigError::Invalid { key, value: parsed.to_string() });
     }
@@ -164,12 +164,12 @@ mod tests {
 
     #[test]
     fn parse_i64_rejects_zero() {
-        assert!(parse_i64("TEST", Some("0".into()), 42).is_err());
+        parse_i64("TEST", Some("0".into()), 42).expect_err("input should be rejected");
     }
 
     #[test]
     fn parse_usize_rejects_zero() {
-        assert!(parse_usize("TEST", Some("0".into()), 3).is_err());
+        parse_usize("TEST", Some("0".into()), 3).expect_err("input should be rejected");
     }
 
     #[test]
@@ -190,10 +190,11 @@ mod tests {
 
     #[test]
     fn numeric_settings_reject_invalid_values() {
-        assert!(parse_i64("I64", Some("bad".into()), 1).is_err());
-        assert!(parse_i64("I64", Some("-1".into()), 1).is_err());
-        assert!(parse_usize("USIZE", Some("bad".into()), 1).is_err());
-        assert!(parse_duration_secs("DURATION", Some("bad".into()), 1).is_err());
+        parse_i64("I64", Some("bad".into()), 1).expect_err("input should be rejected");
+        parse_i64("I64", Some("-1".into()), 1).expect_err("input should be rejected");
+        parse_usize("USIZE", Some("bad".into()), 1).expect_err("input should be rejected");
+        parse_duration_secs("DURATION", Some("bad".into()), 1)
+            .expect_err("input should be rejected");
     }
 
     #[test]
@@ -218,6 +219,6 @@ mod tests {
 
     #[test]
     fn parse_duration_secs_rejects_zero() {
-        assert!(parse_duration_secs("TEST", Some("0".into()), 1).is_err());
+        parse_duration_secs("TEST", Some("0".into()), 1).expect_err("input should be rejected");
     }
 }

--- a/crates/apps/rokbattles-processor/src/main.rs
+++ b/crates/apps/rokbattles-processor/src/main.rs
@@ -22,7 +22,8 @@ use crate::{config::Config, error::ProcessorError, processing::process_loop, sto
 #[tokio::main]
 async fn main() -> Result<(), ProcessorError> {
     let dotenv_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".env");
-    dotenvy::from_path(&dotenv_path).ok();
+    // Environment variables can be supplied without a local .env file.
+    let _dotenv_result = dotenvy::from_path(&dotenv_path);
 
     let config = Config::from_env()?;
     tracing_subscriber::fmt()

--- a/crates/apps/rokbattles-processor/src/processing.rs
+++ b/crates/apps/rokbattles-processor/src/processing.rs
@@ -190,7 +190,7 @@ fn prepare_processed_document(raw: &RawMail) -> Result<(MailType, Document), Pro
     let mut processed_doc = mongodb::bson::to_document(&processed)?;
     let metadata = processed_doc
         .get_document_mut("metadata")
-        .map_err(|_| ProcessorError::MissingProcessedMetadata)?;
+        .map_err(|_error| ProcessorError::MissingProcessedMetadata)?;
     metadata.insert("source_checksum", raw.checksum.clone());
     metadata.insert("source_size", raw.size);
     Ok((mail_type, processed_doc))
@@ -215,26 +215,26 @@ fn should_mark_error(error: &ProcessorError) -> bool {
 }
 
 fn parse_raw_mail(mut doc: Document) -> Result<RawMail, ProcessorError> {
-    let id = doc.get_object_id("_id").map_err(|_| ProcessorError::MissingField("_id"))?;
+    let id = doc.get_object_id("_id").map_err(|_error| ProcessorError::MissingField("_id"))?;
     let status = doc.get_str("status").unwrap_or(crate::storage::STATUS_PENDING).to_string();
     let metadata =
-        doc.get_document("metadata").map_err(|_| ProcessorError::MissingField("metadata"))?;
+        doc.get_document("metadata").map_err(|_error| ProcessorError::MissingField("metadata"))?;
     let checksum = metadata
         .get_str("checksum")
-        .map_err(|_| ProcessorError::MissingField("metadata.checksum"))?
+        .map_err(|_error| ProcessorError::MissingField("metadata.checksum"))?
         .to_string();
     let size =
-        metadata.get_i64("size").map_err(|_| ProcessorError::MissingField("metadata.size"))?;
+        metadata.get_i64("size").map_err(|_error| ProcessorError::MissingField("metadata.size"))?;
     let algorithm = metadata
         .get_str("algo")
-        .map_err(|_| ProcessorError::MissingField("metadata.algo"))?
+        .map_err(|_error| ProcessorError::MissingField("metadata.algo"))?
         .to_string();
     let mut mail = match doc.remove("mail") {
         Some(Bson::Document(mail)) => mail,
         _ => return Err(ProcessorError::MissingField("mail")),
     };
     let mail_id =
-        mail.get_str("id").map_err(|_| ProcessorError::MissingField("mail.id"))?.to_string();
+        mail.get_str("id").map_err(|_error| ProcessorError::MissingField("mail.id"))?.to_string();
     let binary = match mail.remove("binary") {
         Some(Bson::Binary(binary)) => binary.bytes,
         _ => return Err(ProcessorError::MissingField("mail.binary")),
@@ -248,7 +248,7 @@ fn decode_mail_binary(raw: &RawMail) -> Result<Value, ProcessorError> {
         return Err(ProcessorError::UnsupportedCompression(raw.algorithm.clone()));
     }
     let expected_size =
-        usize::try_from(raw.size).map_err(|_| ProcessorError::InvalidSize(raw.size))?;
+        usize::try_from(raw.size).map_err(|_error| ProcessorError::InvalidSize(raw.size))?;
 
     let decoder = zstd::stream::read::Decoder::new(raw.binary.as_slice())?;
     let mut bytes = Vec::with_capacity(expected_size);

--- a/crates/common/rokbattles-bson/Cargo.toml
+++ b/crates/common/rokbattles-bson/Cargo.toml
@@ -4,11 +4,11 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
-[dependencies]
-mongodb = { workspace = true }
-
 [lib]
 doctest = false
+
+[dependencies]
+mongodb = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-container/Cargo.toml
+++ b/crates/common/rokbattles-container/Cargo.toml
@@ -24,9 +24,6 @@ serde_json = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
 
-[lints]
-workspace = true
-
 [dev-dependencies]
 criterion.workspace = true
 
@@ -34,3 +31,6 @@ criterion.workspace = true
 name = "container"
 harness = false
 required-features = ["read", "write"]
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-djb2-simd/Cargo.toml
+++ b/crates/common/rokbattles-djb2-simd/Cargo.toml
@@ -4,15 +4,15 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
-[dev-dependencies]
-criterion.workspace = true
-
-[lints]
-workspace = true
-
 [lib]
 doctest = false
+
+[dev-dependencies]
+criterion.workspace = true
 
 [[bench]]
 name = "checksum"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/common/rokbattles-drastc/Cargo.toml
+++ b/crates/common/rokbattles-drastc/Cargo.toml
@@ -4,11 +4,11 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
-[dependencies]
-serde = { workspace = true, features = ["derive"] }
-
 [lib]
 doctest = false
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-cli/Cargo.toml
+++ b/crates/common/rokbattles-mail-cli/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
 rokbattles-mail-codec = { path = "../rokbattles-mail-codec", features = ["read"] }
@@ -15,9 +18,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-battle-info/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-battle-info/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-battle-results/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-battle-results/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-alliance-aoo-individual-results/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-alliance-aoo-individual-results/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-barcanyonkillboss/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-barcanyonkillboss/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-battle/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-battle/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-duelbattle2/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-duelbattle2/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-eventmemberlootreport/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-eventmemberlootreport/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-rss/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-rss/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-system-barbarianfort/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-system-barbarianfort/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-processor-system-kahartreasure/Cargo.toml
+++ b/crates/common/rokbattles-mail-processor-system-kahartreasure/Cargo.toml
@@ -4,12 +4,12 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk" }
 serde_json = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-reconstructor/Cargo.toml
+++ b/crates/common/rokbattles-mail-reconstructor/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 base64 = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
@@ -12,9 +15,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 rokbattles-mail-codec = { path = "../rokbattles-mail-codec", features = ["write"] }
 rokbattles-mail-registry = { path = "../rokbattles-mail-registry" }
-
-[lib]
-doctest = false
 
 [dev-dependencies]
 rokbattles-mail-codec = { path = "../rokbattles-mail-codec", features = ["read"] }

--- a/crates/common/rokbattles-mail-registry/Cargo.toml
+++ b/crates/common/rokbattles-mail-registry/Cargo.toml
@@ -4,6 +4,9 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [features]
 default = []
 processors = [
@@ -33,9 +36,6 @@ rokbattles-mail-processor-rss = { path = "../rokbattles-mail-processor-rss", opt
 rokbattles-mail-sdk = { path = "../rokbattles-mail-sdk", optional = true }
 rokbattles-mail-processor-system-barbarianfort = { path = "../rokbattles-mail-processor-system-barbarianfort", optional = true }
 rokbattles-mail-processor-system-kahartreasure = { path = "../rokbattles-mail-processor-system-kahartreasure", optional = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true

--- a/crates/common/rokbattles-mail-sdk/Cargo.toml
+++ b/crates/common/rokbattles-mail-sdk/Cargo.toml
@@ -4,13 +4,13 @@ edition.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+doctest = false
+
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-
-[lib]
-doctest = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
Workspace lint inheritance was missing from six apps. Enable it everywhere and normalize crate manifest section ordering, then resolve the resulting Clippy diagnostics so the workspace passes with warnings denied.

The first commit contains only Cargo manifest changes. The second fixes Rust lint and formatting issues: replaces unchecked indexing with slice patterns and iterators, makes intentional error handling explicit, improves test failure messages, and checks commander IDs before conversion. A regression test covers IDs that would wrap to supported commanders. Watcher commands retrieve managed state through AppHandle to avoid Tauri-generated lint failures on stable Rust. Documented lint expectations cover exact numeric boolean encoding and the existing projection helper argument count.

Validation on macOS:

- `cargo +stable clippy --workspace --all-targets --all-features --locked -- -D warnings` (Rust 1.98, matching CI)
- `cargo test --workspace --all-features --locked` — 969 tests passed
- `cargo fmt --all --check`
- `git diff --check`
- All 28 crate manifests validated for ordering, lint inheritance, and preserved TOML values

The existing Cargo warning about `unstable.min-publish-age` remains.

